### PR TITLE
Integrate ChatContext with Firestore

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -1,51 +1,24 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  collection,
+  doc,
+  query,
+  onSnapshot,
+  addDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  orderBy,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { db } from '../firebase';
 import { useDev } from './DevContext';
+import { useUser } from './UserContext';
 
 const ChatContext = createContext();
 
 const STORAGE_KEY = 'chatMatches';
-
-const initialMatches = [
-  {
-    id: '1',
-    name: 'Emily',
-    age: 25,
-    image: require('../assets/user1.jpg'),
-    messages: [
-      { id: 'm1', text: 'Hey! Want to play a game?', sender: 'them' },
-      { id: 'm2', text: 'Sure! Tic Tac Toe?', sender: 'you' },
-      { id: 'm3', text: 'Sounds good!', sender: 'them' },
-    ],
-    matchedAt: '2 days ago',
-    activeGameId: null,
-    pendingInvite: null,
-  },
-  {
-    id: '2',
-    name: 'Liam',
-    age: 27,
-    image: require('../assets/user2.jpg'),
-    messages: [
-      { id: 'm1', text: 'Ready for a rematch?', sender: 'them' },
-    ],
-    matchedAt: '1 day ago',
-    activeGameId: null,
-    pendingInvite: null,
-  },
-  {
-    id: '3',
-    name: 'Ava',
-    age: 23,
-    image: require('../assets/user1.jpg'),
-    messages: [
-      { id: 'm1', text: 'BRB grabbing coffee ☕', sender: 'them' },
-    ],
-    matchedAt: '5 hours ago',
-    activeGameId: null,
-    pendingInvite: null,
-  },
-];
 
 export const ChatProvider = ({ children }) => {
   const { devMode } = useDev();
@@ -62,30 +35,105 @@ export const ChatProvider = ({ children }) => {
     pendingInvite: null,
   };
 
-  const [matches, setMatches] = useState(
-    devMode ? [...initialMatches, devMatch] : initialMatches
-  );
+  const [matches, setMatches] = useState(devMode ? [devMatch] : []);
 
+  const { user } = useUser();
+
+  // Migrate any old AsyncStorage data into Firestore
   useEffect(() => {
-    AsyncStorage.getItem(STORAGE_KEY).then((data) => {
-      if (data) {
-        try {
-          const parsed = JSON.parse(data);
-          if (Array.isArray(parsed)) {
-            setMatches(parsed);
-          }
-        } catch (e) {
-          console.warn('Failed to parse matches from storage', e);
+    if (!user?.uid) return;
+    const migrate = async () => {
+      try {
+        const data = await AsyncStorage.getItem(STORAGE_KEY);
+        if (!data) return;
+        const parsed = JSON.parse(data);
+        if (Array.isArray(parsed)) {
+          await Promise.all(
+            parsed.map(async (m) => {
+              const ref = doc(db, 'users', user.uid, 'matches', m.id);
+              await setDoc(
+                ref,
+                {
+                  name: m.name,
+                  age: m.age,
+                  image: m.image,
+                  activeGameId: m.activeGameId || null,
+                  pendingInvite: m.pendingInvite || null,
+                  createdAt: serverTimestamp(),
+                },
+                { merge: true }
+              );
+              const msgCol = collection(ref, 'messages');
+              for (const msg of m.messages || []) {
+                await addDoc(msgCol, {
+                  text: msg.text,
+                  sender: msg.sender,
+                  createdAt: serverTimestamp(),
+                });
+              }
+            })
+          );
+          await AsyncStorage.removeItem(STORAGE_KEY);
         }
+      } catch (e) {
+        console.warn('Chat migration failed', e);
+      }
+    };
+    migrate();
+  }, [user?.uid]);
+
+  // Subscribe to Firestore match documents
+  useEffect(() => {
+    if (!user?.uid) return;
+    const q = query(
+      collection(db, 'users', user.uid, 'matches'),
+      orderBy('createdAt', 'desc')
+    );
+    const unsub = onSnapshot(q, (snap) => {
+      const data = snap.docs.map((d) => ({ id: d.id, ...d.data(), messages: [] }));
+      setMatches((prev) => {
+        const filtered = prev.filter((m) => m.id === devMatch.id);
+        return devMode ? [...data, ...filtered] : data;
+      });
+    });
+    return unsub;
+  }, [user?.uid, devMode]);
+
+  // Subscribe to messages for each match
+  const messageSubs = useRef({});
+  useEffect(() => {
+    if (!user?.uid) return;
+    const ids = matches.filter((m) => m.id !== devMatch.id).map((m) => m.id);
+    ids.forEach((id) => {
+      if (!messageSubs.current[id]) {
+        const mq = query(
+          collection(db, 'users', user.uid, 'matches', id, 'messages'),
+          orderBy('createdAt', 'asc')
+        );
+        messageSubs.current[id] = onSnapshot(mq, (snap) => {
+          const msgs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+          setMatches((prev) =>
+            prev.map((m) => (m.id === id ? { ...m, messages: msgs } : m))
+          );
+        });
       }
     });
-  }, []);
+    Object.keys(messageSubs.current).forEach((id) => {
+      if (!ids.includes(id)) {
+        messageSubs.current[id]();
+        delete messageSubs.current[id];
+      }
+    });
+    return () => {
+      Object.values(messageSubs.current).forEach((u) => u());
+      messageSubs.current = {};
+    };
+  }, [user?.uid, matches.map((m) => m.id).join()]);
 
   useEffect(() => {
     setMatches((prev) => {
       if (devMode) {
         if (!prev.find((m) => m.id === devMatch.id)) {
-          console.log('Adding dev match');
           return [...prev, devMatch];
         }
         return prev;
@@ -94,78 +142,97 @@ export const ChatProvider = ({ children }) => {
     });
   }, [devMode]);
 
-  useEffect(() => {
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(matches)).catch((err) => {
-      console.warn('Failed to save matches to storage', err);
-    });
-  }, [matches]);
 
-  const sendMessage = (matchId, text, sender = 'you') => {
-    if (!text) return;
-    setMatches((prev) =>
-      prev.map((m) =>
-        m.id === matchId
-          ? {
-              ...m,
-              messages: [
-                ...m.messages,
-                { id: Date.now().toString(), text, sender },
-              ],
-            }
-          : m
-      )
-    );
-  };
-
-  const setActiveGame = (matchId, gameId) => {
-    setMatches((prev) =>
-      prev.map((m) =>
-        m.id === matchId
-          ? { ...m, activeGameId: gameId, pendingInvite: null }
-          : m
-      )
-    );
-  };
-
-  const sendGameInvite = (matchId, gameId, from = 'you') => {
-    setMatches((prev) =>
-      prev.map((m) =>
-        m.id === matchId
-          ? { ...m, pendingInvite: { gameId, from } }
-          : m
-      )
-    );
-    if (devMode) {
-      console.log('Auto-accepting game invite');
-      acceptGameInvite(matchId);
-    }
-  };
-
-  const clearGameInvite = (matchId) => {
-    setMatches((prev) =>
-      prev.map((m) =>
-        m.id === matchId
-          ? { ...m, pendingInvite: null }
-          : m
-      )
-    );
-  };
-
-  const acceptGameInvite = (matchId) => {
-    const invite = matches.find((m) => m.id === matchId)?.pendingInvite;
-    if (invite) {
+  const sendMessage = async (matchId, text, sender = 'you') => {
+    if (!user?.uid || !text) return;
+    if (matchId === devMatch.id) {
       setMatches((prev) =>
         prev.map((m) =>
           m.id === matchId
             ? {
                 ...m,
-                activeGameId: invite.gameId,
-                pendingInvite: null,
+                messages: [
+                  ...m.messages,
+                  { id: Date.now().toString(), text, sender },
+                ],
               }
             : m
         )
       );
+      return;
     }
+    await addDoc(
+      collection(db, 'users', user.uid, 'matches', matchId, 'messages'),
+      { text, sender, createdAt: serverTimestamp() }
+    );
+  };
+
+  const setActiveGame = (matchId, gameId) => {
+    if (!user?.uid) return;
+    if (matchId === devMatch.id) {
+      setMatches((prev) =>
+        prev.map((m) =>
+          m.id === matchId
+            ? { ...m, activeGameId: gameId, pendingInvite: null }
+            : m
+        )
+      );
+      return;
+    }
+    updateDoc(doc(db, 'users', user.uid, 'matches', matchId), {
+      activeGameId: gameId,
+      pendingInvite: null,
+    });
+  };
+
+  const sendGameInvite = async (matchId, gameId, from = 'you') => {
+    if (!user?.uid) return;
+    if (matchId === devMatch.id) {
+      setMatches((prev) =>
+        prev.map((m) =>
+          m.id === matchId ? { ...m, pendingInvite: { gameId, from } } : m
+        )
+      );
+      if (devMode) acceptGameInvite(matchId);
+      return;
+    }
+    await updateDoc(doc(db, 'users', user.uid, 'matches', matchId), {
+      pendingInvite: { gameId, from },
+    });
+    if (devMode) acceptGameInvite(matchId);
+  };
+
+  const clearGameInvite = (matchId) => {
+    if (!user?.uid) return;
+    if (matchId === devMatch.id) {
+      setMatches((prev) =>
+        prev.map((m) => (m.id === matchId ? { ...m, pendingInvite: null } : m))
+      );
+      return;
+    }
+    updateDoc(doc(db, 'users', user.uid, 'matches', matchId), {
+      pendingInvite: null,
+    });
+  };
+
+  const acceptGameInvite = (matchId) => {
+    if (!user?.uid) return;
+    const invite = matches.find((m) => m.id === matchId)?.pendingInvite;
+    if (!invite) return;
+    if (matchId === devMatch.id) {
+      setMatches((prev) =>
+        prev.map((m) =>
+          m.id === matchId
+            ? { ...m, activeGameId: invite.gameId, pendingInvite: null }
+            : m
+        )
+      );
+      return;
+    }
+    updateDoc(doc(db, 'users', user.uid, 'matches', matchId), {
+      activeGameId: invite.gameId,
+      pendingInvite: null,
+    });
   };
 
   const getPendingInvite = (matchId) =>
@@ -177,14 +244,37 @@ export const ChatProvider = ({ children }) => {
   const getMessages = (matchId) =>
     matches.find((m) => m.id === matchId)?.messages || [];
 
-  const addMatch = (match) =>
-    setMatches((prev) => {
-      if (prev.find((m) => m.id === match.id)) return prev;
-      return [...prev, match];
-    });
+  const addMatch = async (match) => {
+    if (!user?.uid || !match?.id) return;
+    if (match.id === devMatch.id) {
+      setMatches((prev) => {
+        if (prev.find((m) => m.id === match.id)) return prev;
+        return [...prev, match];
+      });
+      return;
+    }
+    await setDoc(
+      doc(db, 'users', user.uid, 'matches', match.id),
+      {
+        name: match.name,
+        age: match.age,
+        image: match.image,
+        activeGameId: null,
+        pendingInvite: null,
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    );
+  };
 
-  const removeMatch = (matchId) =>
-    setMatches((prev) => prev.filter((m) => m.id !== matchId));
+  const removeMatch = (matchId) => {
+    if (!user?.uid) return;
+    if (matchId === devMatch.id) {
+      setMatches((prev) => prev.filter((m) => m.id !== matchId));
+      return;
+    }
+    deleteDoc(doc(db, 'users', user.uid, 'matches', matchId));
+  };
 
   return (
     <ChatContext.Provider

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -22,6 +22,7 @@ import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
 import { useNavigation } from '@react-navigation/native';
 import { games, gameList } from '../games';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function ChatScreen({ route }) {
   const { user } = route.params || {};
@@ -29,6 +30,7 @@ export default function ChatScreen({ route }) {
   const { user: currentUser, addGameXP } = useUser();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const { devMode } = useDev();
+  const isPremiumUser = !!currentUser?.isPremium;
   const {
     getMessages,
     sendMessage,
@@ -88,6 +90,10 @@ export default function ChatScreen({ route }) {
     }
   };
 
+  const handleVoice = () => {
+    sendMessage(user.id, '[Voice Message]');
+  };
+
   const handleGameEnd = (result) => {
     if (!result) return;
     addGameXP();
@@ -102,7 +108,6 @@ export default function ChatScreen({ route }) {
   };
 
   const handleGameSelect = (gameId) => {
-    const isPremiumUser = !!currentUser?.isPremium;
     if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
       setShowGameModal(false);
       navigation.navigate('PremiumPaywall');
@@ -138,7 +143,14 @@ export default function ChatScreen({ route }) {
           ? 'System'
           : user.name}
       </Text>
-      <Text style={chatStyles.messageText}>{item.text}</Text>
+      <View style={chatStyles.messageRow}>
+        <Text style={chatStyles.messageText}>{item.text}</Text>
+        {isPremiumUser && item.sender !== 'system' && (
+          <TouchableOpacity style={chatStyles.reactButton} onPress={() => {}}>
+            <Ionicons name="heart-outline" size={14} color="#d81b60" />
+          </TouchableOpacity>
+        )}
+      </View>
     </View>
   );
 
@@ -153,9 +165,12 @@ export default function ChatScreen({ route }) {
 
   const chatSection = (
     <View style={{ flex: 1, padding: 10 }}>
-      <Text style={[styles.logoText, { marginBottom: 10 }]}>
-        Chat with {user.name}
-      </Text>
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
+        <Text style={styles.logoText}>Chat with {user.name}</Text>
+        {isPremiumUser && (
+          <Text style={chatStyles.premiumBadge}>★ Premium</Text>
+        )}
+      </View>
       <View style={{ flex: 1 }}>
         <FlatList
           data={messages}
@@ -185,6 +200,11 @@ export default function ChatScreen({ route }) {
           onChangeText={setText}
           placeholderTextColor="#888"
         />
+        {isPremiumUser && (
+          <TouchableOpacity style={chatStyles.voiceButton} onPress={handleVoice}>
+            <Ionicons name="mic" size={20} color="#fff" />
+          </TouchableOpacity>
+        )}
         <TouchableOpacity style={chatStyles.sendButton} onPress={handleSend}>
           <Text style={{ color: '#fff', fontWeight: 'bold' }}>Send</Text>
         </TouchableOpacity>
@@ -329,6 +349,14 @@ const chatStyles = StyleSheet.create({
     fontSize: 15,
     color: '#333',
   },
+  messageRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  reactButton: {
+    marginLeft: 6,
+  },
   sender: {
     fontSize: 11,
     fontWeight: 'bold',
@@ -351,6 +379,12 @@ const chatStyles = StyleSheet.create({
     paddingVertical: 8,
     fontSize: 16,
     marginRight: 10,
+  },
+  voiceButton: {
+    backgroundColor: '#607d8b',
+    padding: 10,
+    borderRadius: 20,
+    marginRight: 6,
   },
   sendButton: {
     backgroundColor: '#ff4081',
@@ -412,5 +446,14 @@ const chatStyles = StyleSheet.create({
   gameOptionText: {
     fontSize: 16,
     color: '#333',
+  },
+  premiumBadge: {
+    marginLeft: 8,
+    color: '#fff',
+    backgroundColor: '#d81b60',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+    fontSize: 12,
   },
 });

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -438,6 +438,26 @@ const PlayScreen = ({ navigation }) => {
   const { devMode } = useDev();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const isPremiumUser = !!user?.isPremium;
+  if (!isPremiumUser && !devMode) {
+    return (
+      <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
+        <Header showLogoOnly />
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingTop: 80 }}>
+          <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>
+            {gamesLeft === 0
+              ? 'You reached today\'s free game limit.'
+              : `You have ${gamesLeft} free game${gamesLeft === 1 ? '' : 's'} left today.`}
+          </Text>
+          <TouchableOpacity
+            style={styles.emailBtn}
+            onPress={() => navigation.navigate('PremiumPaywall')}
+          >
+            <Text style={styles.btnText}>Unlock Premium</Text>
+          </TouchableOpacity>
+        </View>
+      </LinearGradient>
+    );
+  }
   const [filter, setFilter] = useState('All');
   const [category, setCategory] = useState('All');
   const [search, setSearch] = useState('');


### PR DESCRIPTION
## Summary
- replace mock chat arrays with Firestore-backed data
- migrate existing AsyncStorage chat data into Firestore
- add real-time listeners for matches and messages
- update chat helper functions to use Firestore
- show premium badge and extra chat options for premium users
- gate Play screen content for non-premium users

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f8853f78c832d8dfbf33183db3786