### PR TITLE
Add Stripe webhook handler

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -54,3 +54,32 @@ exports.stripeWebhook = functions.https.onRequest((req, res) => {
 
   res.status(200).send('ok');
 });
+
+exports.handleStripeWebhook = functions.https.onRequest(async (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    console.error('Webhook signature verification failed', err);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    const uid = session.metadata && session.metadata.uid;
+    if (uid) {
+      try {
+        await admin.firestore().collection('users').doc(uid).update({
+          isPremium: true,
+          premiumUpdatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      } catch (e) {
+        console.error('Failed to update premium status', e);
+        return res.status(500).send('Failed to update user');
+      }
+    }
+  }
+
+  res.status(200).send('ok');
+});


### PR DESCRIPTION
## Summary
- add Firebase Cloud Function `handleStripeWebhook`

## Testing
- `npm test` *(fails: missing script)*
- `cd functions && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855e1e8a438832da784c1ea047cea5a