### PR TITLE
Prevent Firebase config log in production

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -14,7 +14,9 @@ const firebaseConfig = {
   appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
 };
 
-console.log('Firebase config loaded', firebaseConfig);
+if (__DEV__) {
+  console.log('Firebase config loaded', firebaseConfig);
+}
 
 try {
   if (!firebase.apps.length) {


### PR DESCRIPTION
## Summary
- wrap Firebase config logging in a `__DEV__` check so it only prints in development

## Testing
- `npm test` *(fails: Missing script)*
- `node --input-type=module -e "global.__DEV__=false; import('./firebase.js')"` *(fails: cannot find package 'firebase')*


------
https://chatgpt.com/codex/tasks/task_e_685bb2e4cc6c832dbe06d77140f50dc0