### PR TITLE
Update screens to display user info

### DIFF
--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -34,8 +34,8 @@ const SettingsScreen = ({ navigation }) => {
       </Text>
 
       <View style={{ marginBottom: 20 }}>
-        <Text style={[styles.settingText, { color: darkMode ? '#ccc' : '#666' }]}>
-          Account: DemoUser@example.com
+        <Text style={[styles.settingText, { color: darkMode ? '#ccc' : '#666' }]}> 
+          Account: {user?.email || 'Unknown'}
         </Text>
         <Text style={[styles.settingText, { color: darkMode ? '#aaa' : '#999' }]}>
           Status: {isPremium ? '🌟 Premium Member' : 'Free Member'}

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -5,20 +5,22 @@ import { View, Text, StyleSheet, ScrollView, Image, TouchableOpacity } from 'rea
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
+import { useUser } from '../contexts/UserContext';
 
 const StatsScreen = ({ navigation }) => {
   const { darkMode } = useTheme();
+  const { user } = useUser();
+  const isPremium = !!user?.isPremium;
 
   const stats = {
     gamesPlayed: 87,
     gamesWon: 52,
-    favoriteGame: 'Chess',
+    favoriteGame: user?.favoriteGame || 'Chess',
     matches: 120,
     swipes: 421,
     messagesSent: 198,
     streak: 7,
     badge: 'Top 5% Swipers',
-    premium: false
   };
 
   return (
@@ -31,8 +33,8 @@ const StatsScreen = ({ navigation }) => {
         {/* Profile Summary */}
         <View style={styles.profileCard}>
           <Image source={require('../assets/user1.jpg')} style={styles.avatar} />
-          <Text style={styles.name}>DemoUser</Text>
-          {stats.premium && <Text style={styles.premiumBadge}>★ Premium</Text>}
+          <Text style={styles.name}>{user?.displayName || 'User'}</Text>
+          {isPremium && <Text style={styles.premiumBadge}>★ Premium</Text>}
         </View>
 
         {/* Game Stats */}
@@ -76,7 +78,7 @@ const StatsScreen = ({ navigation }) => {
           <Text style={styles.statValue}>{stats.badge}</Text>
         </View>
 
-        {!stats.premium && (
+        {!isPremium && (
           <TouchableOpacity
             onPress={() => navigation.navigate('PremiumPaywall')}
             style={styles.premiumButton}


### PR DESCRIPTION
## Summary
- use `useUser` hook in `StatsScreen` and show user name and favorite game
- display user's email on the Settings screen
- hide/show premium elements based on `user.isPremium`

## Testing
- `npm test` *(fails: npm cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_684e4079cb90832d9544e81665a33fb7