### PR TITLE
Add top event banner

### DIFF
--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../contexts/ThemeContext';
+import styles from '../styles';
+import { eventImageSource } from '../utils/avatar';
+
+const NEXT_EVENT = {
+  title: 'Checkers Blitz Tournament',
+  time: 'Saturday @ 7PM',
+  image: require('../assets/user3.jpg'),
+};
+
+export default function EventBanner() {
+  const navigation = useNavigation();
+  const { darkMode } = useTheme();
+
+  return (
+    <View
+      style={[
+        local.container,
+        { backgroundColor: darkMode ? '#333' : '#fff' },
+      ]}
+    >
+      <Image source={eventImageSource(NEXT_EVENT.image)} style={local.image} />
+      <View style={{ flex: 1 }}>
+        <Text style={local.title}>{NEXT_EVENT.title}</Text>
+        <Text style={local.time}>{NEXT_EVENT.time}</Text>
+      </View>
+      <TouchableOpacity
+        style={[styles.emailBtn, { marginLeft: 10 }]}
+        onPress={() => navigation.navigate('Community')}
+      >
+        <Text style={styles.btnText}>Join Now</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const local = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 16,
+    marginHorizontal: 16,
+    padding: 12,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  image: {
+    width: 60,
+    height: 60,
+    borderRadius: 10,
+    marginRight: 12,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: 'bold',
+  },
+  time: {
+    fontSize: 13,
+    color: '#d81b60',
+    marginTop: 2,
+  },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -19,6 +19,7 @@ import { useChats } from '../contexts/ChatContext';
 import { allGames } from '../data/games';
 import { getRandomBot } from '../ai/bots';
 import ProgressBar from '../components/ProgressBar';
+import EventBanner from '../components/EventBanner';
 
 const HomeScreen = ({ navigation }) => {
   const { theme } = useTheme();
@@ -84,6 +85,8 @@ const HomeScreen = ({ navigation }) => {
             <Text style={[local.streakLabel, { color: theme.textSecondary }]}>{`${user?.streak || 0} day streak`}</Text>
             <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
           </View>
+
+          <EventBanner />
 
           <Text style={local.section}>Quick Play</Text>
           <FlatList


### PR DESCRIPTION
## Summary
- create `EventBanner` component with static next event info and a Join Now CTA
- display `EventBanner` near the top of the Home screen

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e19fddf1c832da7baeda16cfc30ac