### PR TITLE
Add AI bot game mode

### DIFF
--- a/ai/bots.js
+++ b/ai/bots.js
@@ -1,0 +1,24 @@
+export const bots = [
+  {
+    id: 'ava',
+    name: 'Ava',
+    image: require('../assets/user1.jpg'),
+    personality: 'friendly'
+  },
+  {
+    id: 'zane',
+    name: 'Zane',
+    image: require('../assets/user2.jpg'),
+    personality: 'competitive'
+  },
+  {
+    id: 'leo',
+    name: 'Leo',
+    image: require('../assets/user3.jpg'),
+    personality: 'sarcastic'
+  }
+];
+
+export function getRandomBot() {
+  return bots[Math.floor(Math.random() * bots.length)];
+}

--- a/ai/chatBot.js
+++ b/ai/chatBot.js
@@ -1,0 +1,26 @@
+const friendly = [
+  "Good luck!",
+  "Nice move!",
+  "I'm having fun!",
+  "You're pretty good!"
+];
+
+const competitive = [
+  "I'm going to win this!",
+  "You'll have to try harder.",
+  "Watch this move!",
+  "I bet you didn't see that coming."
+];
+
+const sarcastic = [
+  "Oh wow, impressive...",
+  "Is that your strategy?",
+  "I'll try not to fall asleep.",
+  "Maybe you'll get me next time." 
+];
+
+export function generateReply(personality = 'friendly') {
+  const pools = { friendly, competitive, sarcastic };
+  const list = pools[personality] || friendly;
+  return list[Math.floor(Math.random() * list.length)];
+}

--- a/ai/ticTacToeBot.js
+++ b/ai/ticTacToeBot.js
@@ -1,0 +1,37 @@
+const lines = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
+
+function checkWinner(cells, player) {
+  return lines.some(([a, b, c]) =>
+    cells[a] === player && cells[b] === player && cells[c] === player
+  );
+}
+
+export function getBotMove(cells) {
+  const available = cells
+    .map((c, i) => (c === null ? i : null))
+    .filter((v) => v !== null);
+  if (available.length === 0) return null;
+  // win if possible
+  for (const idx of available) {
+    const copy = [...cells];
+    copy[idx] = '1';
+    if (checkWinner(copy, '1')) return idx;
+  }
+  // block opponent win
+  for (const idx of available) {
+    const copy = [...cells];
+    copy[idx] = '0';
+    if (checkWinner(copy, '0')) return idx;
+  }
+  if (available.includes(4)) return 4;
+  return available[Math.floor(Math.random() * available.length)];
+}

--- a/hooks/useTicTacToeBotGame.js
+++ b/hooks/useTicTacToeBotGame.js
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback } from 'react';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { Game as TicTacToeGame } from '../games/tic-tac-toe';
+import { getBotMove } from '../ai/ticTacToeBot';
+
+export default function useTicTacToeBotGame(onGameEnd) {
+  const [G, setG] = useState(TicTacToeGame.setup());
+  const [currentPlayer, setCurrentPlayer] = useState('0');
+  const [gameover, setGameover] = useState(null);
+
+  const applyMove = useCallback(
+    (moveName, ...args) => {
+      if (gameover) return;
+      const newG = JSON.parse(JSON.stringify(G));
+      let nextPlayer = currentPlayer;
+      const ctx = {
+        currentPlayer,
+        events: {
+          endTurn: () => {
+            nextPlayer = currentPlayer === '0' ? '1' : '0';
+          },
+        },
+      };
+      const move = TicTacToeGame.moves[moveName];
+      if (!move) return;
+      const res = move({ G: newG, ctx }, ...args);
+      if (res === INVALID_MOVE) return;
+      if (TicTacToeGame.turn?.moveLimit === 1 && nextPlayer === currentPlayer) {
+        nextPlayer = currentPlayer === '0' ? '1' : '0';
+      }
+      const over = TicTacToeGame.endIf
+        ? TicTacToeGame.endIf({ G: newG, ctx: { currentPlayer: nextPlayer } })
+        : undefined;
+      setG(newG);
+      setCurrentPlayer(nextPlayer);
+      if (over) {
+        setGameover(over);
+        onGameEnd && onGameEnd(over);
+      }
+    },
+    [G, currentPlayer, gameover, onGameEnd]
+  );
+
+  const moves = { clickCell: (idx) => applyMove('clickCell', idx) };
+
+  useEffect(() => {
+    if (currentPlayer === '1' && !gameover) {
+      const idx = getBotMove(G.cells);
+      if (idx !== null && idx !== undefined) {
+        const t = setTimeout(() => moves.clickCell(idx), 600);
+        return () => clearTimeout(t);
+      }
+    }
+  }, [currentPlayer, G, gameover]);
+
+  const reset = () => {
+    setG(TicTacToeGame.setup());
+    setCurrentPlayer('0');
+    setGameover(null);
+  };
+
+  return { G, ctx: { currentPlayer, gameover }, moves, reset };
+}

--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -13,6 +13,7 @@ import EventChatScreen from '../screens/EventChatScreen';
 import PremiumScreen from '../screens/PremiumScreen';
 import PremiumPaywallScreen from '../screens/PremiumPaywallScreen';
 import StatsScreen from '../screens/StatsScreen';
+import GameWithBotScreen from '../screens/GameWithBotScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -31,6 +32,7 @@ export default function AppStack() {
       <Stack.Screen name="Premium" component={PremiumScreen} />
       <Stack.Screen name="PremiumPaywall" component={PremiumPaywallScreen} />
       <Stack.Screen name="Stats" component={StatsScreen} />
+      <Stack.Screen name="GameWithBot" component={GameWithBotScreen} />
     </Stack.Navigator>
   );
 }

