### PR TITLE
Add XP and streak tracking

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -26,7 +26,7 @@ import { games, gameList } from '../games';
 export default function ChatScreen({ route }) {
   const { user } = route.params || {};
   const navigation = useNavigation();
-  const { user: currentUser } = useUser();
+  const { user: currentUser, addGameXP } = useUser();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const { devMode } = useDev();
   const {
@@ -90,6 +90,7 @@ export default function ChatScreen({ route }) {
 
   const handleGameEnd = (result) => {
     if (!result) return;
+    addGameXP();
     if (result.winner !== undefined) {
       const msg = result.winner === '0' ? 'You win!' : `${user.name} wins.`;
       sendMessage(user.id, `Game over. ${msg}`, 'system');

--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -25,7 +25,7 @@ const GameLobbyScreen = ({ route, navigation }) => {
   const { darkMode } = useTheme();
   const { devMode } = useDev();
   const { recordGamePlayed } = useGameLimit();
-  const { user } = useUser();
+  const { user, addGameXP } = useUser();
   const { sendGameInvite } = useMatchmaking();
 
   const { game, opponent, status = 'waiting', inviteId } = route.params || {};
@@ -77,6 +77,7 @@ const GameLobbyScreen = ({ route, navigation }) => {
   }, [countdown]);
 
   const handleGameEnd = (result) => {
+    if (result) addGameXP();
     setGameResult(result);
   };
 

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -96,6 +96,9 @@ export default function OnboardingScreen() {
           location: answers.location,
           favoriteGame: answers.favoriteGame,
           skillLevel: answers.skillLevel,
+          xp: 0,
+          streak: 0,
+          lastPlayedAt: null,
           onboardingComplete: true,
         };
         await setDoc(doc(db, 'users', auth.currentUser.uid), clean, {

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -20,7 +20,8 @@ const StatsScreen = ({ navigation }) => {
     matches: 120,
     swipes: 421,
     messagesSent: 198,
-    streak: 7,
+    xp: user?.xp || 0,
+    streak: user?.streak || 0,
     badge: 'Top 5% Swipers',
   };
 
@@ -51,6 +52,10 @@ const StatsScreen = ({ navigation }) => {
         <View style={styles.statBox}>
           <Text style={styles.statLabel}>Favorite Game</Text>
           <Text style={styles.statValue}>{stats.favoriteGame}</Text>
+        </View>
+        <View style={styles.statBox}>
+          <Text style={styles.statLabel}>XP</Text>
+          <Text style={styles.statValue}>{stats.xp}</Text>
         </View>
 
         {/* Social Stats */}


### PR DESCRIPTION
## Summary
- initialize xp and streak when onboarding
- track game xp/streak in user context and update Firestore
- award xp after a game ends in chats and lobbies
- show xp and streak on stats screen

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e6d13fccc832d8646b119a8e93792