### PR TITLE
Remove early game start credit calls

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -36,7 +36,7 @@ const HomeScreen = ({ navigation }) => {
   const { user } = useUser();
   const { matches } = useChats();
   const isPremiumUser = !!user?.isPremium;
-  const { gamesLeft, recordGamePlayed } = useGameLimit();
+  const { gamesLeft } = useGameLimit();
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
   const [playTarget, setPlayTarget] = useState('match');
 
@@ -73,9 +73,7 @@ const HomeScreen = ({ navigation }) => {
       return;
     }
     setGamePickerVisible(false);
-    if (playTarget !== 'ai') {
-      recordGamePlayed();
-    }
+    // Record the game once the session begins in GameSessionScreen
     if (playTarget === 'ai') {
       const bot = getRandomBot();
       const aiKeyMap = { rockPaperScissors: 'rps' };

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -38,7 +38,7 @@ const PlayScreen = ({ navigation }) => {
   const gradientColors = [theme.gradientStart, theme.gradientEnd];
   const { user } = useUser();
   const { devMode } = useDev();
-  const { gamesLeft, recordGamePlayed } = useGameLimit();
+  const { gamesLeft } = useGameLimit();
   const isPremiumUser = !!user?.isPremium;
   const requireCredits = useRequireGameCredits();
   const [filter, setFilter] = useState('All');
@@ -90,7 +90,7 @@ const PlayScreen = ({ navigation }) => {
     navigation.navigate('GameInvite', {
       game: { id, title, category, description }
     });
-    recordGamePlayed();
+    // Game play is recorded in GameSessionScreen when the session starts
   };
 
   const renderItem = ({ item }) => {


### PR DESCRIPTION
## Summary
- stop calling `recordGamePlayed` from Home and Play screens
- rely on `GameSessionScreen` countdown handler to record the start

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4f7459c832d8307a7705ac7b0f3