### PR TITLE
Refactor App.js provider order

### DIFF
--- a/App.js
+++ b/App.js
@@ -19,28 +19,28 @@ export default function App() {
   usePushNotifications();
   return (
     <DevProvider>
-      <ThemeProvider>
-        <NotificationProvider>
-          <AuthProvider>
+      <AuthProvider>
+        <ThemeProvider>
+          <NotificationProvider>
             <OnboardingProvider>
               <UserProvider>
                 <GameLimitProvider>
                   <ChatProvider>
                     <MatchmakingProvider>
-                    <NavigationContainer>
-                      <RootNavigator />
-                      <DevBanner />
-                    </NavigationContainer>
-                    <NotificationCenter />
-                    <Toast />
-                  </MatchmakingProvider>
-                </ChatProvider>
-              </GameLimitProvider>
-            </UserProvider>
-          </OnboardingProvider>
-        </AuthProvider>
-        </NotificationProvider>
-      </ThemeProvider>
+                      <NavigationContainer>
+                        <RootNavigator />
+                        <DevBanner />
+                      </NavigationContainer>
+                      <NotificationCenter />
+                      <Toast />
+                    </MatchmakingProvider>
+                  </ChatProvider>
+                </GameLimitProvider>
+              </UserProvider>
+            </OnboardingProvider>
+          </NotificationProvider>
+        </ThemeProvider>
+      </AuthProvider>
     </DevProvider>
   );
 }


### PR DESCRIPTION
## Summary
- reorganize context providers so `AuthProvider` wraps the rest of the app

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685209e9ac7c832d8f7f36bbee27e04b