### PR TITLE
Add real-time presence to match list

### DIFF
--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -15,7 +15,17 @@ const MatchesScreen = ({ navigation }) => {
       onPress={() => navigation.navigate('Chat', { user: item })}
     >
       <Image source={item.image} style={styles.avatar} />
-      <Text style={[styles.name, { color: theme.text }]}>{item.name}</Text>
+      <View style={{ flex: 1 }}>
+        <Text style={[styles.name, { color: theme.text }]}>{item.name}</Text>
+        <Text
+          style={[
+            styles.status,
+            { color: item.online ? '#2ecc71' : '#999' },
+          ]}
+        >
+          {item.online ? 'Online' : 'Offline'}
+        </Text>
+      </View>
     </TouchableOpacity>
   );
 
@@ -69,6 +79,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: '#333',
+  },
+  status: {
+    fontSize: 12,
+    marginTop: 2,
   },
 });
 


### PR DESCRIPTION
## Summary
- subscribe to user profiles in `ChatContext` to update presence
- show online/offline status in `MatchesScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca2747210832db121966e26d199c0