### PR TITLE
Use aggregated chat counts in stats

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -52,6 +52,7 @@ A copy of each invite is also stored under `users/{uid}/gameInvites/{inviteId}` 
 - `users` (array of string) – exactly two user ids
 - `createdAt` (timestamp)
 - `typing` (map) – per-user typing status
+- `messageCounts` (map) – per-user sent message totals
 
 ### Subcollections
 - **messages** – chat messages between the matched users.

--- a/functions/index.js
+++ b/functions/index.js
@@ -327,6 +327,12 @@ exports.onChatMessageCreated = functions.firestore
     if (!senderId) return null;
 
     try {
+      const matchRef = admin.firestore().collection('matches').doc(matchId);
+      await matchRef.set(
+        { messageCounts: { [senderId]: admin.firestore.FieldValue.increment(1) } },
+        { merge: true }
+      );
+
       const matchSnap = await admin
         .firestore()
         .collection('matches')

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -59,15 +59,10 @@ const StatsScreen = ({ navigation }) => {
         const matches = matchSnap.size;
 
         let messagesSent = 0;
-        for (const matchDoc of matchSnap.docs) {
-          const msgSnap = await db
-            .collection('matches')
-            .doc(matchDoc.id)
-            .collection('messages')
-            .where('senderId', '==', user.uid)
-            .get();
-          messagesSent += msgSnap.size;
-        }
+        matchSnap.forEach((doc) => {
+          const counts = doc.get('messageCounts') || {};
+          messagesSent += counts[user.uid] || 0;
+        });
 
         const userSnap = await db.collection('users').doc(user.uid).get();
         const data = userSnap.data() || {};


### PR DESCRIPTION
## Summary
- increment `messageCounts` when a chat message is created
- read aggregated `messageCounts` in `StatsScreen`
- document new `messageCounts` field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68615bac0ef4832d8e1792be566d9422