### PR TITLE
Fix logout navigation flow

### DIFF
--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -17,7 +17,8 @@ const SettingsScreen = ({ navigation }) => {
   const handleEditProfile = () => navigation.navigate('Profile', { editMode: true });
   const handleLogout = async () => {
     await auth.signOut();
-    navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+    // RootNavigator will detect the auth change and present the AuthStack
+    // so no manual navigation reset is required here.
   };
   const handleGoPremium = () => navigation.navigate('Premium', { context: 'paywall' });
 


### PR DESCRIPTION
## Summary
- remove redundant navigation reset in `handleLogout`

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861586a4c9c832d8bf5d87f68f58925