### PR TITLE
Add Mancala and Blackjack games

### DIFF
--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Client } from 'boardgame.io/react-native';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+function handValue(hand) {
+  return hand.reduce((a, b) => a + b, 0);
+}
+
+const BlackjackGame = {
+  setup: () => ({ hands: [[], []], states: [0, 0] }), // 0 playing, 1 stand, 2 bust
+  turn: { moveLimit: 1 },
+  moves: {
+    hit: ({ G, ctx }) => {
+      const p = Number(ctx.currentPlayer);
+      if (G.states[p] !== 0) return INVALID_MOVE;
+      const card = ctx.random.D10();
+      G.hands[p].push(card);
+      if (handValue(G.hands[p]) > 21) {
+        G.states[p] = 2;
+        ctx.events.endTurn();
+      }
+    },
+    stand: ({ G, ctx }) => {
+      const p = Number(ctx.currentPlayer);
+      if (G.states[p] !== 0) return INVALID_MOVE;
+      G.states[p] = 1;
+      ctx.events.endTurn();
+    },
+  },
+  endIf: ({ G }) => {
+    if (G.states.every(s => s !== 0)) {
+      const v0 = handValue(G.hands[0]);
+      const v1 = handValue(G.hands[1]);
+      const bust0 = v0 > 21;
+      const bust1 = v1 > 21;
+      if (bust0 && bust1) return { draw: true };
+      if (bust0) return { winner: '1' };
+      if (bust1) return { winner: '0' };
+      if (v0 > v1) return { winner: '0' };
+      if (v1 > v0) return { winner: '1' };
+      return { draw: true };
+    }
+  },
+};
+
+const Card = ({ value }) => (
+  <View style={{ width: 30, height: 40, margin: 2, borderWidth: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <Text>{value}</Text>
+  </View>
+);
+
+const Controls = ({ onHit, onStand, disabled }) => (
+  <View style={{ flexDirection: 'row', marginVertical: 6 }}>
+    <TouchableOpacity onPress={onHit} disabled={disabled} style={{ padding: 6, backgroundColor: '#ddd', marginRight: 8 }}>
+      <Text>Hit</Text>
+    </TouchableOpacity>
+    <TouchableOpacity onPress={onStand} disabled={disabled} style={{ padding: 6, backgroundColor: '#ddd' }}>
+      <Text>Stand</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const BlackjackBoard = ({ G, ctx, moves }) => {
+  const renderHand = (hand) => (
+    <View style={{ flexDirection: 'row' }}>{hand.map((c, i) => <Card key={i} value={c} />)}</View>
+  );
+
+  const status = ctx.gameover
+    ? ctx.gameover.draw
+      ? 'Draw game'
+      : ctx.gameover.winner === '0'
+      ? 'Player A wins!'
+      : 'Player B wins!'
+    : ctx.currentPlayer === '0'
+    ? 'Player A turn'
+    : 'Player B turn';
+
+  const disableHitStand = (player) => G.states[player] !== 0 || ctx.currentPlayer !== String(player) || ctx.gameover;
+
+  return (
+    <View style={{ alignItems: 'center', padding: 10 }}>
+      <Text style={{ marginBottom: 10 }}>{status}</Text>
+      <Text>Player A: {handValue(G.hands[0])}</Text>
+      {renderHand(G.hands[0])}
+      <Controls onHit={() => moves.hit()} onStand={() => moves.stand()} disabled={disableHitStand(0)} />
+      <Text style={{ marginTop: 10 }}>Player B: {handValue(G.hands[1])}</Text>
+      {renderHand(G.hands[1])}
+      <Controls onHit={() => moves.hit()} onStand={() => moves.stand()} disabled={disableHitStand(1)} />
+    </View>
+  );
+};
+
+const BlackjackClient = Client({ game: BlackjackGame, board: BlackjackBoard });
+
+export const Game = BlackjackGame;
+export const Board = BlackjackBoard;
+export const meta = { id: 'blackjack', title: 'Blackjack' };
+
+export default BlackjackClient;

--- a/games/dots-and-boxes.js
+++ b/games/dots-and-boxes.js
@@ -1,0 +1,160 @@
+import React from 'react';
+import { Client } from 'boardgame.io/react-native';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+const SIZE = 2; // 2x2 boxes
+
+function indexH(row, col) {
+  return row * SIZE + col;
+}
+function indexV(row, col) {
+  return row * (SIZE + 1) + col;
+}
+
+const DotsBoxesGame = {
+  setup: () => ({
+    h: Array((SIZE + 1) * SIZE).fill(false),
+    v: Array(SIZE * (SIZE + 1)).fill(false),
+    boxes: Array(SIZE * SIZE).fill(null),
+  }),
+  moves: {
+    drawH: ({ G, ctx }, row, col) => {
+      const i = indexH(row, col);
+      if (G.h[i]) return INVALID_MOVE;
+      G.h[i] = ctx.currentPlayer;
+      let scored = false;
+      if (row > 0) {
+        const box = indexH(row - 1, col);
+      }
+      for (let r = 0; r < SIZE; r++) {
+        for (let c = 0; c < SIZE; c++) {
+          const top = indexH(r, c);
+          const bottom = indexH(r + 1, c);
+          const left = indexV(r, c);
+          const right = indexV(r, c + 1);
+          if (
+            G.h[top] &&
+            G.h[bottom] &&
+            G.v[left] &&
+            G.v[right] &&
+            !G.boxes[r * SIZE + c]
+          ) {
+            G.boxes[r * SIZE + c] = ctx.currentPlayer;
+            scored = true;
+          }
+        }
+      }
+      if (!scored) ctx.events.endTurn();
+    },
+    drawV: ({ G, ctx }, row, col) => {
+      const i = indexV(row, col);
+      if (G.v[i]) return INVALID_MOVE;
+      G.v[i] = ctx.currentPlayer;
+      let scored = false;
+      for (let r = 0; r < SIZE; r++) {
+        for (let c = 0; c < SIZE; c++) {
+          const top = indexH(r, c);
+          const bottom = indexH(r + 1, c);
+          const left = indexV(r, c);
+          const right = indexV(r, c + 1);
+          if (
+            G.h[top] &&
+            G.h[bottom] &&
+            G.v[left] &&
+            G.v[right] &&
+            !G.boxes[r * SIZE + c]
+          ) {
+            G.boxes[r * SIZE + c] = ctx.currentPlayer;
+            scored = true;
+          }
+        }
+      }
+      if (!scored) ctx.events.endTurn();
+    },
+  },
+  endIf: ({ G }) => {
+    if (G.boxes.every(b => b !== null)) {
+      const p0 = G.boxes.filter(b => b === '0').length;
+      const p1 = G.boxes.filter(b => b === '1').length;
+      if (p0 > p1) return { winner: '0' };
+      if (p1 > p0) return { winner: '1' };
+      return { draw: true };
+    }
+  },
+};
+
+const DotsBoxesBoard = ({ G, ctx, moves }) => {
+  const rows = [];
+  for (let r = 0; r <= SIZE; r++) {
+    const cells = [];
+    for (let c = 0; c < SIZE; c++) {
+      const hIndex = indexH(r, c);
+      const active = G.h[hIndex];
+      cells.push(
+        <TouchableOpacity
+          key={'h' + r + '-' + c}
+          onPress={() => moves.drawH(r, c)}
+          style={{ width: 40, height: 10, backgroundColor: active ? 'black' : 'lightgray' }}
+        />
+      );
+      if (c < SIZE) {
+        const boxOwner = r < SIZE ? G.boxes[r * SIZE + c] : null;
+        cells.push(
+          <View key={'box' + r + '-' + c} style={{ width: 10, height: 10 }}>
+            {boxOwner && <Text>{boxOwner === '0' ? 'A' : 'B'}</Text>}
+          </View>
+        );
+      }
+    }
+    rows.push(
+      <View key={'hr' + r} style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <View style={{ width: 10, height: 10, backgroundColor: 'black' }} />
+        {cells}
+      </View>
+    );
+    if (r < SIZE) {
+      const vRow = [];
+      for (let c = 0; c <= SIZE; c++) {
+        const vIndex = indexV(r, c);
+        const active = G.v[vIndex];
+        vRow.push(
+          <TouchableOpacity
+            key={'v' + r + '-' + c}
+            onPress={() => moves.drawV(r, c)}
+            style={{ width: 10, height: 40, backgroundColor: active ? 'black' : 'lightgray' }}
+          />
+        );
+        if (c < SIZE) {
+          vRow.push(<View key={'sp' + r + '-' + c} style={{ width: 40, height: 40 }} />);
+        }
+      }
+      rows.push(<View key={'vr' + r} style={{ flexDirection: 'row' }}>{vRow}</View>);
+    }
+  }
+
+  const status = ctx.gameover
+    ? ctx.gameover.draw
+      ? 'Draw game'
+      : ctx.gameover.winner === '0'
+      ? 'Player A wins!'
+      : 'Player B wins!'
+    : ctx.currentPlayer === '0'
+    ? 'Player A turn'
+    : 'Player B turn';
+
+  return (
+    <View style={{ padding: 10, alignItems: 'center' }}>
+      <Text style={{ marginBottom: 10 }}>{status}</Text>
+      {rows}
+    </View>
+  );
+};
+
+const DotsBoxesClient = Client({ game: DotsBoxesGame, board: DotsBoxesBoard });
+
+export const Game = DotsBoxesGame;
+export const Board = DotsBoxesBoard;
+export const meta = { id: 'dotsAndBoxes', title: 'Dots and Boxes' };
+
+export default DotsBoxesClient;

--- a/games/index.js
+++ b/games/index.js
@@ -10,6 +10,10 @@ import GuessNumberClient, { Game as guessNumberGame, Board as GuessNumberBoard, 
 import BattleshipClient, { Game as battleshipGame, Board as BattleshipBoard, meta as battleshipMeta } from './battleship';
 import CheckersClient, { Game as checkersGame, Board as CheckersBoard, meta as checkersMeta } from './checkers';
 import DominoesClient, { Game as dominoesGame, Board as DominoesBoard, meta as dominoesMeta } from './dominoes';
+import DotsBoxesClient, { Game as dotsBoxesGame, Board as DotsBoxesBoard, meta as dotsBoxesMeta } from './dots-and-boxes';
+import SnakesLaddersClient, { Game as snakesLaddersGame, Board as SnakesLaddersBoard, meta as snakesLaddersMeta } from './snakes-and-ladders';
+import MancalaClient, { Game as mancalaGame, Board as MancalaBoard, meta as mancalaMeta } from './mancala';
+import BlackjackClient, { Game as blackjackGame, Board as BlackjackBoard, meta as blackjackMeta } from './blackjack';
 
 export const games = {
   [ticTacToeMeta.id]: {
@@ -63,6 +67,30 @@ export const games = {
     Game: battleshipGame,
     Board: BattleshipBoard,
     meta: battleshipMeta,
+  },
+  [dotsBoxesMeta.id]: {
+    Client: DotsBoxesClient,
+    Game: dotsBoxesGame,
+    Board: DotsBoxesBoard,
+    meta: dotsBoxesMeta,
+  },
+  [snakesLaddersMeta.id]: {
+    Client: SnakesLaddersClient,
+    Game: snakesLaddersGame,
+    Board: SnakesLaddersBoard,
+    meta: snakesLaddersMeta,
+  },
+  [mancalaMeta.id]: {
+    Client: MancalaClient,
+    Game: mancalaGame,
+    Board: MancalaBoard,
+    meta: mancalaMeta,
+  },
+  [blackjackMeta.id]: {
+    Client: BlackjackClient,
+    Game: blackjackGame,
+    Board: BlackjackBoard,
+    meta: blackjackMeta,
   },
 };
 

--- a/games/mancala.js
+++ b/games/mancala.js
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Client } from 'boardgame.io/react-native';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+const PITS = 6;
+const START_STONES = 4;
+
+function initBoard() {
+  const pits = Array(PITS * 2).fill(START_STONES);
+  const stores = [0, 0];
+  return { pits, stores };
+}
+
+function opposite(index) {
+  return PITS * 2 - 1 - index;
+}
+
+const MancalaGame = {
+  setup: () => initBoard(),
+  turn: { moveLimit: 1 },
+  moves: {
+    sow: ({ G, ctx }, index) => {
+      const player = Number(ctx.currentPlayer);
+      const start = player === 0 ? 0 : PITS;
+      const end = start + PITS - 1;
+      if (index < start || index > end) return INVALID_MOVE;
+      let stones = G.pits[index];
+      if (stones === 0) return INVALID_MOVE;
+      G.pits[index] = 0;
+      let i = index;
+      while (stones > 0) {
+        i = (i + 1) % (PITS * 2 + 2);
+        if (i === (player === 0 ? PITS * 2 + 1 : PITS)) continue; // skip opponent store
+        if (i === PITS * 2) {
+          G.stores[0] += 1;
+        } else if (i === PITS * 2 + 1) {
+          G.stores[1] += 1;
+        } else {
+          G.pits[i % (PITS * 2)] += 1;
+        }
+        stones--;
+      }
+      const lastPit = i;
+      const lastIndex = lastPit % (PITS * 2);
+      if (
+        lastPit !== PITS * 2 &&
+        lastPit !== PITS * 2 + 1 &&
+        ((player === 0 && lastIndex < PITS) || (player === 1 && lastIndex >= PITS)) &&
+        G.pits[lastIndex] === 1 &&
+        G.pits[opposite(lastIndex)] > 0
+      ) {
+        const captured = G.pits[opposite(lastIndex)] + 1;
+        G.pits[opposite(lastIndex)] = 0;
+        G.pits[lastIndex] = 0;
+        G.stores[player] += captured;
+      }
+      if (lastPit !== (player === 0 ? PITS * 2 : PITS * 2 + 1)) {
+        ctx.events.endTurn();
+      }
+    },
+  },
+  endIf: ({ G }) => {
+    const p0Empty = G.pits.slice(0, PITS).every(p => p === 0);
+    const p1Empty = G.pits.slice(PITS).every(p => p === 0);
+    if (p0Empty || p1Empty) {
+      const remaining0 = G.pits.slice(0, PITS).reduce((a, b) => a + b, 0);
+      const remaining1 = G.pits.slice(PITS).reduce((a, b) => a + b, 0);
+      G.stores[0] += remaining0;
+      G.stores[1] += remaining1;
+      G.pits.fill(0);
+      if (G.stores[0] > G.stores[1]) return { winner: '0' };
+      if (G.stores[1] > G.stores[0]) return { winner: '1' };
+      return { draw: true };
+    }
+  },
+};
+
+const Pit = ({ stones, onPress, disabled }) => (
+  <TouchableOpacity
+    onPress={onPress}
+    disabled={disabled}
+    style={{ width: 40, height: 40, margin: 2, borderWidth: 1, alignItems: 'center', justifyContent: 'center' }}
+  >
+    <Text>{stones}</Text>
+  </TouchableOpacity>
+);
+
+const MancalaBoard = ({ G, ctx, moves }) => {
+  const disabled = !!ctx.gameover;
+  const player = Number(ctx.currentPlayer);
+  const pits0 = G.pits.slice(0, PITS);
+  const pits1 = G.pits.slice(PITS).slice().reverse();
+  return (
+    <View style={{ alignItems: 'center', padding: 10 }}>
+      <Text style={{ marginBottom: 10 }}>
+        {ctx.gameover
+          ? ctx.gameover.draw
+            ? 'Draw game'
+            : ctx.gameover.winner === '0'
+            ? 'Player A wins!'
+            : 'Player B wins!'
+          : ctx.currentPlayer === '0'
+          ? 'Player A turn'
+          : 'Player B turn'}
+      </Text>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Text style={{ width: 40, textAlign: 'center' }}>{G.stores[1]}</Text>
+        <View>
+          <View style={{ flexDirection: 'row' }}>
+            {pits1.map((s, idx) => (
+              <Pit
+                key={idx}
+                stones={s}
+                onPress={() => moves.sow(PITS + (PITS - 1 - idx))}
+                disabled={disabled || player !== 1}
+              />
+            ))}
+          </View>
+          <View style={{ flexDirection: 'row' }}>
+            {pits0.map((s, idx) => (
+              <Pit
+                key={idx}
+                stones={s}
+                onPress={() => moves.sow(idx)}
+                disabled={disabled || player !== 0}
+              />
+            ))}
+          </View>
+        </View>
+        <Text style={{ width: 40, textAlign: 'center' }}>{G.stores[0]}</Text>
+      </View>
+    </View>
+  );
+};
+
+const MancalaClient = Client({ game: MancalaGame, board: MancalaBoard });
+
+export const Game = MancalaGame;
+export const Board = MancalaBoard;
+export const meta = { id: 'mancala', title: 'Mancala' };
+
+export default MancalaClient;

--- a/games/snakes-and-ladders.js
+++ b/games/snakes-and-ladders.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Client } from 'boardgame.io/react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+const snakes = { 16: 6, 47: 26, 49: 11, 56: 53, 62: 19, 64: 60, 87: 24, 93: 73, 95: 75, 98: 78 };
+const ladders = { 1: 38, 4: 14, 9: 31, 21: 42, 28: 84, 36: 44, 51: 67, 71: 91, 80: 100 };
+
+const SnakesLaddersGame = {
+  setup: () => ({ positions: [1, 1], lastRoll: null }),
+  turn: { moveLimit: 1 },
+  moves: {
+    roll: ({ G, ctx }) => {
+      const roll = ctx.random.D6();
+      G.lastRoll = roll;
+      let pos = G.positions[ctx.currentPlayer] + roll;
+      if (pos > 100) pos = 100;
+      if (snakes[pos]) pos = snakes[pos];
+      if (ladders[pos]) pos = ladders[pos];
+      G.positions[ctx.currentPlayer] = pos;
+    },
+  },
+  endIf: ({ G }) => {
+    if (G.positions.some(p => p >= 100)) {
+      const winner = G.positions[0] >= 100 ? '0' : '1';
+      return { winner };
+    }
+  },
+};
+
+const cellStyle = { width: 30, height: 30, borderWidth: 1, alignItems: 'center', justifyContent: 'center' };
+
+const SnakesLaddersBoard = ({ G, ctx, moves }) => {
+  const rows = [];
+  for (let r = 9; r >= 0; r--) {
+    const cells = [];
+    for (let c = 0; c < 10; c++) {
+      const num = r % 2 === 0 ? r * 10 + c + 1 : r * 10 + (9 - c) + 1;
+      const tokens = [];
+      if (G.positions[0] === num) tokens.push('A');
+      if (G.positions[1] === num) tokens.push('B');
+      cells.push(
+        <View key={num} style={cellStyle}>
+          <Text>{num}</Text>
+          {tokens.map(t => (
+            <Text key={t} style={{ fontWeight: 'bold' }}>{t}</Text>
+          ))}
+        </View>
+      );
+    }
+    rows.push(
+      <View key={r} style={{ flexDirection: 'row' }}>
+        {cells}
+      </View>
+    );
+  }
+  const status = ctx.gameover
+    ? ctx.gameover.winner === '0'
+      ? 'Player A wins!'
+      : 'Player B wins!'
+    : ctx.currentPlayer === '0'
+    ? 'Player A roll'
+    : 'Player B wait';
+  return (
+    <View style={{ alignItems: 'center', padding: 10 }}>
+      <Text style={{ marginBottom: 10 }}>{status}</Text>
+      {rows}
+      {!ctx.gameover && (
+        <TouchableOpacity
+          style={{ marginTop: 10, padding: 10, backgroundColor: '#ddd' }}
+          onPress={() => moves.roll()}
+        >
+          <Text>Roll Dice</Text>
+        </TouchableOpacity>
+      )}
+      {G.lastRoll && <Text style={{ marginTop: 10 }}>Rolled: {G.lastRoll}</Text>}
+    </View>
+  );
+};
+
+const SnakesLaddersClient = Client({ game: SnakesLaddersGame, board: SnakesLaddersBoard });
+
+export const Game = SnakesLaddersGame;
+export const Board = SnakesLaddersBoard;
+export const meta = { id: 'snakesAndLadders', title: 'Snakes & Ladders' };
+
+export default SnakesLaddersClient;


### PR DESCRIPTION
## Summary
- implement a Mancala board game with sowing and capture rules
- implement a simple Blackjack card game
- register the new games in the game index

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685acc07a664832dbcd66ce146596a98