### PR TITLE
Remove default chat header

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -272,7 +272,6 @@ function PrivateChat({ user }) {
 
   const chatSection = (
     <View style={{ flex: 1, padding: 10 }}>
-      <Text style={[styles.logoText, { marginBottom: 10 }]}>Chat with {user.name}</Text>
       <FlatList
         style={{ flex: 1 }}
         data={messages}


### PR DESCRIPTION
## Summary
- clean up ChatScreen layout by removing the in-app header text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685eea954208832da5e1305cdc51f326