### PR TITLE
Add boardgame persistence and cleanup

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const ChatContext = createContext();
 
@@ -14,6 +15,8 @@ const initialMatches = [
       { id: 'm3', text: 'Sounds good!', sender: 'them' },
     ],
     matchedAt: '2 days ago',
+    activeGameId: null,
+    pendingInvite: null,
   },
   {
     id: '2',
@@ -24,6 +27,8 @@ const initialMatches = [
       { id: 'm1', text: 'Ready for a rematch?', sender: 'them' },
     ],
     matchedAt: '1 day ago',
+    activeGameId: null,
+    pendingInvite: null,
   },
   {
     id: '3',
@@ -34,13 +39,36 @@ const initialMatches = [
       { id: 'm1', text: 'BRB grabbing coffee ☕', sender: 'them' },
     ],
     matchedAt: '5 hours ago',
+    activeGameId: null,
+    pendingInvite: null,
   },
 ];
 
 export const ChatProvider = ({ children }) => {
   const [matches, setMatches] = useState(initialMatches);
 
-  const sendMessage = (matchId, text) => {
+  const STORAGE_KEY = 'chatMatches';
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((data) => {
+      if (data) {
+        try {
+          const parsed = JSON.parse(data);
+          if (Array.isArray(parsed)) {
+            setMatches(parsed);
+          }
+        } catch (e) {
+          console.warn('Failed to parse matches', e);
+        }
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(matches));
+  }, [matches]);
+
+  const sendMessage = (matchId, text, sender = 'you') => {
     setMatches((prev) =>
       prev.map((m) =>
         m.id === matchId
@@ -48,13 +76,54 @@ export const ChatProvider = ({ children }) => {
               ...m,
               messages: [
                 ...m.messages,
-                { id: Date.now().toString(), text, sender: 'you' },
+                { id: Date.now().toString(), text, sender },
               ],
             }
           : m
       )
     );
   };
+
+  const setActiveGame = (matchId, gameId) => {
+    setMatches((prev) =>
+      prev.map((m) =>
+        m.id === matchId ? { ...m, activeGameId: gameId, pendingInvite: null } : m
+      )
+    );
+  };
+
+  const sendGameInvite = (matchId, gameId, from = 'you') => {
+    setMatches((prev) =>
+      prev.map((m) =>
+        m.id === matchId ? { ...m, pendingInvite: { gameId, from } } : m
+      )
+    );
+  };
+
+  const clearGameInvite = (matchId) => {
+    setMatches((prev) =>
+      prev.map((m) => (m.id === matchId ? { ...m, pendingInvite: null } : m))
+    );
+  };
+
+  const acceptGameInvite = (matchId) => {
+    const invite = matches.find((m) => m.id === matchId)?.pendingInvite;
+    if (invite) {
+      setMatches((prev) =>
+        prev.map((m) =>
+          m.id === matchId
+            ? { ...m, activeGameId: invite.gameId, pendingInvite: null }
+            : m
+        )
+      );
+    }
+  };
+
+  const getPendingInvite = (matchId) =>
+    matches.find((m) => m.id === matchId)?.pendingInvite || null;
+
+  const getActiveGame = (matchId) =>
+    matches.find((m) => m.id === matchId)?.activeGameId || null;
 
   const removeMatch = (matchId) =>
     setMatches((prev) => prev.filter((m) => m.id !== matchId));
@@ -63,7 +132,20 @@ export const ChatProvider = ({ children }) => {
     matches.find((m) => m.id === matchId)?.messages || [];
 
   return (
-    <ChatContext.Provider value={{ matches, sendMessage, getMessages, removeMatch }}>
+    <ChatContext.Provider
+      value={{
+        matches,
+        sendMessage,
+        getMessages,
+        removeMatch,
+        setActiveGame,
+        getActiveGame,
+        sendGameInvite,
+        clearGameInvite,
+        acceptGameInvite,
+        getPendingInvite,
+      }}
+    >
       {children}
     </ChatContext.Provider>
   );

--- a/games/tic-tac-toe.js
+++ b/games/tic-tac-toe.js
@@ -1,7 +1,18 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Client } from 'boardgame.io/react';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+
+const lines = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
 
 const TicTacToeGame = {
   setup: () => ({ cells: Array(9).fill(null) }),
@@ -12,29 +23,58 @@ const TicTacToeGame = {
       G.cells[id] = ctx.currentPlayer;
     },
   },
+  endIf: ({ G, ctx }) => {
+    for (let i = 0; i < lines.length; i++) {
+      const [a, b, c] = lines[i];
+      if (
+        G.cells[a] !== null &&
+        G.cells[a] === G.cells[b] &&
+        G.cells[a] === G.cells[c]
+      ) {
+        return { winner: G.cells[a] };
+      }
+    }
+    if (G.cells.every((c) => c !== null)) {
+      return { draw: true };
+    }
+  },
 };
 
-const TicTacToeBoard = ({ G, ctx, moves }) => (
-  <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 150 }}>
-    {G.cells.map((cell, idx) => (
-      <TouchableOpacity
-        key={idx}
-        onPress={() => moves.clickCell(idx)}
-        style={{
-          width: 50,
-          height: 50,
-          borderWidth: 1,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Text style={{ fontSize: 24 }}>
-          {cell === '0' ? 'X' : cell === '1' ? 'O' : ''}
-        </Text>
-      </TouchableOpacity>
-    ))}
-  </View>
-);
+const TicTacToeBoard = ({ G, ctx, moves, onGameEnd }) => {
+  const endedRef = useRef(false);
+
+  useEffect(() => {
+    if (ctx.gameover && !endedRef.current) {
+      endedRef.current = true;
+      onGameEnd && onGameEnd(ctx.gameover);
+    }
+  }, [ctx.gameover, onGameEnd]);
+
+  const disabled = !!ctx.gameover;
+
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 150 }}>
+      {G.cells.map((cell, idx) => (
+        <TouchableOpacity
+          key={idx}
+          onPress={() => moves.clickCell(idx)}
+          disabled={disabled}
+          style={{
+            width: 50,
+            height: 50,
+            borderWidth: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 24 }}>
+            {cell === '0' ? 'X' : cell === '1' ? 'O' : ''}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+};
 
 const TicTacToeClient = Client({
   game: TicTacToeGame,

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -10,22 +10,44 @@ import {
   StyleSheet,
   KeyboardAvoidingView,
   Platform,
+  Modal,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import styles from '../styles';
-import TicTacToe from '../games/tic-tac-toe';
+import { games, gameList } from '../games';
 import { useChats } from '../contexts/ChatContext';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function ChatScreen({ route }) {
   const { user } = route.params;
-  const { getMessages, sendMessage } = useChats();
+  const {
+    getMessages,
+    sendMessage,
+    setActiveGame,
+    getActiveGame,
+    sendGameInvite,
+    clearGameInvite,
+    acceptGameInvite,
+    getPendingInvite,
+  } = useChats();
+  const { darkMode } = useTheme();
   const isWideScreen = Dimensions.get('window').width > 700;
-  const [showGame, setShowGame] = useState(false);
+  const [showGameModal, setShowGameModal] = useState(false);
+  const [activeSection, setActiveSection] = useState('chat');
   const [text, setText] = useState('');
+
+  const activeGameId = getActiveGame(user.id);
+  const pendingInvite = getPendingInvite(user.id);
 
   const rawMessages = getMessages(user.id) || [];
   const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    if (activeGameId) {
+      setActiveSection('game');
+    }
+  }, [activeGameId]);
 
   useEffect(() => {
     const converted = rawMessages.map((msg, index) => ({
@@ -43,20 +65,78 @@ export default function ChatScreen({ route }) {
     }
   };
 
+  const handleAcceptInvite = () => {
+    if (pendingInvite) {
+      const title = games[pendingInvite.gameId].meta.title;
+      acceptGameInvite(user.id);
+      sendMessage(user.id, `Game starting: ${title}`, 'system');
+      setActiveSection('game');
+    }
+  };
+
+  const handleDeclineInvite = () => {
+    if (pendingInvite) {
+      clearGameInvite(user.id);
+      sendMessage(user.id, 'Invite declined', 'system');
+    }
+  };
+
+  const handleGameEnd = (result) => {
+    if (!result) return;
+    if (result.winner !== undefined) {
+      const winnerName = result.winner === '0' ? 'You' : user.name;
+      sendMessage(user.id, `Game over. ${winnerName} won!`, 'system');
+    } else if (result.draw) {
+      sendMessage(user.id, 'Game over. Draw.', 'system');
+    }
+    setActiveGame(user.id, null);
+    setActiveSection('chat');
+  };
+
   const renderMessage = ({ item }) => (
     <View
       style={[
         chatStyles.messageBubble,
         item.sender === 'you'
           ? chatStyles.messageRight
+          : item.sender === 'system'
+          ? chatStyles.messageSystem
           : chatStyles.messageLeft,
       ]}
     >
       <Text style={chatStyles.sender}>
-        {item.sender === 'you' ? 'You' : user.name}
+        {item.sender === 'you'
+          ? 'You'
+          : item.sender === 'system'
+          ? 'System'
+          : user.name}
       </Text>
       <Text style={chatStyles.messageText}>{item.text}</Text>
     </View>
+  );
+
+  const handleGameSelect = (gameId) => {
+    const title = games[gameId].meta.title;
+    if (activeGameId) {
+      if (activeGameId !== gameId) {
+        setActiveGame(user.id, gameId);
+        sendMessage(user.id, `Switched game to ${title}`, 'system');
+        setActiveSection('game');
+      }
+    } else {
+      sendGameInvite(user.id, gameId, 'you');
+      sendMessage(user.id, `Invited ${user.name} to play ${title}`, 'system');
+    }
+    setShowGameModal(false);
+  };
+
+  const renderGameOption = ({ item }) => (
+    <TouchableOpacity
+      style={chatStyles.gameOption}
+      onPress={() => handleGameSelect(item.id)}
+    >
+      <Text style={chatStyles.gameOptionText}>{item.title}</Text>
+    </TouchableOpacity>
   );
 
   const chatSection = (
@@ -64,14 +144,27 @@ export default function ChatScreen({ route }) {
       <Text style={[styles.logoText, { marginBottom: 10 }]}>
         Chat with {user.name}
       </Text>
-      <TouchableOpacity
-        style={[styles.navBtn, { marginBottom: 10 }]}
-        onPress={() => setShowGame((prev) => !prev)}
-      >
-        <Text style={styles.navBtnText}>
-          {showGame ? 'Hide Game' : 'Play Game'}
-        </Text>
-      </TouchableOpacity>
+      {pendingInvite && pendingInvite.from === 'them' && (
+        <View style={chatStyles.inviteBanner}>
+          <Text style={chatStyles.inviteText}>
+            {user.name} invited you to play {games[pendingInvite.gameId].meta.title}
+          </Text>
+          <View style={chatStyles.inviteActions}>
+            <TouchableOpacity
+              style={[chatStyles.playButton, { marginRight: 8 }]}
+              onPress={handleAcceptInvite}
+            >
+              <Text style={{ color: '#fff', fontWeight: 'bold' }}>Accept</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={chatStyles.declineButton}
+              onPress={handleDeclineInvite}
+            >
+              <Text style={{ color: '#fff', fontWeight: 'bold' }}>Decline</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
       <View style={{ flex: 1 }}>
         <FlatList
           data={messages}
@@ -86,6 +179,21 @@ export default function ChatScreen({ route }) {
         keyboardVerticalOffset={60}
         style={chatStyles.inputBar}
       >
+        {activeGameId ? (
+          <TouchableOpacity
+            style={chatStyles.changeButton}
+            onPress={() => setShowGameModal(true)}
+          >
+            <Text style={{ color: '#fff', fontWeight: 'bold' }}>Change Game</Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={chatStyles.playButton}
+            onPress={() => setShowGameModal(true)}
+          >
+            <Text style={{ color: '#fff', fontWeight: 'bold' }}>Play</Text>
+          </TouchableOpacity>
+        )}
         <TextInput
           placeholder="Type a message..."
           style={chatStyles.textInput}
@@ -100,35 +208,88 @@ export default function ChatScreen({ route }) {
     </View>
   );
 
-  const gameSection = showGame ? (
+  const SelectedGameClient = activeGameId ? games[activeGameId].Client : null;
+  const gameSection = SelectedGameClient ? (
     <View
       style={{
         flex: 1,
         padding: 10,
         borderRightWidth: isWideScreen ? 1 : 0,
         borderBottomWidth: isWideScreen ? 0 : 1,
-        borderColor: '#ccc',
+        borderColor: darkMode ? '#444' : '#ccc',
         justifyContent: 'center',
         alignItems: 'center',
       }}
     >
-      <TicTacToe />
+      <SelectedGameClient
+        matchID={user.id}
+        playerID="0"
+        boardProps={{ onGameEnd: handleGameEnd }}
+      />
     </View>
   ) : null;
 
+  const gradientColors = darkMode ? ['#121212', '#1e1e1e'] : ['#fff', '#fdeef4'];
+
+  const toggleBar = (
+    <View style={chatStyles.toggleBar}>
+      <TouchableOpacity
+        style={[
+          chatStyles.toggleButton,
+          activeSection === 'game' && chatStyles.toggleActive,
+        ]}
+        onPress={() => setActiveSection('game')}
+      >
+        <Text style={chatStyles.toggleText}>Game View</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[
+          chatStyles.toggleButton,
+          activeSection === 'chat' && chatStyles.toggleActive,
+        ]}
+        onPress={() => setActiveSection('chat')}
+      >
+        <Text style={chatStyles.toggleText}>Chat View</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
   return (
-    <LinearGradient colors={['#fff', '#fdeef4']} style={{ flex: 1 }}>
+    <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
       <Header />
+      <Modal
+        visible={showGameModal}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowGameModal(false)}
+      >
+        <View style={chatStyles.modalOverlay}>
+          <View style={chatStyles.modalContent}>
+            <FlatList
+              data={gameList}
+              keyExtractor={(item) => item.id}
+              renderItem={renderGameOption}
+            />
+            <TouchableOpacity
+              style={[chatStyles.sendButton, { marginTop: 10 }]}
+              onPress={() => setShowGameModal(false)}
+            >
+              <Text style={{ color: '#fff', fontWeight: 'bold' }}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
       {isWideScreen ? (
         <View style={{ flex: 1, flexDirection: 'row', paddingTop: 60 }}>
           {gameSection}
           {chatSection}
         </View>
       ) : (
-        <ScrollView style={{ flex: 1, paddingTop: 60 }}>
-          {gameSection}
-          {chatSection}
-        </ScrollView>
+        <View style={{ flex: 1, paddingTop: 60 }}>
+          {toggleBar}
+          {activeSection === 'game' && gameSection}
+          {activeSection === 'chat' && chatSection}
+        </View>
       )}
     </LinearGradient>
   );
@@ -148,6 +309,10 @@ const chatStyles = StyleSheet.create({
   messageRight: {
     alignSelf: 'flex-end',
     backgroundColor: '#ffb6c1',
+  },
+  messageSystem: {
+    alignSelf: 'center',
+    backgroundColor: '#ddd',
   },
   messageText: {
     fontSize: 15,
@@ -178,6 +343,82 @@ const chatStyles = StyleSheet.create({
   },
   sendButton: {
     backgroundColor: '#ff4081',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+  },
+  playButton: {
+    backgroundColor: '#009688',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    marginRight: 10,
+  },
+  changeButton: {
+    backgroundColor: '#607d8b',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    marginRight: 10,
+  },
+  toggleBar: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 10,
+  },
+  toggleButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    marginHorizontal: 5,
+    borderRadius: 16,
+    backgroundColor: '#ccc',
+  },
+  toggleActive: {
+    backgroundColor: '#009688',
+  },
+  toggleText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 10,
+    width: '80%',
+    maxHeight: '60%',
+  },
+  gameOption: {
+    padding: 12,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  gameOptionText: {
+    fontSize: 16,
+    color: '#333',
+  },
+  inviteBanner: {
+    backgroundColor: '#333',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  inviteText: {
+    color: '#fff',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  inviteActions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  declineButton: {
+    backgroundColor: '#b00020',
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 20,

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -26,6 +26,8 @@ const MatchesScreen = ({ navigation }) => {
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           contentContainerStyle={{ padding: 20, paddingBottom: 120 }}
+          showsVerticalScrollIndicator={false}
+          horizontal={false}
         />
       </LinearGradient>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- persist match data with AsyncStorage in `ChatContext`
- simplify view toggle in `ChatScreen` and add game over handling
- compute game state from context rather than component state
- detect Tic Tac Toe win/draw and notify `ChatScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ccef040e8832dbcef4c83b0a99389