### PR TITLE
Add toast notifications for invites, uploads, and matches

### DIFF
--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -19,6 +19,7 @@ import { useGameLimit } from '../contexts/GameLimitContext';
 import styles from '../styles';
 import { db } from '../firebase';
 import { useUser } from '../contexts/UserContext';
+import Toast from 'react-native-toast-message';
 
 const devUser = {
   id: '__devUser',
@@ -84,6 +85,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     setLoadingId(user.id);
 
     const inviteId = await sendGameInvite(user.id, gameId);
+    Toast.show({ type: 'success', text1: 'Invite sent!' });
 
     const toLobby = () =>
       navigation.navigate('GameLobby', {

--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -20,6 +20,7 @@ import SyncedGame from '../components/SyncedGame';
 import GameOverModal from '../components/GameOverModal';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { snapshotExists } from '../utils/firestore';
+import Toast from 'react-native-toast-message';
 
 const GameLobbyScreen = ({ route, navigation }) => {
   const { darkMode, theme } = useTheme();
@@ -123,6 +124,7 @@ const GameLobbyScreen = ({ route, navigation }) => {
     }
 
     const newId = await sendGameInvite(opponent.id, game.id);
+    Toast.show({ type: 'success', text1: 'Invite sent!' });
     setGameResult(null);
     navigation.replace('GameLobby', {
       game,

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -57,6 +57,7 @@ const ProfileScreen = ({ navigation }) => {
         photoURL = await uploadAvatarAsync(avatar, user.uid);
       } catch (e) {
         console.warn('Avatar upload failed', e);
+        Toast.show({ type: 'error', text1: 'Failed to upload photo' });
       }
     }
 

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -11,6 +11,7 @@ import {
   StyleSheet,
   ToastAndroid,
 } from 'react-native';
+import Toast from 'react-native-toast-message';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
@@ -205,6 +206,7 @@ const SwipeScreen = () => {
             });
 
             setMatchedUser(displayUser);
+            Toast.show({ type: 'success', text1: "It's a match!" });
             setShowFireworks(true);
             setTimeout(() => setShowFireworks(false), 2000);
           }
@@ -224,6 +226,7 @@ const SwipeScreen = () => {
           pendingInvite: null,
         });
         setMatchedUser(displayUser);
+        Toast.show({ type: 'success', text1: "It's a match!" });
         setShowFireworks(true);
         setTimeout(() => setShowFireworks(false), 2000);
       }


### PR DESCRIPTION
## Summary
- show error toast if profile avatar upload fails
- show toast after inviting a user to play
- show toast after requesting a rematch
- alert the user when a swipe results in a match

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cab800cb0832d97a558cefa3ae494