### PR TITLE
Fix header overlap on MatchesScreen

### DIFF
--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -56,7 +56,7 @@ const MatchesScreen = ({ navigation }) => {
     <SafeAreaView style={{ flex: 1 }}>
       <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
         <Header />
-        <View style={{ flex: 1, paddingTop: 60 }}>
+        <View style={{ flex: 1, paddingTop: 80 }}>
           {newMatches.length > 0 && (
             <>
               <Text style={styles.sectionTitle}>New Matches</Text>


### PR DESCRIPTION
## Summary
- adjust MatchesScreen padding so content clears the header

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686036f35410832da40202f665012919