### PR TITLE
Ensure match document exists for game opponents

### DIFF
--- a/contexts/MatchmakingContext.js
+++ b/contexts/MatchmakingContext.js
@@ -3,6 +3,7 @@ import { db, firebase } from '../firebase';
 import { useUser } from './UserContext';
 import { useListeners } from './ListenerContext';
 import { snapshotExists } from '../utils/firestore';
+import { createMatchIfMissing } from '../utils/matches';
 
 const MatchmakingContext = createContext();
 
@@ -102,6 +103,8 @@ export const MatchmakingProvider = ({ children }) => {
     } catch (e) {
       console.warn('Failed to update invite status', e);
     }
+
+    await createMatchIfMissing(user.uid, data.from === user.uid ? data.to : data.from);
   };
 
   const cancelGameInvite = async (id) => {

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -26,6 +26,7 @@ import SyncedGame from '../components/SyncedGame';
 import GameOverModal from '../components/GameOverModal';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { snapshotExists } from '../utils/firestore';
+import { createMatchIfMissing } from '../utils/matches';
 import Toast from 'react-native-toast-message';
 import { bots, getRandomBot } from "../ai/bots";
 import { generateReply } from "../ai/chatBot";
@@ -101,6 +102,9 @@ const LiveSessionScreen = ({ route, navigation }) => {
       }
       setShowGame(true);
       recordGamePlayed();
+      if (opponent?.id && user?.uid) {
+        await createMatchIfMissing(user.uid, opponent.id);
+      }
       if (inviteId && user?.uid) {
         const ref = db.collection('gameInvites').doc(inviteId);
         const snap = await ref.get();

--- a/utils/matches.js
+++ b/utils/matches.js
@@ -1,0 +1,22 @@
+import { db, firebase } from '../firebase';
+
+export async function createMatchIfMissing(uid, otherUid) {
+  if (!uid || !otherUid) return null;
+  try {
+    const q = await db
+      .collection('matches')
+      .where('users', 'array-contains', uid)
+      .get();
+    const exists = q.docs.some((d) => (d.data().users || []).includes(otherUid));
+    if (!exists) {
+      const ref = await db.collection('matches').add({
+        users: [uid, otherUid],
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      });
+      return ref.id;
+    }
+  } catch (e) {
+    console.warn('Failed to ensure match document', e);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add utility to create matches if missing
- create match document when accepting a game invite
- ensure match is created on session start

## Testing
- `node -e "require('./utils/matches.js'); console.log('ok');"` *(fails: Cannot find module '/workspace/Pinged/firebase')*

------
https://chatgpt.com/codex/tasks/task_e_68615ccc7e80832db65a1f45081ed6a7