### PR TITLE
Add loading indicators when joining games

### DIFF
--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -3,7 +3,8 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Image
+  Image,
+  ActivityIndicator
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
@@ -198,6 +199,13 @@ const GameLobbyScreen = ({ route, navigation }) => {
           ? 'Both players are ready!'
           : 'Waiting for opponent to accept...'}
       </Text>
+      {!isReady && countdown === null && (
+        <ActivityIndicator
+          size="small"
+          color="#d81b60"
+          style={{ marginBottom: 20 }}
+        />
+      )}
 
       {/* Buttons */}
       <View style={{ paddingHorizontal: 20 }}>

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -5,7 +5,8 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  StyleSheet
+  StyleSheet,
+  ActivityIndicator
 } from 'react-native';
 import Header from '../components/Header';
 import styles from '../styles';
@@ -93,13 +94,25 @@ const NotificationsScreen = ({ navigation }) => {
               </Text>
               <View style={local.actions}>
                 <TouchableOpacity
-                  style={[styles.emailBtn, { marginRight: 10 }]}
+                  style={[styles.emailBtn, { marginRight: 10, flexDirection: 'row', justifyContent: 'center' }]}
                   onPress={() => handleAccept(inv)}
+                  disabled={loadingId === inv.id}
                 >
-                  <Text style={styles.btnText}>Accept</Text>
+                  {loadingId === inv.id ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <Text style={styles.btnText}>Accept</Text>
+                  )}
                 </TouchableOpacity>
-                <TouchableOpacity onPress={() => handleDecline(inv)}>
-                  <Text style={{ color: theme.accent, fontSize: 13 }}>Decline</Text>
+                <TouchableOpacity
+                  onPress={() => handleDecline(inv)}
+                  disabled={loadingId === inv.id + '_decline'}
+                >
+                  {loadingId === inv.id + '_decline' ? (
+                    <ActivityIndicator size="small" color={theme.accent} />
+                  ) : (
+                    <Text style={{ color: theme.accent, fontSize: 13 }}>Decline</Text>
+                  )}
                 </TouchableOpacity>
               </View>
             </View>


### PR DESCRIPTION
## Summary
- show `ActivityIndicator` in game lobby while waiting for opponent
- add loading spinners on accept/decline buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685caf7cacb8832d99a69fe5161146a5