### PR TITLE
Fix avatar upload path for onboarding

### DIFF
--- a/utils/upload.js
+++ b/utils/upload.js
@@ -6,7 +6,8 @@ export async function uploadAvatarAsync(uri, uid) {
   const response = await fetch(uri);
   const blob = await response.blob();
 
-  const avatarRef = storage.ref().child(`avatars/${uid}.jpg`);
+  // Store avatar inside a user specific folder so it matches storage.rules
+  const avatarRef = storage.ref().child(`avatars/${uid}/avatar.jpg`);
   const uploadTask = avatarRef.put(blob);
 
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- ensure avatar uploads save to a user folder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a46ebb168832db5ac0f1e451534a2