### PR TITLE
Extend Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,5 +29,19 @@ service cloud.firestore {
       allow read, write: if request.auth != null &&
         request.auth.uid in resource.data.participants;
     }
+
+    match /matches/{matchId} {
+      allow read, write: if request.auth != null &&
+        (request.auth.uid in resource.data.users ||
+         request.auth.uid in request.resource.data.users);
+      match /messages/{messageId} {
+        allow read, write: if request.auth != null &&
+          request.auth.uid in get(/databases/$(database)/documents/matches/$(matchId)).data.users;
+      }
+    }
+
+    match /events/{eventId} {
+      allow read, write: if request.auth != null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add rules for `events` collection
- secure `matches` and nested `messages` collections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68521bfd1ab4832d911fdf2b4ff8132c