### PR TITLE
Fix blank avatar on onboarding

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -228,8 +228,9 @@ export default function OnboardingScreen() {
     if (currentField === 'avatar') {
       return (
         <TouchableOpacity onPress={pickImage} style={styles.imagePicker}>
-          <Image source={avatarSource(answers.avatar)} style={styles.avatar} />
-          {!answers.avatar && (
+          {answers.avatar ? (
+            <Image source={avatarSource(answers.avatar)} style={styles.avatar} />
+          ) : (
             <View style={styles.placeholder}>
               <Text style={{ color: '#999' }}>Tap to select image</Text>
             </View>


### PR DESCRIPTION
## Summary
- don't show default avatar image in onboarding

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ee959e36c832d9e19b2602085a474