### PR TITLE
Refine dark mode styling

### DIFF
--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -5,8 +5,8 @@ import { useTheme } from '../contexts/ThemeContext';
 import styles from '../styles';
 
 export default function GradientBackground({ children }) {
-  const { darkMode } = useTheme();
-  const colors = darkMode ? ['#444', '#222'] : ['#FF75B5', '#FF9A75'];
+  const { theme } = useTheme();
+  const colors = [theme.gradientStart, theme.gradientEnd];
 
   return (
     <LinearGradient colors={colors} style={styles.container}>

--- a/components/Header.js
+++ b/components/Header.js
@@ -5,17 +5,17 @@ import { useTheme } from '../contexts/ThemeContext';
 
 const Header = () => {
   const navigation = useNavigation();
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
 
   const notificationCount = 5; // 🔥 Replace with dynamic logic later
 
   return (
-    <View style={[styles.container, { backgroundColor: darkMode ? '#222' : '#fff' }]}>
+    <View style={[styles.container, { backgroundColor: theme.headerBackground }]}>
       {/* Left icon - Gear */}
       <TouchableOpacity onPress={() => navigation.navigate('Settings')} style={styles.iconWrapper}>
         <Image
           source={require('../assets/gear.png')}
-          style={[styles.icon, { tintColor: darkMode ? '#fff' : '#000' }]}
+          style={[styles.icon, { tintColor: theme.text }]}
         />
       </TouchableOpacity>
 
@@ -30,7 +30,7 @@ const Header = () => {
         <View style={styles.bellWrapper}>
           <Image
             source={require('../assets/bell.png')}
-            style={[styles.icon, { tintColor: darkMode ? '#fff' : '#000' }]}
+            style={[styles.icon, { tintColor: theme.text }]}
           />
           {notificationCount > 0 && (
             <View style={styles.badge}>

--- a/contexts/ThemeContext.js
+++ b/contexts/ThemeContext.js
@@ -1,13 +1,15 @@
 import React, { createContext, useContext, useState } from 'react';
+import { lightTheme, darkTheme } from '../theme';
 
 const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
   const [darkMode, setDarkMode] = useState(false);
-  const toggleTheme = () => setDarkMode(prev => !prev);
+  const toggleTheme = () => setDarkMode((prev) => !prev);
+  const theme = darkMode ? darkTheme : lightTheme;
 
   return (
-    <ThemeContext.Provider value={{ darkMode, toggleTheme }}>
+    <ThemeContext.Provider value={{ darkMode, toggleTheme, theme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/navigation/MainTabs.js
+++ b/navigation/MainTabs.js
@@ -18,7 +18,7 @@ import SettingsScreen from '../screens/SettingsScreen';
 const Tab = createBottomTabNavigator();
 
 export default function MainTabs() {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
 
   return (
     <Tab.Navigator
@@ -28,7 +28,7 @@ export default function MainTabs() {
         tabBarInactiveTintColor: '#888',
         tabBarLabelStyle: { fontSize: 12, paddingBottom: 2 },
         tabBarStyle: {
-          backgroundColor: darkMode ? '#444' : '#fff',
+          backgroundColor: theme.card,
           borderTopWidth: 1,
           borderColor: '#eee',
           height: 60,

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -46,13 +46,13 @@ export default function ChatScreen({ route }) {
     acceptGameInvite,
     getPendingInvite,
   } = useChats();
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { showNotification } = useNotification();
   if (!user) {
     return (
-      <LinearGradient colors={[darkMode ? '#444' : '#fff', darkMode ? '#222' : '#ffe6f0']} style={{ flex: 1 }}>
+      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
         <Header />
-        <Text style={{ marginTop: 80, textAlign: 'center', color: darkMode ? '#fff' : '#000' }}>
+        <Text style={{ marginTop: 80, textAlign: 'center', color: theme.text }}>
           User not found.
         </Text>
       </LinearGradient>
@@ -274,7 +274,7 @@ export default function ChatScreen({ route }) {
     </View>
   ) : null;
 
-  const gradientColors = darkMode ? ['#444', '#222'] : ['#fff', '#fdeef4'];
+  const gradientColors = [theme.gradientStart, theme.gradientEnd];
 
   const toggleBar = (
     <View style={chatStyles.toggleBar}>

--- a/screens/EventChatScreen.js
+++ b/screens/EventChatScreen.js
@@ -16,7 +16,7 @@ const REACTIONS = ['🔥', '❤️', '😂'];
 
 const EventChatScreen = ({ route }) => {
   const { event } = route.params;
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
 
   const [messages, setMessages] = useState([
     { id: '1', user: 'Emily', text: 'Who’s playing tonight?', time: '9:01 PM', reactions: [], pinned: false },
@@ -112,7 +112,7 @@ const EventChatScreen = ({ route }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={{ flex: 1 }}
     >
       <Header />

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -34,7 +34,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   const rawGame = route?.params?.game;
   const gameTitle = typeof rawGame === 'string' ? rawGame : rawGame?.title || 'a game';
   const gameId = typeof rawGame === 'object' ? rawGame.id : null;
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { devMode } = useDev();
   const { user: currentUser } = useUser();
   const { sendGameInvite } = useMatchmaking();
@@ -100,7 +100,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     return (
       <View
         style={{
-          backgroundColor: darkMode ? '#444' : '#fff',
+          backgroundColor: theme.card,
           borderRadius: 16,
           borderWidth: 1,
           borderColor: darkMode ? '#333' : '#eee',
@@ -123,7 +123,7 @@ const GameInviteScreen = ({ route, navigation }) => {
               marginBottom: 8
             }}
           />
-          <Text style={{ fontSize: 15, fontWeight: '600', color: darkMode ? '#fff' : '#000' }}>
+          <Text style={{ fontSize: 15, fontWeight: '600', color: theme.text }}>
             {item.name}
           </Text>
           <Text style={{ fontSize: 12, color: item.online ? '#2ecc71' : '#999', marginBottom: 6 }}>
@@ -133,7 +133,7 @@ const GameInviteScreen = ({ route, navigation }) => {
           {isInvited && isLoading ? (
             <View style={{ alignItems: 'center', marginTop: 8 }}>
               <ActivityIndicator size="small" color="#d81b60" />
-              <Text style={{ color: darkMode ? '#ccc' : '#555', fontSize: 12, marginTop: 4 }}>
+              <Text style={{ color: theme.textSecondary, fontSize: 12, marginTop: 4 }}>
                 Waiting for {item.name}...
               </Text>
             </View>
@@ -158,7 +158,7 @@ const GameInviteScreen = ({ route, navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={styles.swipeScreen}
     >
       <Header showLogoOnly />
@@ -170,7 +170,7 @@ const GameInviteScreen = ({ route, navigation }) => {
               textAlign: 'center',
               marginTop: 36,
               marginBottom: 12,
-              color: darkMode ? '#fff' : '#000'
+              color: theme.text
             }}
           >
             Invite to play {gameTitle}
@@ -180,7 +180,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             style={{
               marginHorizontal: 16,
               marginBottom: 10,
-              backgroundColor: darkMode ? '#333' : '#fff',
+              backgroundColor: theme.card,
               borderRadius: 12,
               paddingHorizontal: 12,
               paddingVertical: 8
@@ -193,7 +193,7 @@ const GameInviteScreen = ({ route, navigation }) => {
               onChangeText={setSearch}
               style={{
                 fontSize: 14,
-                color: darkMode ? '#fff' : '#000',
+                color: theme.text,
                 paddingVertical: 4
               }}
             />

--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -22,7 +22,7 @@ import GameOverModal from '../components/GameOverModal';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 
 const GameLobbyScreen = ({ route, navigation }) => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { devMode } = useDev();
   const { recordGamePlayed } = useGameLimit();
   const { user, addGameXP } = useUser();
@@ -123,11 +123,11 @@ const GameLobbyScreen = ({ route, navigation }) => {
   if (!game || !opponent) {
     return (
       <LinearGradient
-        colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+        colors={[theme.gradientStart, theme.gradientEnd]}
         style={styles.swipeScreen}
       >
         <Header showLogoOnly />
-        <Text style={{ marginTop: 80, color: darkMode ? '#fff' : '#000' }}>
+        <Text style={{ marginTop: 80, color: theme.text }}>
           Invalid game data.
         </Text>
       </LinearGradient>
@@ -136,15 +136,15 @@ const GameLobbyScreen = ({ route, navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={styles.swipeScreen}
     >
       <Header showLogoOnly />
 
       {/* Game Info */}
       <View style={{ alignItems: 'center', marginTop: 70, marginBottom: 20 }}>
-        <MaterialCommunityIcons name="controller-classic" size={34} color={darkMode ? '#fff' : '#d81b60'} />
-        <Text style={{ fontSize: 20, fontWeight: '700', color: darkMode ? '#fff' : '#000' }}>
+        <MaterialCommunityIcons name="controller-classic" size={34} color={theme.text} />
+        <Text style={{ fontSize: 20, fontWeight: '700', color: theme.text }}>
           {game.title}
         </Text>
       </View>
@@ -157,7 +157,7 @@ const GameLobbyScreen = ({ route, navigation }) => {
             source={avatarSource(user?.photoURL)}
             style={{ width: 60, height: 60, borderRadius: 30, marginBottom: 6 }}
           />
-          <Text style={{ fontSize: 14, fontWeight: '600', color: darkMode ? '#fff' : '#222' }}>
+          <Text style={{ fontSize: 14, fontWeight: '600', color: theme.text }}>
             You
           </Text>
         </View>
@@ -170,14 +170,14 @@ const GameLobbyScreen = ({ route, navigation }) => {
             source={avatarSource(opponent?.photo)}
             style={{ width: 60, height: 60, borderRadius: 30, marginBottom: 6 }}
           />
-          <Text style={{ fontSize: 14, fontWeight: '600', color: darkMode ? '#fff' : '#222' }}>
+          <Text style={{ fontSize: 14, fontWeight: '600', color: theme.text }}>
             {opponent?.name || 'Unknown'}
           </Text>
         </View>
       </View>
 
       {/* Status Message */}
-      <Text style={{ textAlign: 'center', color: darkMode ? '#aaa' : '#666', marginBottom: 30 }}>
+      <Text style={{ textAlign: 'center', color: theme.textSecondary, marginBottom: 30 }}>
         {countdown !== null
           ? `Starting in ${countdown}...`
           : isReady

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -27,7 +27,7 @@ const GAMES = [
 
 
 const HomeScreen = ({ navigation }) => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { user } = useUser();
   const isPremiumUser = !!user?.isPremium;
   const { gamesLeft, recordGamePlayed } = useGameLimit();
@@ -35,7 +35,7 @@ const HomeScreen = ({ navigation }) => {
   const [playTarget, setPlayTarget] = useState('stranger');
 
   const card = (children, style = {}) => (
-    <View style={[local.card, { backgroundColor: darkMode ? '#444' : '#fff' }, style]}>
+    <View style={[local.card, { backgroundColor: theme.card }, style]}>
       {children}
     </View>
   );
@@ -65,7 +65,7 @@ const HomeScreen = ({ navigation }) => {
     }
   };
 
-  const gradientColors = darkMode ? ['#444', '#222'] : ['#FF75B5', '#FF9A75'];
+  const gradientColors = [theme.gradientStart, theme.gradientEnd];
 
   return (
     <LinearGradient colors={gradientColors} style={{ flex: 1 }}>

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -6,19 +6,22 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useChats } from '../contexts/ChatContext';
 
 const MatchesScreen = ({ navigation }) => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { matches } = useChats();
 
   const renderItem = ({ item }) => (
-    <TouchableOpacity style={styles.item} onPress={() => navigation.navigate('Chat', { user: item })}>
+    <TouchableOpacity
+      style={[styles.item, { backgroundColor: theme.card }]}
+      onPress={() => navigation.navigate('Chat', { user: item })}
+    >
       <Image source={item.image} style={styles.avatar} />
-      <Text style={styles.name}>{item.name}</Text>
+      <Text style={[styles.name, { color: theme.text }]}>{item.name}</Text>
     </TouchableOpacity>
   );
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <LinearGradient colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']} style={{ flex: 1 }}>
+      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
         <Header />
         <Text style={styles.title}>Your Matches</Text>
         <FlatList

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -20,7 +20,7 @@ import { games } from '../games';
 const NotificationsScreen = ({ navigation }) => {
   const { incomingInvites, acceptGameInvite, cancelGameInvite } = useMatchmaking();
   const { user } = useUser();
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const [loadingId, setLoadingId] = useState(null);
 
   const pendingInvites = incomingInvites.filter((i) => i.status === 'pending');
@@ -66,25 +66,25 @@ const NotificationsScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={styles.container}
     >
       <Header navigation={navigation} />
       <ScrollView contentContainerStyle={{ padding: 20, paddingBottom: 120 }}>
-        <Text style={[local.title, { color: darkMode ? '#fff' : '#000' }]}>Game Invites</Text>
+        <Text style={[local.title, { color: theme.text }]}>Game Invites</Text>
 
         {pendingInvites.length === 0 ? (
-          <Text style={[local.empty, { color: darkMode ? '#ccc' : '#888' }]}>No invites right now.</Text>
+          <Text style={[local.empty, { color: theme.textSecondary }]}>No invites right now.</Text>
         ) : (
           pendingInvites.map((inv) => (
             <View
               key={inv.id}
               style={[
                 local.card,
-                { backgroundColor: darkMode ? '#333' : '#fff' },
+                { backgroundColor: theme.card },
               ]}
             >
-              <Text style={[local.text, { color: darkMode ? '#fff' : '#444' }]}> 
+              <Text style={[local.text, { color: theme.text }]}> 
                 {inv.fromName ? `${inv.fromName} invited you to play ${games[inv.gameId]?.meta?.title || 'a game'}` : 'Game invite received'}
               </Text>
               <View style={local.actions}>
@@ -95,7 +95,7 @@ const NotificationsScreen = ({ navigation }) => {
                   <Text style={styles.btnText}>Accept</Text>
                 </TouchableOpacity>
                 <TouchableOpacity onPress={() => handleDecline(inv)}>
-                  <Text style={{ color: '#d81b60', fontSize: 13 }}>Decline</Text>
+                  <Text style={{ color: theme.accent, fontSize: 13 }}>Decline</Text>
                 </TouchableOpacity>
               </View>
             </View>

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -407,8 +407,8 @@ const getAllCategories = () => {
 };
 
 const PlayScreen = ({ navigation }) => {
-  const { darkMode } = useTheme();
-  const gradientColors = darkMode ? ['#444', '#222'] : ['#FF75B5', '#FF9A75'];
+  const { darkMode, theme } = useTheme();
+  const gradientColors = [theme.gradientStart, theme.gradientEnd];
   const { user } = useUser();
   const { devMode } = useDev();
   const { gamesLeft, recordGamePlayed } = useGameLimit();

--- a/screens/PremiumPaywallScreen.js
+++ b/screens/PremiumPaywallScreen.js
@@ -32,11 +32,11 @@ const features = [
 ];
 
 const PremiumPaywallScreen = ({ navigation }) => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={{ flex: 1 }}
     >
       <Header />

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -15,7 +15,7 @@ import styles from '../styles';
 import { useTheme } from '../contexts/ThemeContext';
 
 const PremiumScreen = () => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
 
   const features = [
     { icon: require('../assets/icons/unlimited.png'), text: 'Unlimited Game Invites' },
@@ -27,7 +27,7 @@ const PremiumScreen = () => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={{ flex: 1 }}
     >
       <Header />

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -10,7 +10,7 @@ import { signOut } from 'firebase/auth';
 import { auth } from '../firebase';
 
 const SettingsScreen = ({ navigation }) => {
-  const { darkMode, toggleTheme } = useTheme();
+  const { darkMode, toggleTheme, theme } = useTheme();
   const { user } = useUser();
   const isPremium = !!user?.isPremium;
   const { devMode, toggleDevMode } = useDev();
@@ -24,20 +24,20 @@ const SettingsScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#fce4ec']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={styles.container}
     >
       <Header />
 
-      <Text style={[styles.logoText, { color: darkMode ? '#fff' : '#d81b60', marginBottom: 10 }]}>
+      <Text style={[styles.logoText, { color: theme.text, marginBottom: 10 }]}>
         Settings
       </Text>
 
       <View style={{ marginBottom: 20 }}>
-        <Text style={[styles.settingText, { color: darkMode ? '#ccc' : '#666' }]}> 
+        <Text style={[styles.settingText, { color: theme.textSecondary }]}>
           Account: {user?.email || 'Unknown'}
         </Text>
-        <Text style={[styles.settingText, { color: darkMode ? '#aaa' : '#999' }]}>
+        <Text style={[styles.settingText, { color: theme.textSecondary }]}>
           Status: {isPremium ? '🌟 Premium Member' : 'Free Member'}
         </Text>
       </View>

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -21,8 +21,8 @@ const useFadeIn = (duration = 1000) => {
 
 export default function SplashScreen({ onFinish }) {
   const fadeAnim = useFadeIn();
-  const { darkMode } = useTheme();
-  const colors = darkMode ? ['#444', '#222'] : ['#FF75B5', '#FF9A75'];
+  const { darkMode, theme } = useTheme();
+  const colors = [theme.gradientStart, theme.gradientEnd];
 
   useEffect(() => {
     const timeout = setTimeout(onFinish, splashDuration);

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -9,7 +9,7 @@ import { useUser } from '../contexts/UserContext';
 import { avatarSource } from '../utils/avatar';
 
 const StatsScreen = ({ navigation }) => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { user } = useUser();
   const isPremium = !!user?.isPremium;
 
@@ -27,7 +27,7 @@ const StatsScreen = ({ navigation }) => {
 
   return (
     <LinearGradient
-      colors={darkMode ? ['#444', '#222'] : ['#fff', '#ffe6f0']}
+      colors={[theme.gradientStart, theme.gradientEnd]}
       style={{ flex: 1 }}
     >
       <Header showLogoOnly />

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -41,7 +41,7 @@ const MAX_LIKES = 100;
 
 
 const SwipeScreen = () => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const navigation = useNavigation();
   const { showNotification } = useNotification();
   const { user: currentUser } = useUser();
@@ -252,7 +252,7 @@ const SwipeScreen = () => {
     navigation.navigate('GameInvite', { user: displayUser });
   };
 
-  const gradientColors = darkMode ? ['#333', '#222'] : ['#FF75B5', '#FF9A75'];
+  const gradientColors = [theme.gradientStart, theme.gradientEnd];
 
   return (
     <LinearGradient colors={gradientColors} style={{ flex: 1 }}>

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,22 @@
+export const lightTheme = {
+  background: '#ffffff',
+  card: '#ffffff',
+  text: '#222222',
+  textSecondary: '#666666',
+  accent: '#d81b60',
+  gradientStart: '#FF75B5',
+  gradientEnd: '#FF9A75',
+  headerBackground: '#ffffff',
+};
+
+export const darkTheme = {
+  background: '#121212',
+  card: '#1E1E1E',
+  text: '#E0E0E0',
+  textSecondary: '#AAAAAA',
+  accent: '#BB86FC',
+  gradientStart: '#2a2a2a',
+  gradientEnd: '#000000',
+  headerBackground: '#1E1E1E',
+};
+


### PR DESCRIPTION
## Summary
- define a `theme` with light and dark colors
- expose theme via `ThemeContext`
- update components and screens to use the new theme colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850f8a28d94832db4605d119f60fa27