### PR TITLE
Fix tic tac toe board layout on small screens

### DIFF
--- a/games/tic-tac-toe.js
+++ b/games/tic-tac-toe.js
@@ -15,8 +15,16 @@ const lines = [
 ];
 
 const BOARD_MARGIN = 40;
-const BOARD_SIZE = Math.min(Dimensions.get('window').width - BOARD_MARGIN, 300);
-const CELL_SIZE = BOARD_SIZE / 3;
+// Ensure the board width is evenly divisible by 3 so all cells fit without
+// wrapping due to rounding errors on smaller screens. We first calculate an
+// approximate board size based on the available width, then derive an integer
+// cell size and recompute the final board size from that cell size.
+const APPROX_BOARD_SIZE = Math.min(
+  Dimensions.get('window').width - BOARD_MARGIN,
+  300
+);
+const CELL_SIZE = Math.floor(APPROX_BOARD_SIZE / 3);
+const BOARD_SIZE = CELL_SIZE * 3;
 
 const TicTacToeGame = {
   setup: () => ({ cells: Array(9).fill(null) }),


### PR DESCRIPTION
## Summary
- ensure board size divides evenly into thirds

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b584f7754832da62f8b142768828e