### PR TITLE
Query users by location in Firestore

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -16,6 +16,15 @@
         {"fieldPath": "createdAt", "order": "DESCENDING"}
       ]
     }
+    ,
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "location", "order": "ASCENDING"},
+        {"fieldPath": "uid", "order": "ASCENDING"}
+      ]
+    }
   ],
   "fieldOverrides": []
 }

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -117,14 +117,14 @@ const SwipeScreen = () => {
     const fetchUsers = async () => {
       if (!currentUser?.uid) return;
       try {
-        const q = db
+        let userQuery = db
           .collection('users')
           .where('uid', '!=', currentUser.uid);
-        const snap = await q.get();
-        let data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
         if (currentUser.location) {
-          data = data.filter((u) => u.location === currentUser.location);
+          userQuery = userQuery.where('location', '==', currentUser.location);
         }
+        const snap = await userQuery.limit(50).get();
+        let data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
         if (devMode) {
           data = [
             {


### PR DESCRIPTION
## Summary
- filter `users` by `location` directly in Firestore and limit results
- add composite index for `users` queries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68615bae22f4832d989e98ff9c5e7681