### PR TITLE
Clarify local game flow

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -193,7 +193,9 @@ export const ChatProvider = ({ children }) => {
     );
   };
 
-  const sendGameInvite = (matchId, gameId, from = 'you') => {
+  // Start a local game against the other user. This only updates the local
+  // matches state and does not create an online invite.
+  const startLocalGame = (matchId, gameId, from = 'you') => {
     setMatches((prev) =>
       prev.map((m) =>
         m.id === matchId
@@ -260,7 +262,7 @@ export const ChatProvider = ({ children }) => {
         removeMatch,
         setActiveGame,
         getActiveGame,
-        sendGameInvite,
+        startLocalGame,
         clearGameInvite,
         acceptGameInvite,
         getPendingInvite,

--- a/docs/game-flows.md
+++ b/docs/game-flows.md
@@ -1,0 +1,15 @@
+# Game Flows
+
+Pinged supports two ways to play mini-games with other users:
+
+## Local Games
+
+Local games happen entirely on the current device. When you start a local game from the chat screen the selected match record is updated with a `pendingInvite` object and, once accepted, an `activeGameId`. No Firestore `gameInvites` document is created.
+
+Use local games for quick, in-person play when both players share the same device.
+
+## Online Games
+
+Online games are coordinated through the `MatchmakingContext`. When an online invite is sent a new document is created under the `gameInvites` collection and mirrored in each user's subcollection. Once every player accepts, the game session is launched remotely.
+
+Online games are best when players are on separate devices and need to coordinate over the network.

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -42,7 +42,7 @@ function PrivateChat({ user }) {
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const { devMode } = useDev();
   const requireCredits = useRequireGameCredits();
-  const { setActiveGame, getActiveGame, getPendingInvite } = useChats();
+  const { setActiveGame, getActiveGame, getPendingInvite, startLocalGame } = useChats();
   const { darkMode, theme } = useTheme();
   const { showNotification } = useNotification();
 


### PR DESCRIPTION
## Summary
- rename ChatContext local invite helper to `startLocalGame`
- document difference between local and online game flows
- import updated helper in `ChatScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4dfa5d8832db71a91eeb2a473cc