### PR TITLE
Add generic AI opponents

### DIFF
--- a/ai/botMoves.js
+++ b/ai/botMoves.js
@@ -1,0 +1,119 @@
+import { getBotMove as tttBot } from './ticTacToeBot';
+import { getBotMove as rpsBot } from './rockPaperScissorsBot';
+
+export const bots = {
+  ticTacToe: (G) => ({ move: 'clickCell', args: [tttBot(G.cells)] }),
+  rps: () => ({ move: 'choose', args: [rpsBot()] }),
+  connectFour: (G) => {
+    const ROWS = 6;
+    const COLS = 7;
+    const valid = [];
+    for (let c = 0; c < COLS; c++) {
+      for (let r = ROWS - 1; r >= 0; r--) {
+        if (G.cells[r * COLS + c] === null) {
+          valid.push(c);
+          break;
+        }
+      }
+    }
+    if (!valid.length) return null;
+    const col = valid[Math.floor(Math.random() * valid.length)];
+    return { move: 'drop', args: [col] };
+  },
+  gomoku: (G) => {
+    const valid = G.cells
+      .map((v, i) => (v === null ? i : null))
+      .filter((v) => v !== null);
+    if (!valid.length) return null;
+    const idx = valid[Math.floor(Math.random() * valid.length)];
+    return { move: 'place', args: [idx] };
+  },
+  battleship: (G, player) => {
+    const hits = G.hits[Number(player)];
+    const valid = hits
+      .map((v, i) => (v === null ? i : null))
+      .filter((v) => v !== null);
+    if (!valid.length) return null;
+    const idx = valid[Math.floor(Math.random() * valid.length)];
+    return { move: 'fire', args: [idx] };
+  },
+  checkers: (G, player, game) => {
+    const SIZE = 8;
+    const moves = [];
+    for (let from = 0; from < SIZE * SIZE; from++) {
+      const piece = G.board[from];
+      if (!piece || !piece.startsWith(player)) continue;
+      for (let to = 0; to < SIZE * SIZE; to++) {
+        const copy = JSON.parse(JSON.stringify(G));
+        const ctx = { currentPlayer: player, events: { endTurn: () => {} } };
+        const res = game.moves.movePiece({ G: copy, ctx }, from, to);
+        if (res !== 'INVALID_MOVE') {
+          moves.push({ move: 'movePiece', args: [from, to] });
+        }
+      }
+    }
+    if (!moves.length) return null;
+    return moves[Math.floor(Math.random() * moves.length)];
+  },
+  dominoes: (G, player, game) => {
+    const moves = [];
+    const hand = G.hands[player];
+    for (let i = 0; i < hand.length; i++) {
+      ['left', 'right'].forEach((side) => {
+        const copy = JSON.parse(JSON.stringify(G));
+        const ctx = { currentPlayer: String(player), events: { endTurn: () => {} } };
+        const res = game.moves.playTile({ G: copy, ctx }, i, side);
+        if (res !== 'INVALID_MOVE') moves.push({ move: 'playTile', args: [i, side] });
+      });
+    }
+    if (G.drawPile.length > 0) moves.push({ move: 'drawTile', args: [] });
+    if (!moves.length) return null;
+    return moves[Math.floor(Math.random() * moves.length)];
+  },
+  dotsAndBoxes: (G) => {
+    const SIZE = 2;
+    const moves = [];
+    for (let r = 0; r <= SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const i = r * SIZE + c;
+        if (!G.h[i]) moves.push({ move: 'drawH', args: [r, c] });
+      }
+    }
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c <= SIZE; c++) {
+        const i = r * (SIZE + 1) + c;
+        if (!G.v[i]) moves.push({ move: 'drawV', args: [r, c] });
+      }
+    }
+    if (!moves.length) return null;
+    return moves[Math.floor(Math.random() * moves.length)];
+  },
+  snakesAndLadders: () => ({ move: 'roll', args: [] }),
+  mancala: (G, player) => {
+    const PITS = 6;
+    const moves = [];
+    if (player === '0') {
+      for (let i = 0; i < PITS; i++) if (G.board[i] > 0) moves.push({ move: 'sow', args: [i] });
+    } else {
+      for (let i = 0; i < PITS; i++) if (G.board[PITS + 1 + i] > 0) moves.push({ move: 'sow', args: [i] });
+    }
+    if (!moves.length) return null;
+    return moves[Math.floor(Math.random() * moves.length)];
+  },
+  blackjack: (G, player) => {
+    if (G.stand[Number(player)]) return null;
+    return Math.random() < 0.5 ? { move: 'hit', args: [] } : { move: 'stand', args: [] };
+  },
+  nim: (G) => {
+    const max = Math.min(3, G.remaining);
+    const n = Math.floor(Math.random() * max) + 1;
+    return { move: 'take', args: [n] };
+  },
+  pig: () => {
+    return Math.random() < 0.5 ? { move: 'roll', args: [] } : { move: 'hold', args: [] };
+  },
+  coinToss: () => {
+    const choice = Math.random() < 0.5 ? 'Heads' : 'Tails';
+    return { move: 'choose', args: [choice] };
+  },
+};

