### PR TITLE
Add Providers component for context wrapping

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,16 +1,6 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { ThemeProvider } from './contexts/ThemeContext';
-import { NotificationProvider } from './contexts/NotificationContext';
-import { UserProvider } from './contexts/UserContext';
-import { AuthProvider } from './contexts/AuthContext';
-import { OnboardingProvider } from './contexts/OnboardingContext';
-import { ChatProvider } from './contexts/ChatContext';
-import { MatchmakingProvider } from './contexts/MatchmakingContext';
-import { GameSessionProvider } from './contexts/GameSessionContext';
-import { DevProvider } from './contexts/DevContext';
-import { GameLimitProvider } from './contexts/GameLimitContext';
-import { ListenerProvider } from './contexts/ListenerContext';
+import Providers from './contexts/Providers';
 import NotificationCenter from './components/NotificationCenter';
 import DevBanner from './components/DevBanner';
 import Toast from 'react-native-toast-message';
@@ -20,33 +10,13 @@ import RootNavigator from './navigation/RootNavigator';
 export default function App() {
   usePushNotifications();
   return (
-    <DevProvider>
-      <ThemeProvider>
-        <AuthProvider>
-          <NotificationProvider>
-            <OnboardingProvider>
-              <UserProvider>
-                <ListenerProvider>
-                  <GameLimitProvider>
-                    <ChatProvider>
-                      <MatchmakingProvider>
-                        <GameSessionProvider>
-                          <NavigationContainer>
-                            <RootNavigator />
-                            <DevBanner />
-                          </NavigationContainer>
-                          <NotificationCenter />
-                          <Toast />
-                        </GameSessionProvider>
-                      </MatchmakingProvider>
-                    </ChatProvider>
-                  </GameLimitProvider>
-                </ListenerProvider>
-              </UserProvider>
-            </OnboardingProvider>
-          </NotificationProvider>
-        </AuthProvider>
-      </ThemeProvider>
-    </DevProvider>
+    <Providers>
+      <NavigationContainer>
+        <RootNavigator />
+        <DevBanner />
+      </NavigationContainer>
+      <NotificationCenter />
+      <Toast />
+    </Providers>
   );
 }

--- a/contexts/Providers.js
+++ b/contexts/Providers.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { DevProvider } from './DevContext';
+import { ThemeProvider } from './ThemeContext';
+import { AuthProvider } from './AuthContext';
+import { NotificationProvider } from './NotificationContext';
+import { OnboardingProvider } from './OnboardingContext';
+import { UserProvider } from './UserContext';
+import { ListenerProvider } from './ListenerContext';
+import { GameLimitProvider } from './GameLimitContext';
+import { ChatProvider } from './ChatContext';
+import { MatchmakingProvider } from './MatchmakingContext';
+import { GameSessionProvider } from './GameSessionContext';
+
+const Providers = ({ children }) => (
+  <DevProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <NotificationProvider>
+          <OnboardingProvider>
+            <UserProvider>
+              <ListenerProvider>
+                <GameLimitProvider>
+                  <ChatProvider>
+                    <MatchmakingProvider>
+                      <GameSessionProvider>{children}</GameSessionProvider>
+                    </MatchmakingProvider>
+                  </ChatProvider>
+                </GameLimitProvider>
+              </ListenerProvider>
+            </UserProvider>
+          </OnboardingProvider>
+        </NotificationProvider>
+      </AuthProvider>
+    </ThemeProvider>
+  </DevProvider>
+);
+
+export default Providers;


### PR DESCRIPTION
## Summary
- centralize app context providers in `contexts/Providers.js`
- wrap navigation in `<Providers>` inside `App.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bb7671344832da9fe443136c4615e