### PR TITLE
Remove extra onboarding navigator

### DIFF
--- a/navigation/OnboardingStack.js
+++ b/navigation/OnboardingStack.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import OnboardingScreen from '../screens/OnboardingScreen';
-import AppStack from './AppStack';
 
 const Stack = createNativeStackNavigator();
 
@@ -10,7 +9,6 @@ export default function OnboardingStack() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Onboarding" component={OnboardingScreen} />
-      <Stack.Screen name="Main" component={AppStack} />
     </Stack.Navigator>
   );
 }

--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -8,7 +8,7 @@ import { useOnboarding } from '../contexts/OnboardingContext';
 import SplashScreen from '../screens/SplashScreen';
 import AuthStack from './AuthStack';
 import AppStack from './AppStack';
-import OnboardingStack from './OnboardingStack';
+import OnboardingScreen from '../screens/OnboardingScreen';
 
 
 const splashDuration = 2000;
@@ -50,7 +50,7 @@ export default function RootNavigator() {
   }
 
   if (!onboarded) {
-    return <OnboardingStack />;
+    return <OnboardingScreen />;
   }
 
   return <AppStack />;


### PR DESCRIPTION
## Summary
- delete unused `Main` screen from onboarding stack
- show `OnboardingScreen` directly in `RootNavigator` when the user hasn't onboarded

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686158649dd8832d980cb4717e47b6b2