### PR TITLE
Implement final onboarding profile update

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -104,7 +104,16 @@ export default function OnboardingScreen() {
         await setDoc(doc(db, 'users', auth.currentUser.uid), clean, {
           merge: true,
         });
-        updateUser(clean);
+        updateUser({
+          photoURL: answers.avatar,
+          age: parseInt(answers.age, 10) || null,
+          gender: answers.gender,
+          bio: answers.bio.trim(),
+          location: answers.location,
+          favoriteGame: answers.favoriteGame,
+          skillLevel: answers.skillLevel,
+          onboardingComplete: true,
+        });
         markOnboarded();
         Toast.show({ type: 'success', text1: 'Profile saved!' });
         navigation.replace('Main');


### PR DESCRIPTION
## Summary
- update onboarding handler to set user profile fields in context when finishing onboarding

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850f0ba6414832d892ca83cd9ff42e0