### PR TITLE
Enable AI for all games

### DIFF
--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -30,7 +30,7 @@ import Toast from 'react-native-toast-message';
 import { bots, getRandomBot } from "../ai/bots";
 import { generateReply } from "../ai/chatBot";
 import useBotGame from "../hooks/useBotGame";
-import { bots as botMoves } from "../ai/botMoves";
+import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
   const type = sessionType || route.params?.sessionType || (route.params?.botId ? "bot" : "live");
@@ -271,15 +271,18 @@ const LiveSessionScreen = ({ route, navigation }) => {
   const { theme } = useTheme();
   const [game, setGame] = useState(initialGame);
 
-  const keyMap = { rps: 'rockPaperScissors' };
-  const gameMap = Object.keys(botMoves).reduce((acc, key) => {
-    const gameKey = keyMap[key] || key;
-    const info = games[gameKey];
-    if (!info) return acc;
-    acc[key] = {
+  const aiKeyMap = { rockPaperScissors: 'rps' };
+  const gameMap = Object.keys(games).reduce((acc, key) => {
+    const info = games[key];
+    const aiKey = aiKeyMap[key] || key;
+    acc[aiKey] = {
       title: info.meta?.title || info.name,
       board: info.Board,
-      state: useBotGame(info.Game, botMoves[key], (res) => handleGameEnd(res, key)),
+      state: useBotGame(
+        info.Game,
+        (G, player, gameObj) => getBotMove(aiKey, G, player, gameObj),
+        (res) => handleGameEnd(res, aiKey)
+      ),
     };
     return acc;
   }, {});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -18,7 +18,6 @@ import { useGameLimit } from '../contexts/GameLimitContext';
 import { useChats } from '../contexts/ChatContext';
 import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
-import { bots as botMoves } from '../ai/botMoves';
 import { getRandomBot } from '../ai/bots';
 import ProgressBar from '../components/ProgressBar';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
@@ -81,9 +80,10 @@ const HomeScreen = ({ navigation }) => {
       navigation.navigate('Play');
     } else if (playTarget === 'ai') {
       const bot = getRandomBot();
+      const aiKeyMap = { rockPaperScissors: 'rps' };
       const aiGames = games
-        .filter((g) => Object.keys(botMoves).includes(g.key))
-        .reduce((m, g) => ({ ...m, [g.id]: g.key }), {});
+        .filter((g) => g.key && gameRegistry[g.key])
+        .reduce((m, g) => ({ ...m, [g.id]: aiKeyMap[g.key] || g.key }), {});
       const gameKey = aiGames[game.id];
       navigation.navigate('GameWithBot', {
         botId: bot.id,


### PR DESCRIPTION
## Summary
- update GameSessionScreen to build bot game map from all games
- update HomeScreen to allow bots on every game

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860ee0738fc832daafdf866d7789550