### PR TITLE
Use upload helper when finishing onboarding

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -12,8 +12,8 @@ import { useNavigation } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import { doc, setDoc, getDoc } from 'firebase/firestore';
-import { db, auth, storage } from '../firebase';
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, auth } from '../firebase';
+import { uploadAvatarAsync } from '../utils/upload';
 import { useUser } from '../contexts/UserContext';
 import { useOnboarding } from '../contexts/OnboardingContext';
 import * as ImagePicker from 'expo-image-picker';
@@ -90,11 +90,10 @@ export default function OnboardingScreen() {
       try {
         let photoURL = answers.avatar;
         if (answers.avatar && !answers.avatar.startsWith('http')) {
-          const response = await fetch(answers.avatar);
-          const blob = await response.blob();
-          const avatarRef = ref(storage, `avatars/${auth.currentUser.uid}.jpg`);
-          await uploadBytes(avatarRef, blob);
-          photoURL = await getDownloadURL(avatarRef);
+          photoURL = await uploadAvatarAsync(
+            answers.avatar,
+            auth.currentUser.uid
+          );
         }
 
         const clean = {


### PR DESCRIPTION
## Summary
- import `uploadAvatarAsync`
- call helper to upload avatar while completing onboarding

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6854fe7cce88832d89df2d546513c7a5