### PR TITLE
Add helper to upload avatars

### DIFF
--- a/utils/upload.js
+++ b/utils/upload.js
@@ -1,0 +1,18 @@
+import { storage } from '../firebase';
+import { ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
+
+export async function uploadAvatarAsync(uri, uid) {
+  if (!uri || !uid) throw new Error('uri and uid required');
+
+  const response = await fetch(uri);
+  const blob = await response.blob();
+
+  const avatarRef = ref(storage, `avatars/${uid}.jpg`);
+  const uploadTask = uploadBytesResumable(avatarRef, blob);
+
+  await new Promise((resolve, reject) => {
+    uploadTask.on('state_changed', null, reject, resolve);
+  });
+
+  return getDownloadURL(avatarRef);
+}


### PR DESCRIPTION
## Summary
- create `uploadAvatarAsync` helper

## Testing
- `npm run lint` *(fails: Missing script 'lint')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6854f5903850832dad9678db8af3542b