### PR TITLE
Update PlayScreen games and add quick minis

### DIFF
--- a/games/coin-flip.js
+++ b/games/coin-flip.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Client } from 'boardgame.io/react-native';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+const CoinFlipGame = {
+  setup: () => ({ choices: [null, null], coin: null }),
+  turn: { moveLimit: 1 },
+  moves: {
+    choose: ({ G, ctx }, choice) => {
+      const player = parseInt(ctx.currentPlayer, 10);
+      if (G.choices[player] !== null) return INVALID_MOVE;
+      G.choices[player] = choice; // 0 = Heads, 1 = Tails
+    },
+  },
+  endIf: ({ G }) => {
+    if (G.choices[0] !== null && G.choices[1] !== null) {
+      const coin = Math.random() < 0.5 ? 0 : 1;
+      G.coin = coin;
+      if (G.choices[0] === G.choices[1]) {
+        return { draw: true };
+      }
+      if (G.choices[0] === coin) return { winner: '0' };
+      if (G.choices[1] === coin) return { winner: '1' };
+      return { draw: true };
+    }
+  },
+};
+
+const labels = ['Heads', 'Tails'];
+
+const CoinFlipBoard = ({ G, ctx, moves, onGameEnd }) => {
+  const endedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (ctx.gameover && !endedRef.current) {
+      endedRef.current = true;
+      onGameEnd && onGameEnd(ctx.gameover);
+    }
+  }, [ctx.gameover, onGameEnd]);
+
+  const disabled = !!ctx.gameover;
+  const yourChoice = G.choices[0];
+  const oppChoice = G.choices[1];
+
+  return (
+    <View style={{ alignItems: 'center' }}>
+      {!ctx.gameover && (
+        <Text style={{ marginBottom: 10, fontWeight: 'bold' }}>
+          {ctx.currentPlayer === '0' ? 'Your turn' : 'Waiting for opponent'}
+        </Text>
+      )}
+      <View style={{ flexDirection: 'row', marginBottom: 20 }}>
+        {labels.map((l, idx) => (
+          <TouchableOpacity
+            key={idx}
+            onPress={() => moves.choose(idx)}
+            disabled={disabled || yourChoice !== null}
+            style={{
+              padding: 10,
+              margin: 5,
+              borderWidth: 1,
+              borderColor: '#333',
+              borderRadius: 6,
+            }}
+          >
+            <Text>{l}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <Text>Your choice: {yourChoice !== null ? labels[yourChoice] : '-'}</Text>
+      <Text>Opponent: {oppChoice !== null ? labels[oppChoice] : '-'}</Text>
+      {G.coin !== null && <Text>Coin: {labels[G.coin]}</Text>}
+      {ctx.gameover && (
+        <Text style={{ marginTop: 10, fontWeight: 'bold' }}>
+          {ctx.gameover.draw
+            ? 'Draw!'
+            : ctx.gameover.winner === '0'
+            ? 'You win!'
+            : 'You lose!'}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const CoinFlipClient = Client({ game: CoinFlipGame, board: CoinFlipBoard });
+
+export const Game = CoinFlipGame;
+export const Board = CoinFlipBoard;
+export const meta = { id: 'coinFlip', title: 'Coin Flip' };
+
+export default CoinFlipClient;

--- a/games/dice-roll.js
+++ b/games/dice-roll.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Client } from 'boardgame.io/react-native';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+const DiceRollGame = {
+  setup: () => ({ rolls: [null, null] }),
+  turn: { moveLimit: 1 },
+  moves: {
+    roll: ({ G, ctx }) => {
+      const player = parseInt(ctx.currentPlayer, 10);
+      if (G.rolls[player] !== null) return INVALID_MOVE;
+      G.rolls[player] = Math.ceil(Math.random() * 6);
+    },
+  },
+  endIf: ({ G }) => {
+    if (G.rolls[0] !== null && G.rolls[1] !== null) {
+      if (G.rolls[0] > G.rolls[1]) return { winner: '0' };
+      if (G.rolls[0] < G.rolls[1]) return { winner: '1' };
+      return { draw: true };
+    }
+  },
+};
+
+const DiceRollBoard = ({ G, ctx, moves, onGameEnd }) => {
+  const endedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (ctx.gameover && !endedRef.current) {
+      endedRef.current = true;
+      onGameEnd && onGameEnd(ctx.gameover);
+    }
+  }, [ctx.gameover, onGameEnd]);
+
+  const disabled = !!ctx.gameover;
+  const yourRoll = G.rolls[0];
+  const oppRoll = G.rolls[1];
+
+  return (
+    <View style={{ alignItems: 'center' }}>
+      {!ctx.gameover && (
+        <Text style={{ marginBottom: 10, fontWeight: 'bold' }}>
+          {ctx.currentPlayer === '0' ? 'Your turn' : 'Waiting for opponent'}
+        </Text>
+      )}
+      <TouchableOpacity
+        onPress={() => moves.roll()}
+        disabled={disabled || yourRoll !== null}
+        style={{
+          padding: 10,
+          margin: 5,
+          borderWidth: 1,
+          borderColor: '#333',
+          borderRadius: 6,
+          backgroundColor: '#d81b60',
+        }}
+      >
+        <Text style={{ color: '#fff' }}>Roll</Text>
+      </TouchableOpacity>
+      <Text>Your roll: {yourRoll !== null ? yourRoll : '-'}</Text>
+      <Text>Opponent: {oppRoll !== null ? oppRoll : '-'}</Text>
+      {ctx.gameover && (
+        <Text style={{ marginTop: 10, fontWeight: 'bold' }}>
+          {ctx.gameover.draw
+            ? 'Draw!'
+            : ctx.gameover.winner === '0'
+            ? 'You win!'
+            : 'You lose!'}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const DiceRollClient = Client({ game: DiceRollGame, board: DiceRollBoard });
+
+export const Game = DiceRollGame;
+export const Board = DiceRollBoard;
+export const meta = { id: 'diceRoll', title: 'Dice Roll' };
+
+export default DiceRollClient;

--- a/games/index.js
+++ b/games/index.js
@@ -7,6 +7,8 @@ import HangmanClient, { Game as hangmanGame, Board as HangmanBoard, meta as hang
 import MinesweeperClient, { Game as minesweeperGame, Board as MinesweeperBoard, meta as minesweeperMeta } from './minesweeper';
 import SudokuClient, { Game as sudokuGame, Board as SudokuBoard, meta as sudokuMeta } from './sudoku';
 import GuessNumberClient, { Game as guessNumberGame, Board as GuessNumberBoard, meta as guessNumberMeta } from './guess-number';
+import CoinFlipClient, { Game as coinFlipGame, Board as CoinFlipBoard, meta as coinFlipMeta } from './coin-flip';
+import DiceRollClient, { Game as diceRollGame, Board as DiceRollBoard, meta as diceRollMeta } from './dice-roll';
 
 export const games = {
   [ticTacToeMeta.id]: {
@@ -42,6 +44,18 @@ export const games = {
     Game: guessNumberGame,
     Board: GuessNumberBoard,
     meta: guessNumberMeta,
+  },
+  [coinFlipMeta.id]: {
+    Client: CoinFlipClient,
+    Game: coinFlipGame,
+    Board: CoinFlipBoard,
+    meta: coinFlipMeta,
+  },
+  [diceRollMeta.id]: {
+    Client: DiceRollClient,
+    Game: diceRollGame,
+    Board: DiceRollBoard,
+    meta: diceRollMeta,
   },
 };
 

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -26,6 +26,7 @@ import { useGameLimit } from '../contexts/GameLimitContext';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const CARD_WIDTH = SCREEN_WIDTH * 0.42;
+const HIDDEN_CATEGORIES = ['Word', 'Card', 'Memory', 'Party'];
 
 const allGames = [
   {
@@ -398,11 +399,35 @@ const allGames = [
     description: 'Guess the secret number with hints each turn.',
     mode: 'solo',
     speed: 'quick'
+  },
+  {
+    id: '34',
+    title: 'Coin Flip',
+    icon: <MaterialCommunityIcons name="coin" size={30} />,
+    route: 'CoinFlip',
+    premium: false,
+    category: 'Quick',
+    description: 'Choose heads or tails and see who wins the flip.',
+    mode: 'versus',
+    speed: 'quick'
+  },
+  {
+    id: '35',
+    title: 'Dice Roll',
+    icon: <FontAwesome5 name="dice" size={28} />,
+    route: 'DiceRoll',
+    premium: false,
+    category: 'Quick',
+    description: 'Roll a die and beat your opponent with the highest number.',
+    mode: 'versus',
+    speed: 'quick'
   }
 ];
 
 const getAllCategories = () => {
-  const cats = [...new Set(allGames.map((g) => g.category))];
+  const cats = [...new Set(allGames.map((g) => g.category))].filter(
+    (c) => !HIDDEN_CATEGORIES.includes(c)
+  );
   return ['All', ...cats];
 };
 
@@ -531,9 +556,11 @@ const PlayScreen = ({ navigation }) => {
         <Text style={{ fontSize: 15, fontWeight: '600', textAlign: 'center' }}>
           {item.title}
         </Text>
-        <Text style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
-          {item.category}
-        </Text>
+        {!HIDDEN_CATEGORIES.includes(item.category) && (
+          <Text style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
+            {item.category}
+          </Text>
+        )}
       </TouchableOpacity>
     </Animated.View>
     );
@@ -688,9 +715,20 @@ const PlayScreen = ({ navigation }) => {
               {previewGame?.description}
             </Text>
             <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 10 }}>
-              <Text style={{ backgroundColor: '#eee', paddingHorizontal: 10, paddingVertical: 4, borderRadius: 12, marginRight: 8, fontSize: 12 }}>
-                {previewGame?.category}
-              </Text>
+              {!HIDDEN_CATEGORIES.includes(previewGame?.category) && (
+                <Text
+                  style={{
+                    backgroundColor: '#eee',
+                    paddingHorizontal: 10,
+                    paddingVertical: 4,
+                    borderRadius: 12,
+                    marginRight: 8,
+                    fontSize: 12,
+                  }}
+                >
+                  {previewGame?.category}
+                </Text>
+              )}
               {previewGame?.mode && (
                 <Text style={{ backgroundColor: '#d1fae5', color: '#065f46', paddingHorizontal: 10, paddingVertical: 4, borderRadius: 12, marginRight: 8, fontSize: 12 }}>
                   {previewGame?.mode === 'both' ? 'Co-op or Versus' : previewGame.mode}


### PR DESCRIPTION
## Summary
- add `coinFlip` and `diceRoll` implementations
- register new games in `games/index.js`
- expand game list with Coin Flip and Dice Roll
- hide Word, Card, Memory and Party categories

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f84583118832d84ba73de02b9af52