### PR TITLE
Refactor card views with reusable component

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+
+const Card = ({ children, style, onPress, ...rest }) => {
+  const Container = onPress ? TouchableOpacity : View;
+  return (
+    <Container style={[styles.card, style]} onPress={onPress} {...rest}>
+      {children}
+    </Container>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3,
+  },
+});
+
+export default Card;

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -12,6 +12,7 @@ import {
   Dimensions
 } from 'react-native';
 import GradientButton from '../components/GradientButton';
+import Card from '../components/Card';
 import { eventImageSource } from '../utils/avatar';
 import Header from '../components/Header';
 import styles from '../styles';
@@ -79,7 +80,7 @@ const CommunityScreen = () => {
   const renderEventCard = (event, idx) => {
     const isJoined = joinedEvents.includes(event.id);
     return (
-      <View
+      <Card
         key={event.id}
         style={[
           local.card,
@@ -108,7 +109,7 @@ const CommunityScreen = () => {
           onPress={() => toggleJoin(event.id)}
           marginVertical={8}
         />
-      </View>
+      </Card>
     );
   };
 
@@ -138,11 +139,11 @@ const CommunityScreen = () => {
         </ScrollView>
 
         {/* Featured */}
-        <View style={[local.banner, { backgroundColor: darkMode ? '#333' : '#fff' }]}>
+        <Card style={[local.banner, { backgroundColor: darkMode ? '#333' : '#fff' }]}>
           <Image source={eventImageSource(require('../assets/user2.jpg'))} style={local.bannerImage} />
           <Text style={local.bannerTitle}>🔥 Featured</Text>
           <Text style={local.bannerText}>Truth or Dare Night — Friday @ 9PM</Text>
-        </View>
+        </Card>
 
         {/* Event grid */}
         <View style={local.grid}>
@@ -169,11 +170,11 @@ const CommunityScreen = () => {
 
         {/* Posts */}
         {posts.map((p) => (
-          <View key={p.id} style={[local.postCard, { backgroundColor: darkMode ? '#444' : '#fff' }]}>
+          <Card key={p.id} style={[local.postCard, { backgroundColor: darkMode ? '#444' : '#fff' }]}>
             <Text style={local.postTitle}>{p.title}</Text>
             <Text style={local.postTime}>{p.time}</Text>
             <Text style={local.postDesc}>{p.description}</Text>
-          </View>
+          </Card>
         ))}
 
         {/* First Join Badge */}
@@ -304,7 +305,7 @@ const local = StyleSheet.create({
     borderRadius: 16,
     padding: 16,
     marginBottom: 20,
-    elevation: 3
+    
   },
   bannerImage: {
     width: '100%',
@@ -332,7 +333,7 @@ const local = StyleSheet.create({
     borderRadius: 16,
     marginBottom: 20,
     padding: 12,
-    elevation: 3
+    
   },
   image: {
     width: '100%',
@@ -390,11 +391,7 @@ const local = StyleSheet.create({
     padding: 14,
     marginHorizontal: 16,
     marginBottom: 12,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 3,
-    elevation: 2
+    
   },
   postTitle: {
     fontSize: 15,

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import Loader from '../components/Loader';
 import SafeKeyboardView from '../components/SafeKeyboardView';
+import Card from '../components/Card';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
@@ -100,7 +101,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     const isLoading = loadingId === item.id;
 
     return (
-      <View
+      <Card
         style={{
           backgroundColor: theme.card,
           borderRadius: 16,
@@ -108,11 +109,7 @@ const GameInviteScreen = ({ route, navigation }) => {
           borderColor: darkMode ? '#333' : '#eee',
           padding: 12,
           margin: 8,
-          width: CARD_WIDTH,
-          shadowColor: '#000',
-          shadowOpacity: 0.06,
-          shadowRadius: 4,
-          elevation: 3
+          width: CARD_WIDTH
         }}
       >
         <View style={{ alignItems: 'center' }}>
@@ -154,7 +151,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             </TouchableOpacity>
           )}
         </View>
-      </View>
+      </Card>
     );
   };
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -20,6 +20,7 @@ import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
 import { getRandomBot } from '../ai/bots';
 import ProgressBar from '../components/ProgressBar';
+import Card from '../components/Card';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { eventImageSource } from '../utils/avatar';
 
@@ -118,12 +119,12 @@ const HomeScreen = ({ navigation }) => {
         <ScrollView contentContainerStyle={{ paddingBottom: 100 }}>
           <Text style={[local.welcome, { color: theme.text }]}>\
 {`Welcome${user?.displayName ? `, ${user.displayName}` : ''}!`}</Text>
-          <View style={[local.progressCard, { backgroundColor: theme.card }]}>
+          <Card style={[local.progressCard, { backgroundColor: theme.card }]}>
             <Text style={[local.levelText, { color: theme.text }]}>{`Level ${level}`}</Text>
             <ProgressBar value={xpProgress} max={100} color={theme.accent} />
             <Text style={[local.streakLabel, { color: theme.textSecondary }]}>{`${user?.streak || 0} day streak`}</Text>
-          <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
-        </View>
+            <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
+          </Card>
 
         <Text style={local.section}>Shortcuts</Text>
         <FlatList
@@ -133,13 +134,13 @@ const HomeScreen = ({ navigation }) => {
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={local.carousel}
           renderItem={({ item }) => (
-            <TouchableOpacity
-              style={[local.tile, { backgroundColor: theme.card }]}
+            <Card
               onPress={() => handleShortcut(item.key)}
+              style={[local.tile, { backgroundColor: theme.card }]}
             >
               <Text style={local.tileEmoji}>{item.emoji}</Text>
               <Text style={[local.tileText, { color: theme.text }]}>{item.title}</Text>
-            </TouchableOpacity>
+            </Card>
           )}
         />
 
@@ -151,13 +152,13 @@ const HomeScreen = ({ navigation }) => {
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={local.carousel}
             renderItem={({ item }) => (
-              <TouchableOpacity
-                style={[local.tile, { backgroundColor: theme.card }]}
+              <Card
                 onPress={() => openGamePicker(item.key)}
+                style={[local.tile, { backgroundColor: theme.card }]}
               >
                 <Text style={local.tileEmoji}>{item.emoji}</Text>
                 <Text style={[local.tileText, { color: theme.text }]}>{item.title}</Text>
-              </TouchableOpacity>
+              </Card>
             )}
           />
 
@@ -169,13 +170,13 @@ const HomeScreen = ({ navigation }) => {
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={local.carousel}
             renderItem={({ item }) => (
-              <TouchableOpacity
-                style={[local.matchTile, { backgroundColor: theme.card }]}
+              <Card
                 onPress={() => navigation.navigate('Chat', { user: item })}
+                style={[local.matchTile, { backgroundColor: theme.card }]}
               >
                 <Image source={item.image} style={local.matchAvatar} />
                 <Text style={[local.matchName, { color: theme.text }]}>{item.name}</Text>
-              </TouchableOpacity>
+              </Card>
             )}
           />
 
@@ -187,22 +188,22 @@ const HomeScreen = ({ navigation }) => {
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={[local.carousel, { paddingBottom: 20 }]}
             renderItem={({ item }) => (
-              <TouchableOpacity
-                style={[local.gameTile, { backgroundColor: theme.card }]}
+              <Card
                 onPress={() => {
                   setPlayTarget('match');
                   selectGame(item);
                 }}
+                style={[local.gameTile, { backgroundColor: theme.card }]}
               >
                 <View style={{ marginBottom: 8 }}>{item.icon}</View>
                 <Text style={[local.gameTitle, { color: theme.text }]}>{item.title}</Text>
-              </TouchableOpacity>
+              </Card>
             )}
           />
 
           <Text style={local.section}>Community</Text>
           {SAMPLE_EVENTS.map((event) => (
-            <View
+            <Card
               key={`e-${event.id}`}
               style={[local.eventCard, { backgroundColor: theme.card }]}
             >
@@ -214,17 +215,17 @@ const HomeScreen = ({ navigation }) => {
                   {event.description}
                 </Text>
               </View>
-            </View>
+            </Card>
           ))}
           {SAMPLE_POSTS.map((post) => (
-            <View
+            <Card
               key={`p-${post.id}`}
               style={[local.postCardPreview, { backgroundColor: theme.card }]}
             >
               <Text style={[local.postTitle, { color: theme.text }]}>{post.title}</Text>
               <Text style={local.postTime}>{post.time}</Text>
               <Text style={[local.postDesc, { color: theme.textSecondary }]}>{post.description}</Text>
-            </View>
+            </Card>
           ))}
         </ScrollView>
 
@@ -268,8 +269,6 @@ const local = StyleSheet.create({
     color: '#ff4081',
   },
   progressCard: {
-    borderRadius: 16,
-    padding: 16,
     marginHorizontal: 16,
     marginBottom: 16,
   },
@@ -290,15 +289,9 @@ const local = StyleSheet.create({
   tile: {
     width: 120,
     height: 100,
-    borderRadius: 16,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3,
   },
   tileEmoji: {
     fontSize: 28,
@@ -311,16 +304,10 @@ const local = StyleSheet.create({
   matchTile: {
     width: 120,
     height: 140,
-    borderRadius: 16,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
     padding: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3,
   },
   matchAvatar: {
     width: 60,
@@ -335,16 +322,10 @@ const local = StyleSheet.create({
   gameTile: {
     width: 120,
     height: 120,
-    borderRadius: 16,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
     padding: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3,
   },
   gameTitle: {
     fontSize: 13,
@@ -378,11 +359,6 @@ const local = StyleSheet.create({
     marginHorizontal: 16,
     marginBottom: 12,
     alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3,
   },
   eventImage: {
     width: 50,
@@ -406,11 +382,6 @@ const local = StyleSheet.create({
     padding: 12,
     marginHorizontal: 16,
     marginBottom: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 2,
   },
   postTitle: {
     fontSize: 14,

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
+import Card from '../components/Card';
 import { useTheme } from '../contexts/ThemeContext';
 import { useChats } from '../contexts/ChatContext';
 
@@ -33,9 +34,9 @@ const MatchesScreen = ({ navigation }) => {
   );
 
   const renderChat = ({ item }) => (
-    <TouchableOpacity
-      style={[styles.chatItem, { backgroundColor: theme.card }]}
+    <Card
       onPress={() => navigation.navigate('Chat', { user: item })}
+      style={[styles.chatItem, { backgroundColor: theme.card }]}
     >
       <Image source={item.image} style={styles.chatAvatar} />
       <View style={{ flex: 1 }}>
@@ -49,7 +50,7 @@ const MatchesScreen = ({ navigation }) => {
           </Text>
         ) : null}
       </View>
-    </TouchableOpacity>
+    </Card>
   );
 
   return (
@@ -119,11 +120,6 @@ const styles = StyleSheet.create({
     padding: 12,
     marginHorizontal: 16,
     borderRadius: 16,
-    shadowColor: '#000',
-    shadowOpacity: 0.05,
-    shadowOffset: { width: 0, height: 1 },
-    shadowRadius: 3,
-    elevation: 2,
   },
   chatAvatar: {
     width: 56,


### PR DESCRIPTION
## Summary
- add `Card` component for common card styling
- refactor Home, Matches, Community and GameInvite screens to use `Card`
- drop duplicate shadow/border styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a25f6948832da0f78d0ec1286c4d