### PR TITLE
Add rules for voice message storage

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -4,5 +4,8 @@ service firebase.storage {
     match /avatars/{userId}/{allPaths=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+    match /voiceMessages/{userId}/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow each user to read/write files under their own `voiceMessages` folder in Firebase Storage

## Testing
- `firebase deploy --only storage` *(fails: `firebase` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615bb04e8c832d98877a82e25c2ac5