### PR TITLE
Add workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for installing dependencies, running tests and lint

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo-in-app-purchases)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb330f728832d8405c17ac8c36ab2