### PR TITLE
Fix onboarding provider order

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,8 +18,8 @@ export default function App() {
     <DevProvider>
       <ThemeProvider>
         <NotificationProvider>
-          <UserProvider>
-            <OnboardingProvider>
+          <OnboardingProvider>
+            <UserProvider>
               <GameLimitProvider>
                 <ChatProvider>
                   <MatchmakingProvider>
@@ -32,8 +32,8 @@ export default function App() {
                   </MatchmakingProvider>
                 </ChatProvider>
               </GameLimitProvider>
-            </OnboardingProvider>
-          </UserProvider>
+            </UserProvider>
+          </OnboardingProvider>
         </NotificationProvider>
       </ThemeProvider>
     </DevProvider>


### PR DESCRIPTION
## Summary
- wrap `UserProvider` with `OnboardingProvider` so user context can access onboarding helpers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ac14798832da16087cf8190a1aa