### PR TITLE
Implement free game limit

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -22,8 +22,8 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `xp` (number)
 - `streak` (number)
 - `lastPlayedAt` (timestamp)
-- `dailyPlayCount` (number)
-- `lastGamePlayedAt` (timestamp)
+- `dailyPlayCount` (number) – count of games started today for free users
+- `lastGamePlayedAt` (timestamp) – when the last game session began
 - `expoPushToken` (string)
 
 ### Subcollections

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,9 +9,30 @@ service cloud.firestore {
       return signedIn() && request.auth.uid == uid;
     }
 
+    function canPlayDaily(oldData, newData) {
+      let premium = (oldData.isPremium == true) || (newData.isPremium == true);
+      if (premium) return true;
+
+      // When play count fields aren't being modified just allow
+      let countChanged = newData.dailyPlayCount != oldData.dailyPlayCount ||
+        newData.lastGamePlayedAt != oldData.lastGamePlayedAt;
+      if (!countChanged) return true;
+
+      // require lastGamePlayedAt to be set to server time when updating
+      if (newData.lastGamePlayedAt != request.time) return false;
+
+      let limit = 1;
+      // No previous timestamp or more than 24h since last game -> reset count
+      return (!oldData.lastGamePlayedAt ||
+          request.time - oldData.lastGamePlayedAt > duration.value(1, 'd'))
+        ? newData.dailyPlayCount == 1 && newData.dailyPlayCount <= limit
+        : newData.dailyPlayCount == oldData.dailyPlayCount + 1 &&
+          newData.dailyPlayCount <= limit;
+    }
+
     match /users/{userId} {
       allow read: if signedIn();
-      allow write: if isUser(userId);
+      allow write: if isUser(userId) && canPlayDaily(resource.data, request.resource.data);
       match /gameInvites/{inviteId} {
         allow read, write: if isUser(userId);
       }


### PR DESCRIPTION
## Summary
- note dailyPlayCount fields in schema documentation
- restrict updates to dailyPlayCount in Firestore security rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c3521f218832d9296347b6f9b8c53