### PR TITLE
Add reusable AuthContext

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { NotificationProvider } from './contexts/NotificationContext';
 import { UserProvider } from './contexts/UserContext';
+import { AuthProvider } from './contexts/AuthContext';
 import { OnboardingProvider } from './contexts/OnboardingContext';
 import { ChatProvider } from './contexts/ChatContext';
 import { MatchmakingProvider } from './contexts/MatchmakingContext';
@@ -20,11 +21,12 @@ export default function App() {
     <DevProvider>
       <ThemeProvider>
         <NotificationProvider>
-          <OnboardingProvider>
-            <UserProvider>
-              <GameLimitProvider>
-                <ChatProvider>
-                  <MatchmakingProvider>
+          <AuthProvider>
+            <OnboardingProvider>
+              <UserProvider>
+                <GameLimitProvider>
+                  <ChatProvider>
+                    <MatchmakingProvider>
                     <NavigationContainer>
                       <RootNavigator />
                       <DevBanner />
@@ -36,6 +38,7 @@ export default function App() {
               </GameLimitProvider>
             </UserProvider>
           </OnboardingProvider>
+        </AuthProvider>
         </NotificationProvider>
       </ThemeProvider>
     </DevProvider>

--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -1,0 +1,115 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signInWithCredential,
+  GoogleAuthProvider,
+  signOut,
+  onAuthStateChanged,
+} from 'firebase/auth';
+import {
+  doc,
+  getDoc,
+  setDoc,
+  serverTimestamp,
+} from 'firebase/firestore';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { auth, db } from '../firebase';
+
+WebBrowser.maybeCompleteAuthSession();
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
+    clientId: process.env.EXPO_PUBLIC_FIREBASE_WEB_CLIENT_ID,
+  });
+
+  const ensureUserDoc = async (fbUser) => {
+    try {
+      const ref = doc(db, 'users', fbUser.uid);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        await setDoc(ref, {
+          uid: fbUser.uid,
+          email: fbUser.email,
+          displayName: fbUser.displayName || '',
+          photoURL: fbUser.photoURL || '',
+          onboardingComplete: false,
+          createdAt: serverTimestamp(),
+        });
+      }
+    } catch (e) {
+      console.warn('Failed to ensure user doc', e);
+    }
+  };
+
+  const loginWithEmail = async (email, password) => {
+    const userCred = await signInWithEmailAndPassword(
+      auth,
+      email.trim(),
+      password,
+    );
+    await ensureUserDoc(userCred.user);
+  };
+
+  const signUpWithEmail = async (email, password) => {
+    const userCred = await createUserWithEmailAndPassword(
+      auth,
+      email.trim(),
+      password,
+    );
+    await setDoc(doc(db, 'users', userCred.user.uid), {
+      uid: userCred.user.uid,
+      email: userCred.user.email,
+      displayName: userCred.user.displayName || '',
+      photoURL: userCred.user.photoURL || '',
+      onboardingComplete: false,
+      createdAt: serverTimestamp(),
+    });
+  };
+
+  const loginWithGoogle = () => promptAsync({ prompt: 'select_account' });
+
+  const logout = () => signOut(auth);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (fbUser) => {
+      setUser(fbUser);
+      if (fbUser) await ensureUserDoc(fbUser);
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.params;
+      const credential = GoogleAuthProvider.credential(id_token);
+      signInWithCredential(auth, credential)
+        .then((res) => ensureUserDoc(res.user))
+        .catch((err) => console.warn('Google login failed', err));
+    }
+  }, [response]);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        loading,
+        loginWithEmail,
+        signUpWithEmail,
+        loginWithGoogle,
+        logout,
+        request,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);


### PR DESCRIPTION
## Summary
- create `AuthContext` for email/password and Google authentication
- inject new `AuthProvider` in `App`
- track firebase user and loading state in `AuthContext`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68520701a4dc832dac7500a765b13af3