--- a/hooks/useBotGame.js
+++ b/hooks/useBotGame.js
@@ -1,0 +1,70 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { INVALID_MOVE } from 'boardgame.io/core';
+
+export default function useBotGame(game, getBotMove, onGameEnd) {
+  const [G, setG] = useState(game.setup());
+  const [currentPlayer, setCurrentPlayer] = useState('0');
+  const [gameover, setGameover] = useState(null);
+
+  const applyMove = useCallback(
+    (moveName, ...args) => {
+      if (gameover) return;
+      const newG = JSON.parse(JSON.stringify(G));
+      let nextPlayer = currentPlayer;
+      const ctx = {
+        currentPlayer,
+        random: {
+          D6: () => Math.ceil(Math.random() * 6),
+        },
+        events: {
+          endTurn: () => {
+            nextPlayer = currentPlayer === '0' ? '1' : '0';
+          },
+        },
+      };
+      const move = game.moves[moveName];
+      if (!move) return;
+      const res = move({ G: newG, ctx }, ...args);
+      if (res === INVALID_MOVE) return;
+      if (game.turn?.moveLimit === 1 && nextPlayer === currentPlayer) {
+        nextPlayer = currentPlayer === '0' ? '1' : '0';
+      }
+      const over = game.endIf
+        ? game.endIf({ G: newG, ctx: { currentPlayer: nextPlayer } })
+        : undefined;
+      setG(newG);
+      setCurrentPlayer(nextPlayer);
+      if (over) {
+        setGameover(over);
+        onGameEnd && onGameEnd(over);
+      }
+    },
+    [G, currentPlayer, gameover, onGameEnd, game]
+  );
+
+  const moves = useMemo(() => {
+    const m = {};
+    for (const name of Object.keys(game.moves || {})) {
+      m[name] = (...args) => applyMove(name, ...args);
+    }
+    return m;
+  }, [applyMove, game]);
+
+  useEffect(() => {
+    if (currentPlayer === '1' && !gameover) {
+      const action = getBotMove(G, currentPlayer, game);
+      if (action && moves[action.move]) {
+        const t = setTimeout(() => moves[action.move](...(action.args || [])), 600);
+        return () => clearTimeout(t);
+      }
+    }
+  }, [currentPlayer, G, gameover, moves, getBotMove]);
+
+  const reset = () => {
+    setG(game.setup());
+    setCurrentPlayer('0');
+    setGameover(null);
+  };
+
+  return { G, ctx: { currentPlayer, gameover }, moves, reset };
+}

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -7,6 +7,7 @@ import {
   Image,
   TextInput,
   FlatList,
+  ScrollView,
   StyleSheet,
   SafeAreaView,
   KeyboardAvoidingView,
@@ -28,11 +29,9 @@ import { snapshotExists } from '../utils/firestore';
 import Toast from 'react-native-toast-message';
 import { bots, getRandomBot } from "../ai/bots";
 import { generateReply } from "../ai/chatBot";
-import useTicTacToeBotGame from "../hooks/useTicTacToeBotGame";
-import { Board as TicTacToeBoard } from "../games/tic-tac-toe";
+import useBotGame from "../hooks/useBotGame";
+import { bots as botMoves } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
-import useRPSBotGame from "../hooks/useRPSBotGame";
-import { Board as RPSBoard } from "../games/rock-paper-scissors";
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
   const type = sessionType || route.params?.sessionType || (route.params?.botId ? "bot" : "live");
   return type === "bot" ? (
@@ -270,14 +269,107 @@ const LiveSessionScreen = ({ route, navigation }) => {
     bots.find((b) => b.id === botId) || getRandomBot()
   );
   const { theme } = useTheme();
-  const ttt = useTicTacToeBotGame((res) => handleGameEnd(res, 'ticTacToe'));
-  const rps = useRPSBotGame((res) => handleGameEnd(res, 'rps'));
-
   const [game, setGame] = useState(initialGame);
 
   const gameMap = {
-    ticTacToe: { title: 'Tic Tac Toe', board: TicTacToeBoard, state: ttt },
-    rps: { title: 'Rock Paper Scissors', board: RPSBoard, state: rps },
+    ticTacToe: {
+      title: 'Tic Tac Toe',
+      board: games['ticTacToe'].Board,
+      state: useBotGame(games['ticTacToe'].Game, botMoves.ticTacToe, (res) =>
+        handleGameEnd(res, 'ticTacToe')
+      ),
+    },
+    rps: {
+      title: 'Rock Paper Scissors',
+      board: games['rockPaperScissors'].Board,
+      state: useBotGame(games['rockPaperScissors'].Game, botMoves.rps, (res) =>
+        handleGameEnd(res, 'rps')
+      ),
+    },
+    connectFour: {
+      title: 'Connect Four',
+      board: games['connectFour'].Board,
+      state: useBotGame(games['connectFour'].Game, botMoves.connectFour, (res) =>
+        handleGameEnd(res, 'connectFour')
+      ),
+    },
+    gomoku: {
+      title: 'Gomoku',
+      board: games['gomoku'].Board,
+      state: useBotGame(games['gomoku'].Game, botMoves.gomoku, (res) =>
+        handleGameEnd(res, 'gomoku')
+      ),
+    },
+    battleship: {
+      title: 'Battleship',
+      board: games['battleship'].Board,
+      state: useBotGame(games['battleship'].Game, botMoves.battleship, (res) =>
+        handleGameEnd(res, 'battleship')
+      ),
+    },
+    checkers: {
+      title: 'Checkers',
+      board: games['checkers'].Board,
+      state: useBotGame(games['checkers'].Game, botMoves.checkers, (res) =>
+        handleGameEnd(res, 'checkers')
+      ),
+    },
+    dominoes: {
+      title: 'Dominoes',
+      board: games['dominoes'].Board,
+      state: useBotGame(games['dominoes'].Game, botMoves.dominoes, (res) =>
+        handleGameEnd(res, 'dominoes')
+      ),
+    },
+    dotsAndBoxes: {
+      title: 'Dots and Boxes',
+      board: games['dotsAndBoxes'].Board,
+      state: useBotGame(games['dotsAndBoxes'].Game, botMoves.dotsAndBoxes, (res) =>
+        handleGameEnd(res, 'dotsAndBoxes')
+      ),
+    },
+    snakesAndLadders: {
+      title: 'Snakes & Ladders',
+      board: games['snakesAndLadders'].Board,
+      state: useBotGame(games['snakesAndLadders'].Game, botMoves.snakesAndLadders, (res) =>
+        handleGameEnd(res, 'snakesAndLadders')
+      ),
+    },
+    mancala: {
+      title: 'Mancala',
+      board: games['mancala'].Board,
+      state: useBotGame(games['mancala'].Game, botMoves.mancala, (res) =>
+        handleGameEnd(res, 'mancala')
+      ),
+    },
+    blackjack: {
+      title: 'Blackjack',
+      board: games['blackjack'].Board,
+      state: useBotGame(games['blackjack'].Game, botMoves.blackjack, (res) =>
+        handleGameEnd(res, 'blackjack')
+      ),
+    },
+    nim: {
+      title: 'Nim',
+      board: games['nim'].Board,
+      state: useBotGame(games['nim'].Game, botMoves.nim, (res) =>
+        handleGameEnd(res, 'nim')
+      ),
+    },
+    pig: {
+      title: 'Pig Dice',
+      board: games['pig'].Board,
+      state: useBotGame(games['pig'].Game, botMoves.pig, (res) =>
+        handleGameEnd(res, 'pig')
+      ),
+    },
+    coinToss: {
+      title: 'Coin Toss',
+      board: games['coinToss'].Board,
+      state: useBotGame(games['coinToss'].Game, botMoves.coinToss, (res) =>
+        handleGameEnd(res, 'coinToss')
+      ),
+    },
   };
 
   const { G, ctx, moves, reset } = gameMap[game].state;
@@ -398,21 +490,17 @@ const LiveSessionScreen = ({ route, navigation }) => {
         >
         <SafeAreaView style={{ flex: 1, paddingTop: 80, paddingHorizontal: 10, paddingBottom: 20 }}>
         <View style={botStyles.gameTabs}>
-          <TouchableOpacity
-            style={[
-              botStyles.tab,
-              game === 'ticTacToe' ? botStyles.tabActive : null,
-            ]}
-            onPress={() => switchGame('ticTacToe')}
-          >
-            <Text style={botStyles.tabText}>Tic Tac Toe</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[botStyles.tab, game === 'rps' ? botStyles.tabActive : null]}
-            onPress={() => switchGame('rps')}
-          >
-            <Text style={botStyles.tabText}>RPS</Text>
-          </TouchableOpacity>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            {Object.entries(gameMap).map(([key, val]) => (
+              <TouchableOpacity
+                key={key}
+                style={[botStyles.tab, game === key ? botStyles.tabActive : null]}
+                onPress={() => switchGame(key)}
+              >
+                <Text style={botStyles.tabText}>{val.title}</Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
         </View>
         <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 20, color: theme.text }}>
           Playing {title} with {bot.name}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -73,7 +73,18 @@ const HomeScreen = ({ navigation }) => {
     } else if (playTarget === 'ai') {
       const bot = getRandomBot();
       // Map game IDs to bot-supported game keys
-      const aiGames = { '1': 'ticTacToe', '3': 'rps' };
+      const aiGames = {
+        '1': 'ticTacToe',
+        '3': 'rps',
+        '4': 'connectFour',
+        '5': 'checkers',
+        '9': 'gomoku',
+        '10': 'mancala',
+        '12': 'battleship',
+        '18': 'blackjack',
+        '24': 'dominoes',
+        '32': 'snakesAndLadders',
+      };
       const gameKey = aiGames[game.id];
       navigation.navigate('GameWithBot', {
         botId: bot.id,


### PR DESCRIPTION
## Summary
- implement reusable `useBotGame` hook for boardgame.io bots
- add random move bots for all boardgame.io games
- expand bot mode to include all games with new tab UI
- update AI mapping in home screen

## Testing
- `node -e "require('./ai/botMoves.js');"` *(fails: cannot load ES module)*

------
https://chatgpt.com/codex/tasks/task_e_685f878f3b8c832d8036dde4e9709092