### PR TITLE
Fix match gating for chat/invites

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -789,7 +789,26 @@ const groupStyles = StyleSheet.create({
  * Exported chat wrapper  *
  *************************/
 export default function ChatScreen({ route }) {
-  const { user, event } = route.params || {};
+  const { user: paramUser, event } = route.params || {};
+  const { matches } = useChats();
+  const { theme } = useTheme();
+
   if (event) return <GroupChat event={event} />;
-  return <PrivateChat user={user} />;
+
+  const match = matches.find(
+    (m) => m.id === paramUser?.id || m.otherUserId === paramUser?.id
+  );
+
+  if (!match) {
+    return (
+      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+        <Header />
+        <Text style={{ marginTop: 80, textAlign: 'center', color: theme.text }}>
+          No match found.
+        </Text>
+      </LinearGradient>
+    );
+  }
+
+  return <PrivateChat user={match} />;
 }


### PR DESCRIPTION
## Summary
- restrict chat screen to matched users only
- load matches for game invites instead of all users
- remove dummy user from GameInvite screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ee947d200832d896a9c3b8bfbe403