### PR TITLE
Fix premium checks for game limit and features

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -251,7 +251,13 @@ export default function ChatScreen({ route }) {
       <View style={chatStyles.inputBar}>
         <TouchableOpacity
           style={activeGameId ? chatStyles.changeButton : chatStyles.playButton}
-          onPress={() => setShowGameModal(true)}
+          onPress={() => {
+            if (!currentUser?.isPremium && gamesLeft <= 0 && !devMode) {
+              navigation.navigate('PremiumPaywall');
+            } else {
+              setShowGameModal(true);
+            }
+          }}
         >
           <Text style={{ color: '#fff', fontWeight: 'bold' }}>
             {activeGameId ? 'Change Game' : 'Play'}

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -45,6 +45,12 @@ const GameInviteScreen = ({ route, navigation }) => {
   const [matches, setMatches] = useState([]);
 
   useEffect(() => {
+    if (!currentUser?.isPremium && gamesLeft <= 0 && !devMode) {
+      navigation.replace('PremiumPaywall');
+    }
+  }, [gamesLeft, currentUser?.isPremium, devMode]);
+
+  useEffect(() => {
     if (!currentUser) return;
     const q = currentUser.uid
       ? db.collection('users').where('uid', '!=', currentUser.uid)


### PR DESCRIPTION
## Summary
- show paywall when pressing Play if user exceeded free games
- redirect to paywall on GameInvite open when out of games

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca580ee34832dba9d1cc2b1d0e399