### PR TITLE
Fix Google sign-in redirect uri

### DIFF
--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
+import * as AuthSession from 'expo-auth-session';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { auth, db, firebase } from '../firebase';
 import { snapshotExists } from '../utils/firestore';
@@ -13,8 +14,11 @@ const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const redirectUri = AuthSession.makeRedirectUri({ scheme: 'pinged' });
+
   const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
     clientId: process.env.EXPO_PUBLIC_FIREBASE_WEB_CLIENT_ID,
+    redirectUri,
   });
 
   const ensureUserDoc = async (fbUser) => {
@@ -75,7 +79,8 @@ export const AuthProvider = ({ children }) => {
     await auth.signOut();
   };
 
-  const loginWithGoogle = () => promptAsync({ prompt: 'select_account' });
+  const loginWithGoogle = () =>
+    promptAsync({ useProxy: false, prompt: 'select_account' });
 
   const logout = () => auth.signOut();
 

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -7,6 +7,7 @@ import GradientButton from '../../components/GradientButton';
 import styles from '../../styles';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
+import * as AuthSession from 'expo-auth-session';
 import { auth, db, firebase } from '../../firebase';
 import { snapshotExists } from '../../utils/firestore';
 import { useOnboarding } from '../../contexts/OnboardingContext';
@@ -20,8 +21,11 @@ export default function LoginScreen() {
   const { markOnboarded } = useOnboarding();
   const { toggleDevMode } = useDev();
 
+  const redirectUri = AuthSession.makeRedirectUri({ scheme: 'pinged' });
+
   const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
     clientId: process.env.EXPO_PUBLIC_FIREBASE_WEB_CLIENT_ID,
+    redirectUri,
   });
 
   useEffect(() => {
@@ -68,7 +72,7 @@ export default function LoginScreen() {
 
       <GradientButton
         text="Sign in with Google"
-        onPress={() => promptAsync({ prompt: 'select_account' })}
+        onPress={() => promptAsync({ useProxy: false, prompt: 'select_account' })}
       />
 
       <GradientButton


### PR DESCRIPTION
## Summary
- add `expo-auth-session` to explicitly make redirect URIs
- disable proxy and set redirectUri in both login screen and auth context

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f701ebc832da87c0ba8cf784fc0