### PR TITLE
Add Cloud Function for push notifications

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,6 +7,7 @@
     "firebase-functions": "^4.4.1",
     "express": "^4.18.2",
     "stripe": "^12.18.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "node-fetch": "^2.6.7"
   }
 }


### PR DESCRIPTION
## Summary
- support sending push notifications via Expo tokens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855e414a2ec832d866def307c6217a8