### PR TITLE
Fix onboarding check after login

### DIFF
--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -38,7 +38,12 @@ export default function RootNavigator() {
     return <SplashScreen onFinish={() => setIsSplash(false)} />;
   }
 
-  const onboarded = user?.onboardingComplete || hasOnboarded;
+  // Prefer the onboarding flag from the user's profile. Only fall back to
+  // the locally persisted flag when the profile has not been loaded yet.
+  const onboarded =
+    user?.onboardingComplete !== undefined
+      ? user.onboardingComplete
+      : hasOnboarded;
 
   if (!user) {
     return <AuthStack />;


### PR DESCRIPTION
## Summary
- ensure onboarding screen shows if the logged-in user's profile doesn't indicate completion

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685b061ebda4832d9f4cde763afd71e4