### PR TITLE
Fix navigation and icon errors

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -71,7 +71,6 @@ export default function OnboardingScreen() {
 
   useEffect(() => {
     if (hasOnboarded) {
-      navigation.replace('Main');
       return;
     }
     const checkExisting = async () => {
@@ -80,7 +79,8 @@ export default function OnboardingScreen() {
       const ref = db.collection('users').doc(uid);
       const snap = await ref.get();
       if (snapshotExists(snap) && snap.data().onboardingComplete) {
-        navigation.replace('Main');
+        updateUser(snap.data());
+        markOnboarded();
       }
     };
     checkExisting();
@@ -141,7 +141,6 @@ export default function OnboardingScreen() {
         updateUser(profile);
         markOnboarded();
         Toast.show({ type: 'success', text1: 'Profile saved!' });
-        navigation.replace('Main');
       } catch (e) {
         console.error('Save error:', e);
         Toast.show({ type: 'error', text1: 'Failed to save profile' });

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -295,7 +295,7 @@ const allGames = [
   {
     id: '25',
     title: 'Mahjong',
-    icon: <MaterialCommunityIcons name="mahjong" size={30} />,
+    icon: <MaterialCommunityIcons name="puzzle" size={30} />,
     route: null,
     premium: true,
     category: 'International',

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -10,6 +10,13 @@ export async function registerForPushNotificationsAsync() {
       return null;
     }
 
+    if (Constants.appOwnership === 'expo' && Platform.OS === 'android') {
+      console.log(
+        'Remote push notifications are not supported in Expo Go on Android. Use a development build.'
+      );
+      return null;
+    }
+
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
     if (existingStatus !== 'granted') {


### PR DESCRIPTION
## Summary
- avoid invalid navigation from Onboarding screen
- replace invalid Mahjong icon with a supported one
- skip remote push registration on Expo Go

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b0bdf62c8832da134cf8c0bc48fda