### PR TITLE
Remove unused Firebase messaging code

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -3,7 +3,6 @@ import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
-import { getMessaging, onMessage } from 'firebase/messaging';
 import { getFunctions } from 'firebase/functions';
 
 const firebaseConfig = {
@@ -19,12 +18,7 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 const storage = getStorage(app);
-const messaging = getMessaging(app);
 const functions = getFunctions(app);
 
-// Listen for foreground messages
-onMessage(messaging, (payload) => {
-  console.log('FCM Message:', payload);
-});
 
-export { auth, db, storage, messaging, functions };
+export { auth, db, storage, functions };


### PR DESCRIPTION
## Summary
- clean up `firebase.js` by removing Firebase messaging imports and initialization

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2db2db4832db96f27c10598cf31