### PR TITLE
Refactor screens to use GradientBackground

### DIFF
--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -2,14 +2,14 @@
 import React from 'react';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
-import styles from '../styles';
 
-export default function GradientBackground({ children }) {
+
+export default function GradientBackground({ children, style, colors }) {
   const { theme } = useTheme();
-  const colors = [theme.gradientStart, theme.gradientEnd];
+  const gradientColors = colors || [theme.gradientStart, theme.gradientEnd];
 
   return (
-    <LinearGradient colors={colors} style={styles.container}>
+    <LinearGradient colors={gradientColors} style={[{ flex: 1 }, style]}>
       {children}
     </LinearGradient>
   );

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -9,7 +9,7 @@ import {
   Modal,
   SafeAreaView,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import Header from '../components/Header';
@@ -46,12 +46,12 @@ function PrivateChat({ user }) {
 
   if (!user) {
     return (
-      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+      <GradientBackground style={{ flex: 1 }}>
         <Header />
         <Text style={{ marginTop: 80, textAlign: 'center', color: theme.text }}>
           User not found.
         </Text>
-      </LinearGradient>
+      </GradientBackground>
     );
   }
 
@@ -364,7 +364,7 @@ function PrivateChat({ user }) {
   const gradientColors = [theme.gradientStart, theme.gradientEnd];
 
   return (
-    <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
+    <GradientBackground colors={gradientColors} style={{ flex: 1 }}>
       <Header />
       <Modal
         visible={showGameModal}
@@ -392,7 +392,7 @@ function PrivateChat({ user }) {
           </View>
         </SafeKeyboardView>
       </SafeAreaView>
-    </LinearGradient>
+    </GradientBackground>
   );
 }
 
@@ -642,7 +642,7 @@ function GroupChat({ event }) {
   );
 
   return (
-    <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+    <GradientBackground style={{ flex: 1 }}>
       <Header />
       <SafeKeyboardView style={{ flex: 1, paddingTop: 60 }}>
         <Text style={groupStyles.eventTitle}>{event.title}</Text>
@@ -674,7 +674,7 @@ function GroupChat({ event }) {
           </TouchableOpacity>
         </View>
       </SafeKeyboardView>
-    </LinearGradient>
+    </GradientBackground>
   );
 }
 
@@ -788,12 +788,12 @@ export default function ChatScreen({ route }) {
 
   if (!match) {
     return (
-      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+      <GradientBackground style={{ flex: 1 }}>
         <Header />
         <Text style={{ marginTop: 80, textAlign: 'center', color: theme.text }}>
           No match found.
         </Text>
-      </LinearGradient>
+      </GradientBackground>
     );
   }
 

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import Loader from '../components/Loader';
 import SafeKeyboardView from '../components/SafeKeyboardView';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useDev } from '../contexts/DevContext';
@@ -153,10 +153,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   };
 
   return (
-    <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
-      style={styles.swipeScreen}
-    >
+    <GradientBackground style={styles.swipeScreen}>
       <Header showLogoOnly />
       <SafeKeyboardView style={{ flex: 1 }}>
           <Text
@@ -211,7 +208,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             removeClippedSubviews={false}
           />
       </SafeKeyboardView>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -13,7 +13,7 @@ import {
   KeyboardAvoidingView,
   Platform
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useDev } from '../contexts/DevContext';
@@ -164,23 +164,17 @@ const LiveSessionScreen = ({ route, navigation }) => {
 
   if (!game || !opponent) {
     return (
-      <LinearGradient
-        colors={[theme.gradientStart, theme.gradientEnd]}
-        style={styles.swipeScreen}
-      >
+      <GradientBackground style={styles.swipeScreen}>
         <Header showLogoOnly />
         <Text style={{ marginTop: 80, color: theme.text }}>
           Invalid game data.
         </Text>
-      </LinearGradient>
+      </GradientBackground>
     );
   }
 
   return (
-    <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
-      style={styles.swipeScreen}
-    >
+    <GradientBackground style={styles.swipeScreen}>
       <Header showLogoOnly />
 
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -257,7 +251,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
           })
         }
       />
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 
@@ -396,7 +390,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
   };
 
   return (
-      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+      <GradientBackground style={{ flex: 1 }}>
         <Header />
         <KeyboardAvoidingView
           style={{ flex: 1 }}
@@ -487,7 +481,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
         </View>
         </SafeAreaView>
         </KeyboardAvoidingView>
-      </LinearGradient>
+      </GradientBackground>
   );
 }
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -10,7 +10,7 @@ import {
   Modal,
   Image,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
@@ -115,7 +115,7 @@ const HomeScreen = ({ navigation }) => {
   const gradientColors = [theme.gradientStart, theme.gradientEnd];
 
   return (
-    <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
+    <GradientBackground colors={gradientColors} style={{ flex: 1 }}>
       <SafeAreaView style={{ flex: 1 }}>
         <Header showLogoOnly />
         <ScrollView contentContainerStyle={{ paddingBottom: 100 }}>
@@ -251,7 +251,7 @@ const HomeScreen = ({ navigation }) => {
           </View>
         </Modal>
       </SafeAreaView>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   SafeAreaView,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useChats } from '../contexts/ChatContext';
@@ -54,7 +54,7 @@ const MatchesScreen = ({ navigation }) => {
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+      <GradientBackground style={{ flex: 1 }}>
         <Header />
         <View style={{ flex: 1, paddingTop: 80 }}>
           {newMatches.length > 0 && (
@@ -79,7 +79,7 @@ const MatchesScreen = ({ navigation }) => {
             showsVerticalScrollIndicator={false}
           />
         </View>
-      </LinearGradient>
+      </GradientBackground>
     </SafeAreaView>
   );
 };

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -10,7 +10,7 @@ import {
 import Loader from '../components/Loader';
 import Header from '../components/Header';
 import styles from '../styles';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { useUser } from '../contexts/UserContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -70,10 +70,7 @@ const NotificationsScreen = ({ navigation }) => {
   };
 
   return (
-    <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
-      style={styles.container}
-    >
+    <GradientBackground style={styles.container}>
       <Header navigation={navigation} />
       <ScrollView contentContainerStyle={{ padding: 20, paddingBottom: 120 }}>
         <Text style={[local.title, { color: theme.text }]}>Game Invites</Text>
@@ -119,7 +116,7 @@ const NotificationsScreen = ({ navigation }) => {
           ))
         )}
       </ScrollView>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -9,7 +9,7 @@ import {
   Image,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import { db, auth, firebase } from '../firebase';
 import { uploadAvatarAsync } from '../utils/upload';
@@ -433,7 +433,7 @@ export default function OnboardingScreen() {
     );
   };
   return (
-    <LinearGradient colors={[styles.gradientStart, styles.gradientEnd]} style={styles.container}>
+    <GradientBackground colors={[styles.gradientStart, styles.gradientEnd]} style={styles.container}>
       <SafeKeyboardView style={styles.inner}>
         <Text style={styles.progressText}>{`Step ${step + 1} of ${questions.length}`}</Text>
 
@@ -463,7 +463,7 @@ export default function OnboardingScreen() {
           </TouchableOpacity>
         </View>
       </SafeKeyboardView>
-    </LinearGradient>
+    </GradientBackground>
   );
 }
 

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -9,7 +9,7 @@ import {
   Animated,
   Keyboard
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import styles from '../styles';
 import Header from '../components/Header';
@@ -111,10 +111,7 @@ const PlayScreen = ({ navigation }) => {
   };
 
   return (
-    <LinearGradient
-      colors={gradientColors}
-      style={styles.swipeScreen}
-    >
+    <GradientBackground colors={gradientColors} style={styles.swipeScreen}>
       <Header showLogoOnly />
       <SafeKeyboardView style={{ flex: 1 }}>
 
@@ -160,7 +157,7 @@ const PlayScreen = ({ navigation }) => {
         onStart={handleStartGame}
       />
       </SafeKeyboardView>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   Image
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import * as WebBrowser from 'expo-web-browser';
 import Header from '../components/Header';
 import styles from '../styles';
@@ -53,7 +53,7 @@ const PremiumScreen = ({ navigation, route }) => {
 
   if (context === 'upgrade') {
     return (
-      <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+      <GradientBackground style={{ flex: 1 }}>
         <Header />
         <ScrollView contentContainerStyle={{ paddingTop: 80, paddingBottom: 100 }}>
           <View style={upgradeStyles.container}>
@@ -77,12 +77,12 @@ const PremiumScreen = ({ navigation, route }) => {
             </Text>
           </View>
         </ScrollView>
-      </LinearGradient>
+      </GradientBackground>
     );
   }
 
   return (
-    <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={{ flex: 1 }}>
+    <GradientBackground style={{ flex: 1 }}>
       <Header />
       <View style={paywallStyles.container}>
         <Text style={paywallStyles.title}>Upgrade to Premium</Text>
@@ -105,7 +105,7 @@ const PremiumScreen = ({ navigation, route }) => {
           <Text style={paywallStyles.cancel}>Maybe Later</Text>
         </TouchableOpacity>
       </View>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { Text, TextInput, TouchableOpacity, View, Image } from 'react-native';
 import SafeKeyboardView from '../components/SafeKeyboardView';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import styles from '../styles';
 import Header from '../components/Header';
 import { useUser } from '../contexts/UserContext';
@@ -95,7 +95,7 @@ const ProfileScreen = ({ navigation, route }) => {
   const saveLabel = editMode ? 'Save Changes' : 'Save';
 
   return (
-    <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
+    <GradientBackground colors={gradientColors} style={{ flex: 1 }}>
       <Header />
       <SafeKeyboardView style={[styles.container, { paddingTop: 60 }]}>
       <TouchableOpacity onPress={() => setEditMode(!editMode)} style={{ alignSelf: 'flex-end', marginBottom: 10 }}>
@@ -158,7 +158,7 @@ const ProfileScreen = ({ navigation, route }) => {
         <Text style={styles.btnText}>{saveLabel}</Text>
       </TouchableOpacity>
       </SafeKeyboardView>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import styles from '../styles';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
@@ -22,10 +22,7 @@ const SettingsScreen = ({ navigation }) => {
   const handleGoPremium = () => navigation.navigate('Premium', { context: 'paywall' });
 
   return (
-    <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
-      style={styles.container}
-    >
+    <GradientBackground style={styles.container}>
       <Header />
 
       <Text style={[styles.logoText, { color: theme.text, marginBottom: 10 }]}>
@@ -82,7 +79,7 @@ const SettingsScreen = ({ navigation }) => {
       >
         <Text style={styles.navBtnText}>Log Out</Text>
       </TouchableOpacity>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, Image, StatusBar, Text } from 'react-native';
 import LottieView from 'lottie-react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import styles from '../styles';
 
@@ -31,7 +31,7 @@ export default function SplashScreen({ onFinish }) {
   }, [onFinish]);
 
   return (
-    <LinearGradient colors={colors} style={styles.container}>
+    <GradientBackground colors={colors} style={styles.container}>
       <StatusBar barStyle="light-content" />
       <Animated.View style={{ opacity: fadeAnim, alignItems: 'center' }}>
         <Image source={require('../assets/logo.png')} style={styles.logoImage} />
@@ -44,6 +44,6 @@ export default function SplashScreen({ onFinish }) {
           style={{ width: 200, height: 200, position: 'absolute', bottom: -20 }}
         />
       </Animated.View>
-    </LinearGradient>
+    </GradientBackground>
   );
 }

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Image, TouchableOpacity } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
@@ -96,10 +96,7 @@ const StatsScreen = ({ navigation }) => {
   const streakProgress = Math.min(stats.streak % 7, 7);
 
   return (
-    <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
-      style={{ flex: 1 }}
-    >
+    <GradientBackground style={{ flex: 1 }}>
       <Header showLogoOnly />
       <ScrollView contentContainerStyle={styles.container}>
         {/* Profile Summary */}
@@ -167,7 +164,7 @@ const StatsScreen = ({ navigation }) => {
           </TouchableOpacity>
         )}
       </ScrollView>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -12,7 +12,7 @@ import {
   ToastAndroid,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
-import { LinearGradient } from 'expo-linear-gradient';
+import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNotification } from '../contexts/NotificationContext';
@@ -368,7 +368,7 @@ const SwipeScreen = () => {
     : 0;
 
   return (
-    <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
+    <GradientBackground colors={gradientColors} style={{ flex: 1 }}>
       <Header />
       <View style={styles.container}>
         {displayUser ? (
@@ -485,7 +485,7 @@ const SwipeScreen = () => {
           </Modal>
         )}
       </View>
-    </LinearGradient>
+    </GradientBackground>
   );
 };
 


### PR DESCRIPTION
## Summary
- allow `<GradientBackground>` to accept custom colors and style
- replace manual `<LinearGradient>` containers with `<GradientBackground>` across screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68615a5a5180832da406454e12433255