### PR TITLE
Connect user profiles to Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+      match /gameInvites/{inviteId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+    }
+  }
+}

--- a/screens/SignUpScreen.js
+++ b/screens/SignUpScreen.js
@@ -7,7 +7,8 @@ import {
   Alert,
 } from 'react-native';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
-import { auth } from '../firebase';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { auth, db } from '../firebase';
 import GradientBackground from '../components/GradientBackground';
 import GradientButton from '../components/GradientButton';
 import SafeKeyboardView from '../components/SafeKeyboardView';
@@ -23,8 +24,20 @@ export default function SignUpScreen({ navigation }) {
       return;
     }
     try {
-      const userCred = await createUserWithEmailAndPassword(auth, email.trim(), password);
+      const userCred = await createUserWithEmailAndPassword(
+        auth,
+        email.trim(),
+        password
+      );
       console.log('✅ Signed up:', userCred.user.uid);
+      await setDoc(doc(db, 'users', userCred.user.uid), {
+        uid: userCred.user.uid,
+        email: userCred.user.email,
+        displayName: userCred.user.displayName || '',
+        photoURL: userCred.user.photoURL || '',
+        onboardingComplete: false,
+        createdAt: serverTimestamp(),
+      });
       navigation.replace('Onboarding');
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## Summary
- create user document on sign up
- load players from Firestore on swipe screen
- load matches from Firestore on game invite screen
- add Firestore security rules

## Testing
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6850ce28c2ec832d89f0e5107eb6a2d1