### PR TITLE
Merge premium screens

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -26,7 +26,6 @@ export default function AppStack() {
       <Stack.Screen name="Community" component={CommunityScreen} />
       <Stack.Screen name="EventChat" component={EventChatScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
-      <Stack.Screen name="PremiumPaywall" component={PremiumScreen} />
       <Stack.Screen name="Stats" component={StatsScreen} />
       <Stack.Screen name="GameWithBot" component={GameSessionScreen} />
     </Stack.Navigator>

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -184,7 +184,7 @@ export default function ChatScreen({ route }) {
     const isPremiumUser = !!currentUser?.isPremium;
     if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
       setShowGameModal(false);
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     const title = games[gameId].meta.title;
@@ -254,7 +254,7 @@ export default function ChatScreen({ route }) {
           style={activeGameId ? chatStyles.changeButton : chatStyles.playButton}
           onPress={() => {
             if (!currentUser?.isPremium && gamesLeft <= 0 && !devMode) {
-              navigation.navigate('PremiumPaywall');
+              navigation.navigate('Premium', { context: 'paywall' });
             } else {
               setShowGameModal(true);
             }

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -47,7 +47,7 @@ const GameInviteScreen = ({ route, navigation }) => {
 
   useEffect(() => {
     if (!currentUser?.isPremium && gamesLeft <= 0 && !devMode) {
-      navigation.replace('PremiumPaywall');
+      navigation.replace('Premium', { context: 'paywall' });
     }
   }, [gamesLeft, currentUser?.isPremium, devMode]);
 
@@ -77,7 +77,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   const handleInvite = async (user) => {
     const isPremiumUser = !!currentUser?.isPremium;
     if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
 

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -97,7 +97,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
     if (countdown === null) return;
     const handleStart = async () => {
       if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
-        navigation.navigate('PremiumPaywall');
+        navigation.navigate('Premium', { context: 'paywall' });
         return;
       }
       setShowGame(true);
@@ -130,7 +130,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
 
   const handleRematch = async () => {
     if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     if (inviteId && user?.uid) {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -40,7 +40,7 @@ const HomeScreen = ({ navigation }) => {
       setPlayTarget(target);
       setGamePickerVisible(true);
     } else {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
     }
   };
 
@@ -48,7 +48,7 @@ const HomeScreen = ({ navigation }) => {
     const isLocked = !isPremiumUser && game.premium;
     if (isLocked) {
       setGamePickerVisible(false);
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     setGamePickerVisible(false);

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -80,11 +80,11 @@ const PlayScreen = ({ navigation }) => {
     if (!previewGame) return;
     setPreviewGame(null);
     if (previewGame.premium && !isPremiumUser && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     const { id, title, category, description } = previewGame;

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -19,7 +19,7 @@ const SettingsScreen = ({ navigation }) => {
     await auth.signOut();
     navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
   };
-  const handleGoPremium = () => navigation.navigate('PremiumPaywall');
+  const handleGoPremium = () => navigation.navigate('Premium', { context: 'paywall' });
 
   return (
     <LinearGradient

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -158,7 +158,7 @@ const StatsScreen = ({ navigation }) => {
 
         {!isPremium && (
           <TouchableOpacity
-            onPress={() => navigation.navigate('PremiumPaywall')}
+            onPress={() => navigation.navigate('Premium', { context: 'paywall' })}
             style={styles.premiumButton}
           >
             <Text style={styles.premiumText}>Upgrade to Premium</Text>

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -170,7 +170,7 @@ const SwipeScreen = () => {
 
     if (direction === 'right') {
       if (likesUsed >= MAX_LIKES && !isPremiumUser && !devMode) {
-        navigation.navigate('PremiumPaywall');
+        navigation.navigate('Premium', { context: 'paywall' });
         return;
       }
 
@@ -247,7 +247,7 @@ const SwipeScreen = () => {
 
   const rewind = () => {
     if (!isPremiumUser && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     if (history.length === 0) return;
@@ -260,7 +260,7 @@ const SwipeScreen = () => {
 
   const handleSuperLike = () => {
     if (!isPremiumUser && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     setShowSuperLikeAnim(true);
@@ -271,7 +271,7 @@ const SwipeScreen = () => {
 
   const handleBoost = () => {
     if (!isPremiumUser && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     setBoostActive(true);
@@ -318,7 +318,7 @@ const SwipeScreen = () => {
   const handleGameInvite = () => {
     if (!displayUser) return;
     if (!isPremiumUser && gamesLeft <= 0 && !devMode) {
-      navigation.navigate('PremiumPaywall');
+      navigation.navigate('Premium', { context: 'paywall' });
       return;
     }
     navigation.navigate('GameInvite', { user: displayUser });


### PR DESCRIPTION
## Summary
- remove `PremiumPaywall` from navigation and use the same `Premium` screen for both views
- update navigation calls to pass `{ context: 'paywall' }`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e12ff651c832da1393ca15f959f20