### PR TITLE
Persist dark mode preference

### DIFF
--- a/contexts/ThemeContext.js
+++ b/contexts/ThemeContext.js
@@ -1,16 +1,42 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ActivityIndicator, View } from 'react-native';
 import { lightTheme, darkTheme } from '../theme';
 
 const ThemeContext = createContext();
+const STORAGE_KEY = 'darkMode';
 
 export const ThemeProvider = ({ children }) => {
+  const [loaded, setLoaded] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
-  const toggleTheme = () => setDarkMode((prev) => !prev);
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((val) => setDarkMode(val === 'true'))
+      .finally(() => setLoaded(true));
+  }, []);
+
+  const toggleTheme = async () => {
+    const next = !darkMode;
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, next.toString());
+    } catch (e) {
+      console.warn('Failed to persist dark mode', e);
+    }
+    setDarkMode(next);
+  };
+
   const theme = darkMode ? darkTheme : lightTheme;
 
   return (
     <ThemeContext.Provider value={{ darkMode, toggleTheme, theme }}>
-      {children}
+      {loaded ? (
+        children
+      ) : (
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator size="large" color="#d81b60" />
+        </View>
+      )}
     </ThemeContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- save dark mode selection to AsyncStorage
- load saved theme on startup

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685acebadce8832d8843247586b4f7e9