### PR TITLE
Improve light/dark gradients

### DIFF
--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -6,7 +6,7 @@ import styles from '../styles';
 
 export default function GradientBackground({ children }) {
   const { darkMode } = useTheme();
-  const colors = darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#FF75B5', '#FF9A75'];
+  const colors = darkMode ? ['#444', '#222'] : ['#FF75B5', '#FF9A75'];
 
   return (
     <LinearGradient colors={colors} style={styles.container}>

--- a/components/Header.js
+++ b/components/Header.js
@@ -10,7 +10,7 @@ const Header = () => {
   const notificationCount = 5; // 🔥 Replace with dynamic logic later
 
   return (
-    <View style={[styles.container, { backgroundColor: darkMode ? '#111' : '#fff' }]}>
+    <View style={[styles.container, { backgroundColor: darkMode ? '#222' : '#fff' }]}>
       {/* Left icon - Gear */}
       <TouchableOpacity onPress={() => navigation.navigate('Settings')} style={styles.iconWrapper}>
         <Image

--- a/navigation/MainTabs.js
+++ b/navigation/MainTabs.js
@@ -28,7 +28,7 @@ export default function MainTabs() {
         tabBarInactiveTintColor: '#888',
         tabBarLabelStyle: { fontSize: 12, paddingBottom: 2 },
         tabBarStyle: {
-          backgroundColor: darkMode ? '#2c2c2c' : '#fff',
+          backgroundColor: darkMode ? '#444' : '#fff',
           borderTopWidth: 1,
           borderColor: '#eee',
           height: 60,

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -201,7 +201,7 @@ export default function ChatScreen({ route }) {
     </View>
   ) : null;
 
-  const gradientColors = darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#fdeef4'];
+  const gradientColors = darkMode ? ['#444', '#222'] : ['#fff', '#fdeef4'];
 
   const toggleBar = (
     <View style={chatStyles.toggleBar}>

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -86,7 +86,7 @@ const CommunityScreen = () => {
         style={[
           local.card,
           {
-            backgroundColor: darkMode ? '#2c2c2c' : '#fff',
+            backgroundColor: darkMode ? '#444' : '#fff',
             marginRight: idx % 2 === 0 ? 8 : 0,
             marginLeft: idx % 2 !== 0 ? 8 : 0
           }
@@ -122,7 +122,7 @@ const CommunityScreen = () => {
   };
 
   return (
-    <View style={{ flex: 1, backgroundColor: darkMode ? '#1b1b1b' : '#fce4ec' }}>
+    <View style={{ flex: 1, backgroundColor: darkMode ? '#333' : '#fce4ec' }}>
       <Header />
 
       <ScrollView contentContainerStyle={{ paddingTop: 100, paddingBottom: 150 }}>
@@ -147,7 +147,7 @@ const CommunityScreen = () => {
         </ScrollView>
 
         {/* Featured */}
-        <View style={[local.banner, { backgroundColor: darkMode ? '#272727' : '#fff' }]}>
+        <View style={[local.banner, { backgroundColor: darkMode ? '#333' : '#fff' }]}>
           <Image source={require('../assets/user2.jpg')} style={local.bannerImage} />
           <Text style={local.bannerTitle}>🔥 Featured</Text>
           <Text style={local.bannerText}>Truth or Dare Night — Friday @ 9PM</Text>

--- a/screens/EventChatScreen.js
+++ b/screens/EventChatScreen.js
@@ -112,7 +112,7 @@ const EventChatScreen = ({ route }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={{ flex: 1 }}
     >
       <Header />

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -76,7 +76,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     return (
       <View
         style={{
-          backgroundColor: darkMode ? '#2c2c2c' : '#fff',
+          backgroundColor: darkMode ? '#444' : '#fff',
           borderRadius: 16,
           borderWidth: 1,
           borderColor: darkMode ? '#333' : '#eee',
@@ -134,7 +134,7 @@ const GameInviteScreen = ({ route, navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={styles.swipeScreen}
     >
       <Header showLogoOnly />

--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -26,7 +26,7 @@ const GameLobbyScreen = ({ route, navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={styles.swipeScreen}
     >
       <Header showLogoOnly />

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -48,7 +48,7 @@ const HomeScreen = ({ navigation }) => {
   const [playTarget, setPlayTarget] = useState('stranger');
 
   const card = (children, style = {}) => (
-    <View style={[local.card, { backgroundColor: darkMode ? '#2c2c2c' : '#fff' }, style]}>
+    <View style={[local.card, { backgroundColor: darkMode ? '#444' : '#fff' }, style]}>
       {children}
     </View>
   );
@@ -86,7 +86,7 @@ const HomeScreen = ({ navigation }) => {
   });
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: darkMode ? '#1b1b1b' : '#fce4ec' }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: darkMode ? '#333' : '#fce4ec' }}>
       <View style={{ position: 'relative' }}>
         <Header showLogoOnly />
         <TouchableOpacity
@@ -139,7 +139,7 @@ const HomeScreen = ({ navigation }) => {
         <Text style={local.section}>Active Games</Text>
         <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ paddingLeft: 16, marginBottom: 16 }}>
           {ACTIVE_GAMES.map((game) => (
-            <View key={game.id} style={[local.activeGameCard, { backgroundColor: darkMode ? '#2c2c2c' : '#fff' }]}>
+            <View key={game.id} style={[local.activeGameCard, { backgroundColor: darkMode ? '#444' : '#fff' }]}>
               <View style={{ alignItems: 'center' }}>
                 <Image source={game.image} style={local.avatarRound} />
                 <Text style={local.nameSmall}>{game.name}</Text>

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -18,7 +18,7 @@ const MatchesScreen = ({ navigation }) => {
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <LinearGradient colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']} style={{ flex: 1 }}>
+      <LinearGradient colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']} style={{ flex: 1 }}>
         <Header />
         <Text style={styles.title}>Your Matches</Text>
         <FlatList

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -288,8 +288,8 @@ export default function OnboardingScreen() {
 }
 
 const getStyles = (darkMode) => {
-  const background = darkMode ? '#1b1b1b' : '#FFFFFF';
-  const cardBg = darkMode ? '#242424' : '#FFFFFF';
+  const background = darkMode ? '#333' : '#FFFFFF';
+  const cardBg = darkMode ? '#444' : '#FFFFFF';
   const textColor = darkMode ? '#EEE' : '#222';
   const accent = '#FF75B5';
 

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -385,7 +385,7 @@ const PlayScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={styles.swipeScreen}
     >
       <Header showLogoOnly />

--- a/screens/PremiumPaywallScreen.js
+++ b/screens/PremiumPaywallScreen.js
@@ -36,7 +36,7 @@ const PremiumPaywallScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={{ flex: 1 }}
     >
       <Header />

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -27,7 +27,7 @@ const PremiumScreen = () => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={{ flex: 1 }}
     >
       <Header />

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -24,7 +24,7 @@ const SettingsScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#222', '#000'] : ['#fff', '#fce4ec']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#fce4ec']}
       style={styles.container}
     >
       <Header />

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -22,7 +22,7 @@ const useFadeIn = (duration = 1000) => {
 export default function SplashScreen({ onFinish }) {
   const fadeAnim = useFadeIn();
   const { darkMode } = useTheme();
-  const colors = darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#FF75B5', '#FF9A75'];
+  const colors = darkMode ? ['#444', '#222'] : ['#FF75B5', '#FF9A75'];
 
   useEffect(() => {
     const timeout = setTimeout(onFinish, splashDuration);

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -25,7 +25,7 @@ const StatsScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#2c2c2c', '#1b1b1b'] : ['#fff', '#ffe6f0']}
+      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
       style={{ flex: 1 }}
     >
       <Header showLogoOnly />

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -191,7 +191,7 @@ const SwipeScreen = () => {
     navigation.navigate('GameInvite', { user: displayUser });
   };
 
-  const gradientColors = darkMode ? ['#1a1a1a', '#0f0f0f'] : ['#FF75B5', '#FF9A75'];
+  const gradientColors = darkMode ? ['#333', '#222'] : ['#FF75B5', '#FF9A75'];
 
   return (
     <LinearGradient colors={gradientColors} style={{ flex: 1 }}>

--- a/styles.js
+++ b/styles.js
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
     textDecorationLine: 'underline'
   },
   navBtn: {
-    backgroundColor: '#111',
+    backgroundColor: '#222',
     paddingVertical: 14,
     paddingHorizontal: 40,
     borderRadius: 12,


### PR DESCRIPTION
## Summary
- lighten dark theme gradients for a softer look across the app
- adjust dark background colors on cards and banners
- tweak onboarding and settings gradients
- update header and button styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e41b028fc832d96623dce57b97b4a