### PR TITLE
Improve dark mode styling

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -38,10 +38,10 @@ const questions = [
 
 export default function OnboardingScreen() {
   const navigation = useNavigation();
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
   const { updateUser } = useUser();
   const { markOnboarded, hasOnboarded } = useOnboarding();
-  const styles = getStyles(darkMode);
+  const styles = getStyles(theme);
 
   const [step, setStep] = useState(0);
   const [answers, setAnswers] = useState({
@@ -356,14 +356,14 @@ export default function OnboardingScreen() {
   );
 }
 
-const getStyles = (darkMode) => {
-  const background = darkMode ? '#333' : '#FFFFFF';
-  const cardBg = darkMode ? '#444' : '#FFFFFF';
-  const textColor = darkMode ? '#EEE' : '#222';
-  const accent = '#FF75B5';
+const getStyles = (theme) => {
+  const background = theme.background;
+  const cardBg = theme.card;
+  const textColor = theme.text;
+  const accent = theme.accent;
 
   return StyleSheet.create({
-    container: { flex: 1, padding: 20 },
+    container: { flex: 1, padding: 20, backgroundColor: background },
     inner: { flex: 1, justifyContent: 'center' },
     progressText: {
       color: textColor,
@@ -374,7 +374,7 @@ const getStyles = (darkMode) => {
     progressContainer: {
       height: 8,
       width: '100%',
-      backgroundColor: darkMode ? '#333' : '#eee',
+      backgroundColor: theme.card,
       borderRadius: 4,
       overflow: 'hidden',
       marginBottom: 20,
@@ -418,7 +418,7 @@ const getStyles = (darkMode) => {
       width: 150,
       height: 150,
       borderRadius: 75,
-      backgroundColor: darkMode ? '#333' : '#eee',
+      backgroundColor: theme.card,
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -467,7 +467,7 @@ const getStyles = (darkMode) => {
       color: '#fff',
       fontSize: 16,
     },
-    gradientStart: '#FF75B5',
-    gradientEnd: '#FF9A75',
+    gradientStart: theme.gradientStart,
+    gradientEnd: theme.gradientEnd,
   });
 };

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -9,7 +9,8 @@ import { useUser } from '../contexts/UserContext';
 import { avatarSource } from '../utils/avatar';
 
 const StatsScreen = ({ navigation }) => {
-  const { darkMode, theme } = useTheme();
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
   const { user } = useUser();
   const isPremium = !!user?.isPremium;
 
@@ -97,7 +98,7 @@ const StatsScreen = ({ navigation }) => {
   );
 };
 
-const styles = StyleSheet.create({
+const getStyles = (theme) => StyleSheet.create({
   container: {
     paddingBottom: 80,
     paddingTop: 60,
@@ -115,12 +116,13 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 20,
-    fontWeight: 'bold'
+    fontWeight: 'bold',
+    color: theme.text
   },
   premiumBadge: {
     marginTop: 6,
     color: '#fff',
-    backgroundColor: '#d81b60',
+    backgroundColor: theme.accent,
     paddingHorizontal: 10,
     paddingVertical: 4,
     borderRadius: 12,
@@ -130,10 +132,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
     marginTop: 20,
-    marginBottom: 8
+    marginBottom: 8,
+    color: theme.text
   },
   statBox: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.card,
     borderRadius: 12,
     padding: 14,
     marginBottom: 10,
@@ -145,16 +148,16 @@ const styles = StyleSheet.create({
   },
   statLabel: {
     fontSize: 14,
-    color: '#666'
+    color: theme.textSecondary
   },
   statValue: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#111'
+    color: theme.text
   },
   premiumButton: {
     marginTop: 20,
-    backgroundColor: '#d81b60',
+    backgroundColor: theme.accent,
     paddingVertical: 12,
     borderRadius: 14,
     alignItems: 'center'
@@ -164,6 +167,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontSize: 15
   }
+
 });
 
 export default StatsScreen;

--- a/theme.js
+++ b/theme.js
@@ -15,8 +15,8 @@ export const darkTheme = {
   text: '#E0E0E0',
   textSecondary: '#AAAAAA',
   accent: '#BB86FC',
-  gradientStart: '#2a2a2a',
-  gradientEnd: '#000000',
+  gradientStart: '#5a189a',
+  gradientEnd: '#240046',
   headerBackground: '#1E1E1E',
 };
 


### PR DESCRIPTION
## Summary
- tune dark theme gradient colors
- switch OnboardingScreen to use theme values
- generate StatsScreen styles from theme

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca9da72c4832da5d1235c5b7b67fa