### PR TITLE
Fix missing closing tag in SwipeScreen

### DIFF
--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -396,6 +396,7 @@ const SwipeScreen = () => {
               <Text style={styles.bio}>{displayUser.bio}</Text>
             </View>
           </TouchableOpacity>
+          </Animated.View>
         ) : null}
         {showSuperLikeAnim ? (
           <View style={styles.superLikeOverlay} pointerEvents="none">


### PR DESCRIPTION
## Summary
- correct JSX structure by closing `Animated.View`

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7cae02e8832da9e3e7b0a591690e