### PR TITLE
Add typing indicator and read receipts

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -52,12 +52,14 @@ A copy of each invite is also stored under `users/{uid}/gameInvites/{inviteId}` 
 ## Matches (`matches/{matchId}`)
 - `users` (array of string) – exactly two user ids
 - `createdAt` (timestamp)
+- `typing` (map) – per-user typing status
 
 ### Subcollections
 - **messages** – chat messages between the matched users.
   - `senderId` (string)
   - `text` (string)
   - `timestamp` (timestamp)
+  - `readBy` (array of string)
 
 ## Game Sessions (`gameSessions/{sessionId}`)
 - `gameId` (string)


### PR DESCRIPTION
## Summary
- track typing status in Firestore matches
- mark messages as read using `readBy`
- display read receipts and typing indicator on chat screen
- document new Firestore fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca101cd3c832d82959c37a3bffd82