### PR TITLE
Wrap app root in SafeAreaView and KeyboardAvoidingView

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import { SafeAreaView, KeyboardAvoidingView, Platform } from 'react-native';
 import Providers from './contexts/Providers';
 import NotificationCenter from './components/NotificationCenter';
 import DevBanner from './components/DevBanner';
@@ -10,13 +11,21 @@ import RootNavigator from './navigation/RootNavigator';
 export default function App() {
   usePushNotifications();
   return (
-    <Providers>
-      <NavigationContainer>
-        <RootNavigator />
-        <DevBanner />
-      </NavigationContainer>
-      <NotificationCenter />
-      <Toast />
-    </Providers>
+    <SafeAreaView style={{ flex: 1 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={60}
+      >
+        <Providers>
+          <NavigationContainer>
+            <RootNavigator />
+            <DevBanner />
+          </NavigationContainer>
+          <NotificationCenter />
+          <Toast />
+        </Providers>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the main App component with `SafeAreaView` and `KeyboardAvoidingView`

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685ca907f3f4832d82be77caa1c4e646