### PR TITLE
Add Firestore rule for user updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,7 +32,9 @@ service cloud.firestore {
 
     match /users/{userId} {
       allow read: if signedIn();
-      allow write: if isUser(userId) && canPlayDaily(resource.data, request.resource.data);
+      // Only allow users to update their own document
+      allow update: if isUser(userId) &&
+        canPlayDaily(resource.data, request.resource.data);
       match /gameInvites/{inviteId} {
         allow read, write: if isUser(userId);
       }


### PR DESCRIPTION
## Summary
- restrict user document writes to updates by the owner

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c54d1c1c8832db1aa8ac246c45227