### PR TITLE
Refactor games for ctx.random and new hooks

### DIFF
--- a/docs/bot-heuristics.md
+++ b/docs/bot-heuristics.md
@@ -1,0 +1,18 @@
+# Bot Heuristics
+
+The current bots mostly make random moves. Here are some simple strategies that could improve play quality:
+
+## Checkers
+- Prioritize capturing moves whenever available.
+- Avoid leaving pieces vulnerable to immediate capture.
+- King pieces should move toward opponent pieces to maintain pressure.
+
+## Battleship
+- After a hit, target surrounding cells to sink the ship.
+- Track previous misses to avoid firing at the same location twice.
+- Prefer shots that maximize coverage of remaining spaces.
+
+## Connect Four
+- First look for winning drops for yourself, then block your opponent's winning moves.
+- Favor center columns to create multiple connection opportunities.
+- When forced to choose randomly, pick columns that keep options open rather than the edges.

--- a/games/battleship.js
+++ b/games/battleship.js
@@ -1,19 +1,24 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const SIZE = 5;
 const SHIPS = [3, 2];
 
-function placeShips() {
+function placeShips(random) {
   const board = Array(SIZE * SIZE).fill(0);
   for (const len of SHIPS) {
     let placed = false;
     while (!placed) {
-      const vertical = Math.random() < 0.5;
-      const row = Math.floor(Math.random() * (vertical ? SIZE - len + 1 : SIZE));
-      const col = Math.floor(Math.random() * (vertical ? SIZE : SIZE - len + 1));
+      const vertical = random.Shuffle([true, false])[0];
+      const row = random.Shuffle(
+        [...Array(vertical ? SIZE - len + 1 : SIZE).keys()]
+      )[0];
+      const col = random.Shuffle(
+        [...Array(vertical ? SIZE : SIZE - len + 1).keys()]
+      )[0];
       let canPlace = true;
       for (let i = 0; i < len; i++) {
         const r = row + (vertical ? i : 0);
@@ -37,8 +42,8 @@ function placeShips() {
 }
 
 const BattleshipGame = {
-  setup: () => ({
-    boards: [placeShips(), placeShips()],
+  setup: (ctx) => ({
+    boards: [placeShips(ctx.random), placeShips(ctx.random)],
     hits: [Array(SIZE * SIZE).fill(null), Array(SIZE * SIZE).fill(null)],
   }),
   turn: { moveLimit: 1 },
@@ -101,13 +106,7 @@ const OwnCell = ({ ship, hit }) => {
 };
 
 const BattleshipBoard = ({ G, ctx, moves, playerID, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const player = Number(playerID || '0');
   const opponent = 1 - player;

--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -1,16 +1,17 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
-function createDeck() {
+function createDeck(random) {
   const values = [2,3,4,5,6,7,8,9,10,10,10,10,11];
   const deck = [];
   for (let i = 0; i < 4; i++) {
     deck.push(...values);
   }
   for (let i = deck.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = random.Shuffle([...Array(i + 1).keys()])[0];
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
   return deck;
@@ -21,8 +22,8 @@ function handValue(hand) {
 }
 
 const BlackjackGame = {
-  setup: () => {
-    const deck = createDeck();
+  setup: (ctx) => {
+    const deck = createDeck(ctx.random);
     return {
       deck,
       hands: [ [deck.pop(), deck.pop()], [deck.pop(), deck.pop()] ],
@@ -63,13 +64,7 @@ const BlackjackGame = {
 };
 
 const BlackjackBoard = ({ G, ctx, moves, playerID, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const me = Number(playerID || '0');
   const opponent = 1 - me;

--- a/games/checkers.js
+++ b/games/checkers.js
@@ -1,7 +1,8 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const SIZE = 8;
 
@@ -117,13 +118,7 @@ const Square = ({ dark, piece, selected, onPress }) => {
 
 const CheckersBoard = ({ G, ctx, moves, onGameEnd }) => {
   const [selected, setSelected] = useState(null);
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const handlePress = (idx) => {
     const piece = G.board[idx];

--- a/games/coin-toss.js
+++ b/games/coin-toss.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const CoinTossGame = {
   setup: () => ({ choice: null, result: null }),
@@ -10,7 +11,7 @@ const CoinTossGame = {
     choose: ({ G }, guess) => {
       if (G.choice) return INVALID_MOVE;
       G.choice = guess;
-      G.result = Math.random() < 0.5 ? 'Heads' : 'Tails';
+      G.result = ctx.random.D2() === 1 ? 'Heads' : 'Tails';
     },
   },
   endIf: ({ G }) => {
@@ -21,13 +22,7 @@ const CoinTossGame = {
 };
 
 const CoinTossBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!G.choice;
 

--- a/games/connect-four.js
+++ b/games/connect-four.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const ROWS = 6;
 const COLS = 7;
@@ -75,13 +76,7 @@ const Cell = ({ value }) => {
 };
 
 const ConnectFourBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endedRef = React.useRef(false);
-  React.useEffect(() => {
-    if (ctx.gameover && !endedRef.current) {
-      endedRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!ctx.gameover;
 

--- a/games/dominoes.js
+++ b/games/dominoes.js
@@ -1,9 +1,10 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
-function initTiles() {
+function initTiles(random) {
   const tiles = [];
   for (let i = 0; i <= 6; i++) {
     for (let j = i; j <= 6; j++) {
@@ -11,7 +12,7 @@ function initTiles() {
     }
   }
   for (let i = tiles.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = random.Shuffle([...Array(i + 1).keys()])[0];
     const tmp = tiles[i];
     tiles[i] = tiles[j];
     tiles[j] = tmp;
@@ -20,8 +21,8 @@ function initTiles() {
 }
 
 const DominoesGame = {
-  setup: () => {
-    const tiles = initTiles();
+  setup: (ctx) => {
+    const tiles = initTiles(ctx.random);
     const hands = {
       '0': tiles.slice(0, 7),
       '1': tiles.slice(7, 14),
@@ -98,13 +99,7 @@ const DominoTile = ({ values, selected, onPress }) => (
 
 const DominoesBoard = ({ G, ctx, moves, onGameEnd }) => {
   const [selected, setSelected] = useState(null);
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const myHand = G.hands[ctx.currentPlayer];
   const disabled = !!ctx.gameover;

--- a/games/flirty-questions.js
+++ b/games/flirty-questions.js
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const QUESTIONS = [
   'What first attracted you to me?',
@@ -30,13 +31,7 @@ const FlirtyGame = {
 };
 
 const FlirtyBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   return (
     <View style={{ alignItems: 'center', padding: 20 }}>

--- a/games/gomoku.js
+++ b/games/gomoku.js
@@ -1,7 +1,8 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const SIZE = 10;
 
@@ -63,13 +64,7 @@ function checkWinner(cells) {
 }
 
 const GomokuBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   return (
     <View style={{ alignItems: 'center' }}>

--- a/games/guess-number.js
+++ b/games/guess-number.js
@@ -1,10 +1,11 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const GuessNumberGame = {
-  setup: () => ({ target: Math.ceil(Math.random() * 100), guesses: [] }),
+  setup: (ctx) => ({ target: ctx.random.D100(), guesses: [] }),
   moves: {
     guess: ({ G }, value) => {
       const num = parseInt(value, 10);
@@ -21,13 +22,7 @@ const GuessNumberGame = {
 
 const GuessNumberBoard = ({ G, ctx, moves, onGameEnd }) => {
   const [input, setInput] = useState('');
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const last = G.guesses[G.guesses.length - 1];
   let hint = '';

--- a/games/hangman.js
+++ b/games/hangman.js
@@ -1,13 +1,15 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const WORDS = ['react', 'native', 'expo', 'javascript', 'hangman'];
 
 const HangmanGame = {
-  setup: () => {
-    const word = WORDS[Math.floor(Math.random() * WORDS.length)].toLowerCase();
+  setup: (ctx) => {
+    const idx = ctx.random.Shuffle([...Array(WORDS.length).keys()])[0];
+    const word = WORDS[idx].toLowerCase();
     return { word, guesses: [], wrong: 0 };
   },
   moves: {
@@ -28,13 +30,7 @@ const HangmanGame = {
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
 const HangmanBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const display = G.word
     .split('')

--- a/games/mancala.js
+++ b/games/mancala.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const PITS = 6;
 const INIT_STONES = 4;
@@ -94,13 +95,7 @@ const Pit = ({ stones, onPress }) => (
 );
 
 const MancalaBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const ended = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !ended.current) {
-      ended.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!ctx.gameover;
 

--- a/games/memory-match.js
+++ b/games/memory-match.js
@@ -1,22 +1,16 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const PAIRS = ['🐶','🐱','🐭','🐹','🐰','🦊','🐻','🐼'];
 const SIZE = 4; // 4x4 grid
 
-function shuffle(arr) {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr;
-}
 
 const MemoryMatchGame = {
-  setup: () => ({
-    deck: shuffle([...PAIRS, ...PAIRS]),
+  setup: (ctx) => ({
+    deck: ctx.random.Shuffle([...PAIRS, ...PAIRS]),
     flipped: Array(16).fill(false),
     matched: Array(16).fill(false),
     selected: [],
@@ -45,13 +39,7 @@ const MemoryMatchGame = {
 };
 
 const MemoryMatchBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   return (
     <View style={{ alignItems: 'center' }}>

--- a/games/minesweeper.js
+++ b/games/minesweeper.js
@@ -1,17 +1,18 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const ROWS = 5;
 const COLS = 5;
 const MINES = 5;
 
-function createBoard() {
+function createBoard(random) {
   const board = Array(ROWS * COLS).fill(0);
   let mines = 0;
   while (mines < MINES) {
-    const idx = Math.floor(Math.random() * board.length);
+    const idx = random.Shuffle([...Array(board.length).keys()])[0];
     if (board[idx] === -1) continue;
     board[idx] = -1;
     mines++;
@@ -37,8 +38,8 @@ function createBoard() {
 }
 
 const MinesweeperGame = {
-  setup: () => ({
-    board: createBoard(),
+  setup: (ctx) => ({
+    board: createBoard(ctx.random),
     revealed: Array(ROWS * COLS).fill(false),
     flagged: Array(ROWS * COLS).fill(false),
   }),
@@ -106,13 +107,7 @@ const Cell = ({ value, revealed, flagged, onReveal, onFlag }) => {
 };
 
 const MinesweeperBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const rows = [];
   for (let r = 0; r < ROWS; r++) {

--- a/games/nim.js
+++ b/games/nim.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const NimGame = {
   setup: () => ({ remaining: 21 }),
@@ -20,13 +21,7 @@ const NimGame = {
 };
 
 const NimBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!ctx.gameover;
 

--- a/games/pig.js
+++ b/games/pig.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const PigGame = {
   setup: () => ({ scores: [0, 0], turnTotal: 0, lastRoll: null }),
@@ -36,13 +37,7 @@ const PigGame = {
 };
 
 const PigBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!ctx.gameover;
   const status = ctx.gameover

--- a/games/rock-paper-scissors.js
+++ b/games/rock-paper-scissors.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const choices = ['Rock', 'Paper', 'Scissors'];
 
@@ -31,14 +32,7 @@ const RPSGame = {
 };
 
 const RPSBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endedRef = React.useRef(false);
-
-  React.useEffect(() => {
-    if (ctx.gameover && !endedRef.current) {
-      endedRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!ctx.gameover;
   const yourChoice = G.moves[0];

--- a/games/sudoku.js
+++ b/games/sudoku.js
@@ -1,7 +1,8 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const puzzle = [
   5,3,0,0,7,0,0,0,0,
@@ -52,13 +53,7 @@ const SudokuGame = {
 };
 
 const SudokuBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endRef = useRef(false);
-  useEffect(() => {
-    if (ctx.gameover && !endRef.current) {
-      endRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const rows = [];
   for (let r = 0; r < 9; r++) {

--- a/games/tic-tac-toe.js
+++ b/games/tic-tac-toe.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
+import useOnGameOver from '../hooks/useOnGameOver';
 
 const lines = [
   [0, 1, 2],
@@ -48,14 +49,7 @@ const TicTacToeGame = {
 };
 
 const TicTacToeBoard = ({ G, ctx, moves, onGameEnd }) => {
-  const endedRef = useRef(false);
-
-  useEffect(() => {
-    if (ctx.gameover && !endedRef.current) {
-      endedRef.current = true;
-      onGameEnd && onGameEnd(ctx.gameover);
-    }
-  }, [ctx.gameover, onGameEnd]);
+  useOnGameOver(ctx.gameover, onGameEnd);
 
   const disabled = !!ctx.gameover;
 

--- a/hooks/useBotGame.js
+++ b/hooks/useBotGame.js
@@ -1,70 +1,29 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import { INVALID_MOVE } from 'boardgame.io/core';
+import { useMemo, useEffect, useState } from 'react';
+import { Client } from 'boardgame.io/client';
 
 export default function useBotGame(game, getBotMove, onGameEnd) {
-  const [G, setG] = useState(game.setup());
-  const [currentPlayer, setCurrentPlayer] = useState('0');
-  const [gameover, setGameover] = useState(null);
-
-  const applyMove = useCallback(
-    (moveName, ...args) => {
-      if (gameover) return;
-      const newG = JSON.parse(JSON.stringify(G));
-      let nextPlayer = currentPlayer;
-      const ctx = {
-        currentPlayer,
-        random: {
-          D6: () => Math.ceil(Math.random() * 6),
+  const client = useMemo(() => {
+    return Client({
+      game,
+      numPlayers: 2,
+      ai: {
+        bot: {
+          play: ({ state }) => getBotMove(state.G, state.ctx.currentPlayer, game),
         },
-        events: {
-          endTurn: () => {
-            nextPlayer = currentPlayer === '0' ? '1' : '0';
-          },
-        },
-      };
-      const move = game.moves[moveName];
-      if (!move) return;
-      const res = move({ G: newG, ctx }, ...args);
-      if (res === INVALID_MOVE) return;
-      if (game.turn?.moveLimit === 1 && nextPlayer === currentPlayer) {
-        nextPlayer = currentPlayer === '0' ? '1' : '0';
-      }
-      const over = game.endIf
-        ? game.endIf({ G: newG, ctx: { currentPlayer: nextPlayer } })
-        : undefined;
-      setG(newG);
-      setCurrentPlayer(nextPlayer);
-      if (over) {
-        setGameover(over);
-        onGameEnd && onGameEnd(over);
-      }
-    },
-    [G, currentPlayer, gameover, onGameEnd, game]
-  );
+      },
+    });
+  }, [game, getBotMove]);
 
-  const moves = useMemo(() => {
-    const m = {};
-    for (const name of Object.keys(game.moves || {})) {
-      m[name] = (...args) => applyMove(name, ...args);
-    }
-    return m;
-  }, [applyMove, game]);
+  const [state, setState] = useState(client.getState());
 
   useEffect(() => {
-    if (currentPlayer === '1' && !gameover) {
-      const action = getBotMove(G, currentPlayer, game);
-      if (action && moves[action.move]) {
-        const t = setTimeout(() => moves[action.move](...(action.args || [])), 600);
-        return () => clearTimeout(t);
-      }
-    }
-  }, [currentPlayer, G, gameover, moves, getBotMove]);
+    client.start();
+    const unsub = client.subscribe(s => {
+      setState(s);
+      if (s.ctx.gameover) onGameEnd && onGameEnd(s.ctx.gameover);
+    });
+    return () => unsub();
+  }, [client, onGameEnd]);
 
-  const reset = () => {
-    setG(game.setup());
-    setCurrentPlayer('0');
-    setGameover(null);
-  };
-
-  return { G, ctx: { currentPlayer, gameover }, moves, reset };
+  return { G: state.G, ctx: state.ctx, moves: client.moves, reset: client.reset };
 }

--- a/hooks/useOnGameOver.js
+++ b/hooks/useOnGameOver.js
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from 'react';
+
+export default function useOnGameOver(gameover, callback) {
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (gameover && !called.current) {
+      called.current = true;
+      callback && callback(gameover);
+    }
+  }, [gameover, callback]);
+}


### PR DESCRIPTION
## Summary
- ensure all board components handle game over via a shared `useOnGameOver` hook
- switch random logic in games to use `ctx.random`
- replace custom bot logic with `Client` based `useBotGame`
- document possible heuristics for improving bots

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861596d1958832dbd88a57ee3525fe3