### PR TITLE
Add Firestore schema documentation

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -1,0 +1,80 @@
+# Firestore Schema
+
+This document outlines the final Firestore structure used by the Pinged application. It lists the primary collections and the fields stored for each document.
+
+## Users (`users/{uid}`)
+- `uid` (string) – user identifier (document ID)
+- `email` (string)
+- `displayName` (string)
+- `photoURL` (string)
+- `name` (string)
+- `age` (number)
+- `gender` (string)
+- `genderPref` (string)
+- `location` (string)
+- `favoriteGame` (string)
+- `skillLevel` (string)
+- `bio` (string)
+- `onboardingComplete` (boolean)
+- `createdAt` (timestamp)
+- `isPremium` (boolean)
+- `premiumUpdatedAt` (timestamp)
+- `xp` (number)
+- `streak` (number)
+- `lastPlayedAt` (timestamp)
+- `dailyPlayCount` (number)
+- `lastGamePlayedAt` (timestamp)
+- `expoPushToken` (string)
+
+### Subcollections
+- **gameInvites** – invitations sent or received by the user. Each invite document mirrors the root `gameInvites` collection.
+- **notifications** – optional per-user notifications (see `notifications` below).
+
+## Match Requests (`matchRequests/{requestId}`)
+- `from` (string) – user id of requester
+- `to` (string) – user id of target
+- `status` (string) – `pending`, `accepted`, or `cancelled`
+- `createdAt` (timestamp)
+
+## Game Invites (`gameInvites/{inviteId}`)
+- `from` (string) – sender uid
+- `to` (string) – recipient uid
+- `gameId` (string)
+- `fromName` (string)
+- `status` (string) – `pending`, `ready`, `accepted`, `declined`, `cancelled`
+- `acceptedBy` (array of strings) – user ids who accepted the invite
+- `createdAt` (timestamp)
+
+A copy of each invite is also stored under `users/{uid}/gameInvites/{inviteId}` for quick access.
+
+## Matches (`matches/{matchId}`)
+- `users` (array of string) – exactly two user ids
+- `createdAt` (timestamp)
+
+### Subcollections
+- **messages** – chat messages between the matched users.
+  - `senderId` (string)
+  - `text` (string)
+  - `timestamp` (timestamp)
+
+## Game Sessions (`gameSessions/{sessionId}`)
+- `gameId` (string)
+- `players` (array of string) – user ids
+- `state` (map) – current game state object
+- `currentPlayer` (string) – id of the current player (`"0"` or `"1"`)
+- `gameover` (map|null)
+- `createdAt` (timestamp)
+- `updatedAt` (timestamp)
+
+## Chats
+Chat conversations occur inside match documents under the `messages` subcollection (see **Matches** above). Each event also has a chat stored at `events/{eventId}/messages` following the same message shape.
+
+## Notifications (`users/{uid}/notifications/{notificationId}`)
+- `message` (string)
+- `read` (boolean)
+- `type` (string) – e.g. `invite`, `match`, etc.
+- `createdAt` (timestamp)
+- `extra` (map) – optional additional data
+
+These per-user notifications can be paired with push notifications to keep users informed of invites or other activity.
+


### PR DESCRIPTION
## Summary
- document the collections used by the app
- include users, matches, game sessions, chats and notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c0cb05618832db048661552485717