### PR TITLE
Change bio input to multiline

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -322,6 +322,24 @@ export default function OnboardingScreen() {
       );
     }
 
+    if (currentField === 'bio') {
+      return (
+        <TextInput
+          style={[styles.input, styles.bioInput]}
+          value={answers.bio}
+          onChangeText={(text) =>
+            setAnswers((prev) => ({ ...prev, bio: text.slice(0, 200) }))
+          }
+          placeholder={questions[step].label}
+          placeholderTextColor={darkMode ? '#999' : '#aaa'}
+          multiline
+          numberOfLines={4}
+          maxLength={200}
+          textAlignVertical="top"
+        />
+      );
+    }
+
     return (
       <TextInput
         style={styles.input}
@@ -419,6 +437,10 @@ const getStyles = (theme) => {
       color: textColor,
       fontSize: 18,
       paddingVertical: 8,
+    },
+    bioInput: {
+      height: 100,
+      textAlignVertical: 'top',
     },
     imagePicker: {
       alignSelf: 'center',


### PR DESCRIPTION
## Summary
- add multiline support for short bio in onboarding
- style short bio textarea with 100px height and 200-char limit

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ee98bc4ac832d90e58b987b5dfb94