### PR TITLE
Fix chat navigation user objects

### DIFF
--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -53,8 +53,8 @@ const GameInviteScreen = ({ route, navigation }) => {
     const toLobby = () =>
       navigation.navigate('GameLobby', {
         game: { title: game.title },
-        opponent: { name: user.name, photo: user.photo },
-        status: devMode ? 'ready' : 'waiting'
+        opponent: { id: user.id, name: user.name, photo: user.photo },
+        status: devMode ? 'ready' : 'waiting',
       });
 
     if (devMode) {

--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -98,10 +98,16 @@ const GameLobbyScreen = ({ route, navigation }) => {
             alignItems: 'center',
             marginBottom: 12
           }}
-          onPress={() => navigation.navigate('Chat', {
-            user: opponent,
-            gameId: game.id
-          })}
+          onPress={() =>
+            navigation.navigate('Chat', {
+              user: {
+                id: opponent?.id,
+                name: opponent?.name,
+                image: opponent?.photo,
+              },
+              gameId: game.id,
+            })
+          }
         >
           <Text style={{ color: '#000', fontWeight: '600' }}>Chat</Text>
         </TouchableOpacity>

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -160,7 +160,18 @@ const HomeScreen = ({ navigation }) => {
         {/* 🔥 Suggested Match */}
         <Text style={local.section}>Suggested Match</Text>
         {card(
-          <TouchableOpacity onPress={() => navigation.navigate('Chat', { user: 'Emily' })} style={local.row}>
+          <TouchableOpacity
+            onPress={() =>
+              navigation.navigate('Chat', {
+                user: {
+                  id: '2',
+                  name: 'Emily',
+                  image: require('../assets/user2.jpg'),
+                },
+              })
+            }
+            style={local.row}
+          >
             <Image source={require('../assets/user2.jpg')} style={local.suggestedImage} />
             <View>
               <Text style={local.name}>Emily</Text>


### PR DESCRIPTION
## Summary
- pass a full user object when jumping to a chat from the home screen
- include user id in the game lobby/chat handoff
- keep opponent id when inviting to a game

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e3f83919c832dab6560cea150f7d5