### PR TITLE
Add storage.rules for avatar uploads

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,5 +5,8 @@
   },
   "functions": {
     "source": "functions"
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /avatars/{userId}/{allPaths=**} {
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add storage.rules to restrict avatar uploads
- configure firebase.json to use storage rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685502fd6808832d8700fd865a682cd7