--- a/screens/GameWithBotScreen.js
+++ b/screens/GameWithBotScreen.js
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import Header from '../components/Header';
+import { useTheme } from '../contexts/ThemeContext';
+import { bots, getRandomBot } from '../ai/bots';
+import { generateReply } from '../ai/chatBot';
+import useTicTacToeBotGame from '../hooks/useTicTacToeBotGame';
+import { Board as TicTacToeBoard } from '../games/tic-tac-toe';
+
+export default function GameWithBotScreen({ route }) {
+  const botId = route.params?.botId;
+  const bot = bots.find((b) => b.id === botId) || getRandomBot();
+  const { theme } = useTheme();
+  const { G, ctx, moves, reset } = useTicTacToeBotGame(handleGameEnd);
+
+  const [messages, setMessages] = useState([
+    { id: 'start', sender: bot.name, text: `Hi! I'm ${bot.name}. Let's play!` },
+  ]);
+  const [text, setText] = useState('');
+
+  function handleGameEnd(res) {
+    if (!res) return;
+    let msg = 'Draw.';
+    if (res.winner === '0') msg = 'You win!';
+    else if (res.winner === '1') msg = `${bot.name} wins.`;
+    addSystemMessage(`Game over. ${msg}`);
+  }
+
+  const addSystemMessage = (t) =>
+    setMessages((m) => [{ id: Date.now().toString(), sender: 'system', text: t }, ...m]);
+
+  const sendMessage = (t) => {
+    setMessages((m) => [
+      { id: Date.now().toString(), sender: 'you', text: t },
+      ...m,
+    ]);
+    const reply = generateReply(bot.personality);
+    setTimeout(
+      () =>
+        setMessages((m) => [
+          { id: Date.now().toString(), sender: bot.name, text: reply },
+          ...m,
+        ]),
+      600
+    );
+  };
+
+  const handleSend = () => {
+    const t = text.trim();
+    if (!t) return;
+    sendMessage(t);
+    setText('');
+  };
+
+  const renderMessage = ({ item }) => (
+    <View
+      style={[
+        styles.message,
+        item.sender === 'you'
+          ? styles.right
+          : item.sender === 'system'
+          ? styles.system
+          : styles.left,
+      ]}
+    >
+      <Text style={styles.sender}>
+        {item.sender === 'you' ? 'You' : item.sender}
+      </Text>
+      <Text style={styles.text}>{item.text}</Text>
+    </View>
+  );
+
+  return (
+    <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+      <Header />
+      <View style={{ flex: 1, paddingTop: 60, paddingHorizontal: 10 }}>
+        <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, color: theme.text }}>
+          Playing Tic Tac Toe with {bot.name}
+        </Text>
+        <View style={{ alignItems: 'center' }}>
+          <TicTacToeBoard G={G} ctx={ctx} moves={moves} onGameEnd={handleGameEnd} />
+        </View>
+        <TouchableOpacity style={styles.resetBtn} onPress={reset}>
+          <Text style={{ color: '#fff', fontWeight: 'bold' }}>Reset</Text>
+        </TouchableOpacity>
+        <View style={{ flex: 1, marginTop: 20 }}>
+          <FlatList
+            data={messages}
+            keyExtractor={(item) => item.id}
+            renderItem={renderMessage}
+            inverted
+            contentContainerStyle={{ paddingBottom: 20 }}
+          />
+        </View>
+        <View style={styles.inputBar}>
+          <TextInput
+            style={styles.input}
+            placeholder="Type a message..."
+            value={text}
+            onChangeText={setText}
+          />
+          <TouchableOpacity style={styles.sendBtn} onPress={handleSend}>
+            <Text style={{ color: '#fff', fontWeight: 'bold' }}>Send</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  message: {
+    padding: 8,
+    borderRadius: 10,
+    marginVertical: 4,
+    maxWidth: '80%',
+  },
+  left: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#f9f9f9',
+  },
+  right: {
+    alignSelf: 'flex-end',
+    backgroundColor: '#ffb6c1',
+  },
+  system: {
+    alignSelf: 'center',
+    backgroundColor: '#eee',
+  },
+  sender: {
+    fontSize: 11,
+    fontWeight: 'bold',
+    marginBottom: 2,
+  },
+  text: { fontSize: 15 },
+  inputBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: '#fff',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 20,
+    marginRight: 8,
+  },
+  sendBtn: {
+    backgroundColor: '#d81b60',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+  },
+  resetBtn: {
+    backgroundColor: '#607d8b',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+    alignSelf: 'center',
+    marginTop: 10,
+  },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -16,6 +16,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
 import { LinearGradient } from 'expo-linear-gradient';
+import { getRandomBot } from '../ai/bots';
 
 
 const GAMES = [
@@ -120,6 +121,19 @@ const HomeScreen = ({ navigation }) => {
             onPress={() => openGamePicker('stranger')}
           >
             <Text style={styles.btnText}>Play With Stranger</Text>
+          </TouchableOpacity>
+        )}
+
+        {/* 🤖 Play With AI */}
+        {card(
+          <TouchableOpacity
+            style={[styles.emailBtn, { alignSelf: 'center', backgroundColor: '#6c5ce7' }]}
+            onPress={() => {
+              const bot = getRandomBot();
+              navigation.navigate('GameWithBot', { botId: bot.id });
+            }}
+          >
+            <Text style={styles.btnText}>Play With AI</Text>
           </TouchableOpacity>
         )}
       </ScrollView>


### PR DESCRIPTION
## Summary
- add simple bot profiles and chatbot replies
- create AI opponent logic for TicTacToe
- build hook for local bot games
- add GameWithBot screen for playing bots
- allow launching AI game from HomeScreen
- wire new screen into app navigation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aff196f08832dbc0a4cb509e89be0