### PR TITLE
Remove unused GameLobbyScreen

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -24,7 +24,7 @@ export default function AppStack() {
       <Stack.Screen name="Notifications" component={NotificationsScreen} />
       <Stack.Screen name="EditProfile" component={EditProfileScreen} />
       <Stack.Screen name="GameInvite" component={GameInviteScreen} />
-      <Stack.Screen name="GameLobby" component={GameSessionScreen} />
+      <Stack.Screen name="GameSession" component={GameSessionScreen} />
       <Stack.Screen name="Community" component={CommunityScreen} />
       <Stack.Screen name="EventChat" component={EventChatScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -88,7 +88,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     Toast.show({ type: 'success', text1: 'Invite sent!' });
 
     const toLobby = () =>
-      navigation.navigate('GameLobby', {
+      navigation.navigate('GameSession', {
         game: { id: gameId, title: gameTitle },
         opponent: { id: user.id, name: user.name, photo: user.photo },
         inviteId,

--- a/screens/GameLobbyScreen.js
+++ b/screens/GameLobbyScreen.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import GameSessionScreen from './GameSessionScreen';
-
-export default function GameLobbyScreen(props) {
-  return <GameSessionScreen {...props} sessionType="live" />;
-}

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -148,7 +148,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
     const newId = await sendGameInvite(opponent.id, game.id);
     Toast.show({ type: 'success', text1: 'Invite sent!' });
     setGameResult(null);
-    navigation.replace('GameLobby', {
+    navigation.replace('GameSession', {
       game,
       opponent,
       inviteId: newId,

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -37,7 +37,7 @@ const NotificationsScreen = ({ navigation }) => {
         .update({ status: 'accepted' });
       const snap = await db.collection('users').doc(invite.from).get();
       const opp = snap.data() || {};
-      navigation.navigate('GameLobby', {
+      navigation.navigate('GameSession', {
         game: {
           id: invite.gameId,
           title: games[invite.gameId]?.meta?.title || 'Game',


### PR DESCRIPTION
## Summary
- remove `GameLobbyScreen`
- navigate directly to `GameSessionScreen` after invites
- keep rematch navigation consistent

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e1079956c832dba7bc109d300aa2f