### PR TITLE
Rename sendGameInvite helper

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -193,7 +193,7 @@ export const ChatProvider = ({ children }) => {
     );
   };
 
-  const sendGameInvite = (matchId, gameId, from = 'you') => {
+  const startLocalGame = (matchId, gameId, from = 'you') => {
     setMatches((prev) =>
       prev.map((m) =>
         m.id === matchId
@@ -260,7 +260,7 @@ export const ChatProvider = ({ children }) => {
         removeMatch,
         setActiveGame,
         getActiveGame,
-        sendGameInvite,
+        startLocalGame,
         clearGameInvite,
         acceptGameInvite,
         getPendingInvite,

--- a/docs/game-flows.md
+++ b/docs/game-flows.md
@@ -1,0 +1,11 @@
+# Game Flows
+
+Pinged supports two types of game play between matched users.
+
+## Local Games
+
+Local games are launched directly from the chat screen. When a player selects a game, the `startLocalGame` helper in `ChatContext` stores an invite in the local chat state. Once accepted, the game component is rendered inline in the chat. Local games are not persisted to Firestore and only exist for the current chat session.
+
+## Online Games
+
+Online games rely on Firestore backed invites. Using `useMatchmaking().sendGameInvite` creates a document under `gameInvites` and, once accepted by both players, a `gameSessions` document is created. The session is then played in `GameSessionScreen` and the state is synchronized across devices.


### PR DESCRIPTION
## Summary
- rename the local `sendGameInvite` function in `ChatContext` to `startLocalGame`
- document how local and online games differ

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a551b550832db61624c801d3202c