### PR TITLE
Use env URLs for Stripe checkout

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -21,8 +21,8 @@ exports.createCheckoutSession = functions.https.onCall(async (data, context) => 
         { price: process.env.STRIPE_PRICE_ID, quantity: 1 }
       ],
       metadata: { uid },
-      success_url: data.successUrl || 'https://example.com/success',
-      cancel_url: data.cancelUrl || 'https://example.com/cancel'
+      success_url: data.successUrl || process.env.SUCCESS_URL,
+      cancel_url: data.cancelUrl || process.env.CANCEL_URL
     });
     return { url: session.url };
   } catch (err) {

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -24,8 +24,8 @@ const PremiumScreen = () => {
     try {
       const createSession = httpsCallable(functions, 'createCheckoutSession');
       const result = await createSession({
-        successUrl: 'https://example.com/success',
-        cancelUrl: 'https://example.com/cancel'
+        successUrl: process.env.SUCCESS_URL,
+        cancelUrl: process.env.CANCEL_URL
       });
       const { url } = result.data || {};
       if (url) {


### PR DESCRIPTION
## Summary
- swap hard-coded example.com URLs with `process.env.SUCCESS_URL` and `process.env.CANCEL_URL`

## Testing
- `npm test` *(fails: Missing script)*
- `cd functions && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68529ed9def4832dbeae343c90b1db3a