### PR TITLE
Connect favorite game picker to Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -79,6 +79,11 @@ service cloud.firestore {
       allow read, write: if signedIn();
     }
 
+    // List of available games for onboarding
+    match /games/{gameId} {
+      allow read: if true;
+    }
+
     // Community Board posts accessible to all signed-in users
     match /communityPosts/{postId} {
       allow read: if true;

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -55,6 +55,32 @@ export default function OnboardingScreen() {
     favoriteGame: '',
     skillLevel: '',
   });
+  const defaultGameOptions = [
+    { label: 'Chess', value: 'Chess' },
+    { label: 'Checkers', value: 'Checkers' },
+    { label: 'Tic Tac Toe', value: 'Tic Tac Toe' },
+  ];
+  const [gameOptions, setGameOptions] = useState(defaultGameOptions);
+
+  useEffect(() => {
+    const unsub = db
+      .collection('games')
+      .orderBy('title')
+      .onSnapshot(
+        (snap) => {
+          if (!snap.empty) {
+            setGameOptions(
+              snap.docs.map((d) => ({
+                label: d.data().title,
+                value: d.data().title,
+              }))
+            );
+          }
+        },
+        (e) => console.warn('Failed to load games', e)
+      );
+    return unsub;
+  }, []);
 
   const currentField = questions[step].key;
   const progress = (step + 1) / questions.length;
@@ -254,11 +280,7 @@ export default function OnboardingScreen() {
         { label: 'Other', value: 'Other' },
         { label: 'Any', value: 'Any' },
       ],
-      favoriteGame: [
-        { label: 'Chess', value: 'Chess' },
-        { label: 'Checkers', value: 'Checkers' },
-        { label: 'Tic Tac Toe', value: 'Tic Tac Toe' },
-      ],
+      favoriteGame: gameOptions,
       skillLevel: [
         { label: 'Beginner', value: 'Beginner' },
         { label: 'Intermediate', value: 'Intermediate' },


### PR DESCRIPTION
## Summary
- load available games from Firestore when onboarding
- use fetched games in the favorite game picker
- allow reading games collection via Firestore rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca4fa022c832da7602930a9b0a649