### PR TITLE
Replace color literals with theme variables

### DIFF
--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -13,7 +13,8 @@ const NEXT_EVENT = {
 
 export default function EventBanner() {
   const navigation = useNavigation();
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
+  const local = getStyles(theme);
 
   return (
     <View
@@ -37,10 +38,11 @@ export default function EventBanner() {
   );
 }
 
-const local = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
     borderRadius: 16,
     marginHorizontal: 16,
     padding: 12,
@@ -63,7 +65,7 @@ const local = StyleSheet.create({
   },
   time: {
     fontSize: 13,
-    color: '#d81b60',
+    color: theme.accent,
     marginTop: 2,
   },
 });

--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Animated, TouchableOpacity, View, Text, Dimensions } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../contexts/ThemeContext';
 
 const CARD_WIDTH = Dimensions.get('window').width * 0.42;
 
 export default function GameCard({ item, scale, onPress, toggleFavorite, isFavorite }) {
+  const { theme } = useTheme();
   return (
     <Animated.View style={{ transform: [{ scale }] }}>
       <TouchableOpacity
@@ -56,7 +58,7 @@ export default function GameCard({ item, scale, onPress, toggleFavorite, isFavor
               position: 'absolute',
               top: 8,
               right: 8,
-              backgroundColor: item.premium ? '#d81b60' : '#aaa',
+              backgroundColor: item.premium ? theme.accent : '#aaa',
               paddingHorizontal: 6,
               paddingVertical: 2,
               borderRadius: 8
@@ -72,7 +74,7 @@ export default function GameCard({ item, scale, onPress, toggleFavorite, isFavor
           <Ionicons
             name="lock-closed"
             size={18}
-            color="#d81b60"
+            color={theme.accent}
             style={{ position: 'absolute', bottom: 8, right: 8 }}
           />
         )}

--- a/components/GameFilters.js
+++ b/components/GameFilters.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View, TextInput, TouchableOpacity, Text, Keyboard } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function GameFilters({ search, setSearch, filter, setFilter, category, setCategory, categories }) {
+  const { theme } = useTheme();
   return (
     <>
       <View
@@ -36,7 +38,7 @@ export default function GameFilters({ search, setSearch, filter, setFilter, cate
               paddingVertical: 4,
               paddingHorizontal: 10,
               borderRadius: 16,
-              backgroundColor: filter === label ? '#d81b60' : '#eee',
+              backgroundColor: filter === label ? theme.accent : '#eee',
               marginHorizontal: 3
             }}
           >
@@ -62,7 +64,7 @@ export default function GameFilters({ search, setSearch, filter, setFilter, cate
               paddingVertical: 3,
               paddingHorizontal: 8,
               borderRadius: 16,
-              backgroundColor: category === cat ? '#ff80ab' : '#eee',
+              backgroundColor: category === cat ? theme.gradientStart : '#eee',
               margin: 2
             }}
           >

--- a/components/GamePreviewModal.js
+++ b/components/GamePreviewModal.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Modal, View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function GamePreviewModal({ visible, game, onStart, onClose }) {
+  const { theme } = useTheme();
   return (
     <Modal animationType="slide" transparent visible={visible} onRequestClose={onClose}>
       <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'flex-end' }}>
@@ -28,7 +30,7 @@ export default function GamePreviewModal({ visible, game, onStart, onClose }) {
             )}
           </View>
           <TouchableOpacity
-            style={{ backgroundColor: game?.route ? '#d81b60' : '#ccc', borderRadius: 10, paddingVertical: 12, alignItems: 'center' }}
+            style={{ backgroundColor: game?.route ? theme.accent : '#ccc', borderRadius: 10, paddingVertical: 12, alignItems: 'center' }}
             disabled={!game?.route}
             onPress={onStart}
           >

--- a/components/GradientButton.js
+++ b/components/GradientButton.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function GradientButton({
   text,
@@ -11,10 +12,11 @@ export default function GradientButton({
   icon,
   style,
 }) {
+  const { theme } = useTheme();
   return (
     <Pressable onPress={onPress} style={{ width, marginVertical }}>
       <LinearGradient
-        colors={['#FF75B5', '#FF9A75']}
+        colors={[theme.gradientStart, theme.gradientEnd]}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 0 }}
         style={[

--- a/components/MultiSelectList.js
+++ b/components/MultiSelectList.js
@@ -20,7 +20,7 @@ export default function MultiSelectList({ options = [], selected = [], onChange,
           <MaterialCommunityIcons
             name={selected.includes(opt.value) ? 'checkbox-marked' : 'checkbox-blank-outline'}
             size={24}
-            color={theme?.accent || '#d81b60'}
+            color={theme?.accent}
           />
           <Text style={styles.label}>{opt.label}</Text>
         </TouchableOpacity>

--- a/components/ProgressBar.js
+++ b/components/ProgressBar.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 
-export default function ProgressBar({ label, value = 0, max = 100, color = '#d81b60' }) {
+export default function ProgressBar({ label, value = 0, max = 100, color }) {
+  const { theme } = useTheme();
   const pct = Math.min(value / max, 1);
   return (
     <View style={{ marginVertical: 4 }}>
@@ -21,7 +23,7 @@ export default function ProgressBar({ label, value = 0, max = 100, color = '#d81
           style={{
             height: '100%',
             width: `${pct * 100}%`,
-            backgroundColor: color,
+            backgroundColor: color || theme.accent,
           }}
         />
       </View>

--- a/games/checkers.js
+++ b/games/checkers.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const SIZE = 8;
@@ -72,8 +73,9 @@ const CheckersGame = {
 };
 
 const Square = ({ dark, piece, selected, onPress }) => {
+  const { theme } = useTheme();
   const bg = dark ? '#b58863' : '#f0d9b5';
-  const color = piece?.startsWith('0') ? '#d81b60' : '#000';
+  const color = piece?.startsWith('0') ? theme.accent : '#000';
   const king = piece?.endsWith('K');
   return (
     <TouchableOpacity

--- a/games/coin-toss.js
+++ b/games/coin-toss.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const CoinTossGame = {
@@ -23,6 +24,7 @@ const CoinTossGame = {
 
 const CoinTossBoard = ({ G, ctx, moves, onGameEnd }) => {
   useOnGameOver(ctx.gameover, onGameEnd);
+  const { theme } = useTheme();
 
   const disabled = !!G.choice;
 
@@ -44,7 +46,7 @@ const CoinTossBoard = ({ G, ctx, moves, onGameEnd }) => {
                 margin: 5,
                 paddingHorizontal: 12,
                 paddingVertical: 8,
-                backgroundColor: '#d81b60',
+                backgroundColor: theme.accent,
                 borderRadius: 6,
               }}
             >

--- a/games/dominoes.js
+++ b/games/dominoes.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 function initTiles(random) {
@@ -100,6 +101,7 @@ const DominoTile = ({ values, selected, onPress }) => (
 const DominoesBoard = ({ G, ctx, moves, onGameEnd }) => {
   const [selected, setSelected] = useState(null);
   useOnGameOver(ctx.gameover, onGameEnd);
+  const { theme } = useTheme();
 
   const myHand = G.hands[ctx.currentPlayer];
   const disabled = !!ctx.gameover;
@@ -146,7 +148,7 @@ const DominoesBoard = ({ G, ctx, moves, onGameEnd }) => {
             }
           }}
           disabled={selected === null || disabled}
-          style={{ marginHorizontal: 6, padding: 6, backgroundColor: '#d81b60', borderRadius: 4 }}
+          style={{ marginHorizontal: 6, padding: 6, backgroundColor: theme.accent, borderRadius: 4 }}
         >
           <Text style={{ color: '#fff' }}>Play Left</Text>
         </TouchableOpacity>
@@ -158,14 +160,14 @@ const DominoesBoard = ({ G, ctx, moves, onGameEnd }) => {
             }
           }}
           disabled={selected === null || disabled}
-          style={{ marginHorizontal: 6, padding: 6, backgroundColor: '#d81b60', borderRadius: 4 }}
+          style={{ marginHorizontal: 6, padding: 6, backgroundColor: theme.accent, borderRadius: 4 }}
         >
           <Text style={{ color: '#fff' }}>Play Right</Text>
         </TouchableOpacity>
         <TouchableOpacity
           onPress={() => moves.drawTile()}
           disabled={disabled || G.drawPile.length === 0}
-          style={{ marginHorizontal: 6, padding: 6, backgroundColor: '#d81b60', borderRadius: 4 }}
+          style={{ marginHorizontal: 6, padding: 6, backgroundColor: theme.accent, borderRadius: 4 }}
         >
           <Text style={{ color: '#fff' }}>Draw</Text>
         </TouchableOpacity>

--- a/games/guess-number.js
+++ b/games/guess-number.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const GuessNumberGame = {
@@ -23,6 +24,7 @@ const GuessNumberGame = {
 const GuessNumberBoard = ({ G, ctx, moves, onGameEnd }) => {
   const [input, setInput] = useState('');
   useOnGameOver(ctx.gameover, onGameEnd);
+  const { theme } = useTheme();
 
   const last = G.guesses[G.guesses.length - 1];
   let hint = '';
@@ -52,7 +54,7 @@ const GuessNumberBoard = ({ G, ctx, moves, onGameEnd }) => {
           moves.guess(input);
           setInput('');
         }}
-        style={{ backgroundColor: '#d81b60', paddingHorizontal: 12, paddingVertical: 8, borderRadius: 6 }}
+        style={{ backgroundColor: theme.accent, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 6 }}
         disabled={!!ctx.gameover}
       >
         <Text style={{ color: '#fff' }}>Guess</Text>

--- a/games/nim.js
+++ b/games/nim.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const NimGame = {
@@ -22,6 +23,7 @@ const NimGame = {
 
 const NimBoard = ({ G, ctx, moves, onGameEnd }) => {
   useOnGameOver(ctx.gameover, onGameEnd);
+  const { theme } = useTheme();
 
   const disabled = !!ctx.gameover;
 
@@ -38,7 +40,7 @@ const NimBoard = ({ G, ctx, moves, onGameEnd }) => {
               margin: 5,
               paddingHorizontal: 12,
               paddingVertical: 8,
-              backgroundColor: '#d81b60',
+              backgroundColor: theme.accent,
               borderRadius: 6,
             }}
           >

--- a/games/pig.js
+++ b/games/pig.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const PigGame = {
@@ -38,6 +39,7 @@ const PigGame = {
 
 const PigBoard = ({ G, ctx, moves, onGameEnd }) => {
   useOnGameOver(ctx.gameover, onGameEnd);
+  const { theme } = useTheme();
 
   const disabled = !!ctx.gameover;
   const status = ctx.gameover
@@ -61,7 +63,7 @@ const PigBoard = ({ G, ctx, moves, onGameEnd }) => {
             marginRight: 10,
             paddingHorizontal: 12,
             paddingVertical: 8,
-            backgroundColor: '#d81b60',
+            backgroundColor: theme.accent,
             borderRadius: 6,
           }}
         >
@@ -73,7 +75,7 @@ const PigBoard = ({ G, ctx, moves, onGameEnd }) => {
           style={{
             paddingHorizontal: 12,
             paddingVertical: 8,
-            backgroundColor: '#d81b60',
+            backgroundColor: theme.accent,
             borderRadius: 6,
           }}
         >

--- a/games/tic-tac-toe.js
+++ b/games/tic-tac-toe.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Client } from 'boardgame.io/react-native';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const lines = [
@@ -50,6 +51,8 @@ const TicTacToeGame = {
 
 const TicTacToeBoard = ({ G, ctx, moves, onGameEnd }) => {
   useOnGameOver(ctx.gameover, onGameEnd);
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
 
   const disabled = !!ctx.gameover;
 
@@ -102,13 +105,14 @@ const TicTacToeBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const styles = StyleSheet.create({
+const getStyles = (theme) =>
+  StyleSheet.create({
   boardContainer: {
     flexDirection: 'column',
     width: BOARD_SIZE,
     height: BOARD_SIZE,
     borderWidth: 2,
-    borderColor: '#d81b60',
+    borderColor: theme.accent,
     borderRadius: 16,
     backgroundColor: '#fff',
     overflow: 'hidden',

--- a/navigation/MainTabs.js
+++ b/navigation/MainTabs.js
@@ -20,9 +20,9 @@ export default function MainTabs() {
 
   return (
     <Tab.Navigator
-      screenOptions={({ route }) => ({
-        headerShown: false,
-        tabBarActiveTintColor: '#FF75B5',
+        screenOptions={({ route }) => ({
+          headerShown: false,
+          tabBarActiveTintColor: theme.gradientStart,
         tabBarInactiveTintColor: '#888',
         tabBarLabelStyle: { fontSize: 12, paddingBottom: 2 },
         tabBarStyle: {

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -44,6 +44,7 @@ function PrivateChat({ user }) {
   const requireCredits = useRequireGameCredits();
   const { setActiveGame, getActiveGame, getPendingInvite } = useChats();
   const { darkMode, theme } = useTheme();
+  const privateStyles = getPrivateStyles(theme);
   const { showNotification } = useNotification();
 
   if (!user) {
@@ -335,7 +336,7 @@ function PrivateChat({ user }) {
           <TouchableOpacity
             onPress={() => setDevPlayer('0')}
             style={{
-              backgroundColor: devPlayer === '0' ? '#d81b60' : '#ccc',
+              backgroundColor: devPlayer === '0' ? theme.accent : '#ccc',
               paddingHorizontal: 10,
               paddingVertical: 6,
               borderRadius: 8,
@@ -347,7 +348,7 @@ function PrivateChat({ user }) {
           <TouchableOpacity
             onPress={() => setDevPlayer('1')}
             style={{
-              backgroundColor: devPlayer === '1' ? '#d81b60' : '#ccc',
+              backgroundColor: devPlayer === '1' ? theme.accent : '#ccc',
               paddingHorizontal: 10,
               paddingVertical: 6,
               borderRadius: 8,
@@ -396,7 +397,8 @@ function PrivateChat({ user }) {
   );
 }
 
-const privateStyles = StyleSheet.create({
+const getPrivateStyles = (theme) =>
+  StyleSheet.create({
   messageBubble: {
     padding: 10,
     borderRadius: 10,
@@ -449,7 +451,7 @@ const privateStyles = StyleSheet.create({
     marginRight: 10,
   },
   sendButton: {
-    backgroundColor: '#ff4081',
+    backgroundColor: theme.accent,
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 20,
@@ -510,6 +512,7 @@ function GroupChat({ event }) {
   const flatListRef = useRef();
   const { theme } = useTheme();
   const { user } = useUser();
+  const groupStyles = getGroupStyles(theme);
 
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
@@ -678,7 +681,8 @@ function GroupChat({ event }) {
   );
 }
 
-const groupStyles = StyleSheet.create({
+const getGroupStyles = (theme) =>
+  StyleSheet.create({
   eventTitle: {
     fontSize: 18,
     fontWeight: 'bold',
@@ -693,7 +697,7 @@ const groupStyles = StyleSheet.create({
     marginBottom: 10,
   },
   userBubble: {
-    backgroundColor: '#d81b60',
+    backgroundColor: theme.accent,
     alignSelf: 'flex-end',
   },
   otherBubble: {
@@ -730,7 +734,7 @@ const groupStyles = StyleSheet.create({
     marginRight: 10,
   },
   sendBtn: {
-    backgroundColor: '#d81b60',
+    backgroundColor: theme.accent,
     borderRadius: 20,
     paddingHorizontal: 16,
     paddingVertical: 8,

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -29,7 +29,8 @@ const cardWidth = (screenWidth - 48) / 2;
 const FILTERS = ['All', 'Tonight', 'Flirty', 'Tournaments'];
 
 const CommunityScreen = () => {
-  const { darkMode } = useTheme();
+  const { darkMode, theme } = useTheme();
+  const local = getStyles(theme);
   const navigation = useNavigation();
   const { user } = useUser();
   const [events, setEvents] = useState([]);
@@ -129,7 +130,7 @@ const CommunityScreen = () => {
               style={[
                 local.filterBtn,
                 {
-                  backgroundColor: f === activeFilter ? '#d81b60' : '#ccc'
+                  backgroundColor: f === activeFilter ? theme.accent : '#ccc'
                 }
               ]}
             >
@@ -237,7 +238,7 @@ const CommunityScreen = () => {
               marginVertical={14}
             />
             <TouchableOpacity onPress={() => setShowHostModal(false)} style={{ marginTop: 10 }}>
-              <Text style={{ color: '#d81b60' }}>Cancel</Text>
+              <Text style={{ color: theme.accent }}>Cancel</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -284,7 +285,7 @@ const CommunityScreen = () => {
               marginVertical={14}
             />
             <TouchableOpacity onPress={() => setShowPostModal(false)} style={{ marginTop: 10 }}>
-              <Text style={{ color: '#d81b60' }}>Cancel</Text>
+              <Text style={{ color: theme.accent }}>Cancel</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -293,7 +294,8 @@ const CommunityScreen = () => {
   );
 };
 
-const local = StyleSheet.create({
+const getStyles = (theme) =>
+  StyleSheet.create({
   header: {
     fontSize: 22,
     fontWeight: 'bold',
@@ -314,7 +316,7 @@ const local = StyleSheet.create({
     marginBottom: 10
   },
   bannerTitle: {
-    color: '#d81b60',
+    color: theme.accent,
     fontWeight: 'bold',
     fontSize: 16
   },
@@ -347,7 +349,7 @@ const local = StyleSheet.create({
   },
   time: {
     fontSize: 12,
-    color: '#d81b60',
+    color: theme.accent,
     marginBottom: 2
   },
   desc: {
@@ -400,7 +402,7 @@ const local = StyleSheet.create({
   },
   postTime: {
     fontSize: 12,
-    color: '#d81b60',
+    color: theme.accent,
     marginBottom: 4
   },
   postDesc: {

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -139,7 +139,7 @@ const GameInviteScreen = ({ route, navigation }) => {
           ) : (
             <TouchableOpacity
               style={{
-                backgroundColor: '#d81b60',
+                backgroundColor: theme.accent,
                 borderRadius: 20,
                 paddingHorizontal: 12,
                 paddingVertical: 6,

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -46,6 +46,7 @@ const GameSessionScreen = ({ route, navigation, sessionType }) => {
 
 const LiveSessionScreen = ({ route, navigation }) => {
   const { darkMode, theme } = useTheme();
+  const local = getStyles(theme);
   const { devMode } = useDev();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const { user, addGameXP } = useUser();
@@ -192,7 +193,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
                   <TouchableOpacity
                     onPress={() => setDevPlayer('0')}
                     style={{
-                      backgroundColor: devPlayer === '0' ? '#d81b60' : '#ccc',
+                      backgroundColor: devPlayer === '0' ? theme.accent : '#ccc',
                       paddingHorizontal: 12,
                       paddingVertical: 6,
                       borderRadius: 10,
@@ -204,7 +205,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
                   <TouchableOpacity
                     onPress={() => setDevPlayer('1')}
                     style={{
-                      backgroundColor: devPlayer === '1' ? '#d81b60' : '#ccc',
+                      backgroundColor: devPlayer === '1' ? theme.accent : '#ccc',
                       paddingHorizontal: 12,
                       paddingVertical: 6,
                       borderRadius: 10,
@@ -262,13 +263,15 @@ const LiveSessionScreen = ({ route, navigation }) => {
 };
 
 
- function BotSessionScreen({ route }) {
+function BotSessionScreen({ route }) {
   const botId = route.params?.botId;
   const initialGame = route.params?.game || 'ticTacToe';
   const [bot, setBot] = useState(
     bots.find((b) => b.id === botId) || getRandomBot()
   );
   const { theme } = useTheme();
+  const botStyles = getBotStyles(theme);
+  const styles = getStyles(theme);
   const [game, setGame] = useState(initialGame);
 
   const aiKeyMap = { rockPaperScissors: 'rps' };
@@ -491,7 +494,8 @@ const LiveSessionScreen = ({ route, navigation }) => {
   );
 }
 
-const botStyles = StyleSheet.create({
+const getBotStyles = (theme) =>
+  StyleSheet.create({
   messageRow: {
     flexDirection: 'row',
     alignItems: 'flex-end',
@@ -537,7 +541,7 @@ const botStyles = StyleSheet.create({
     marginRight: 8,
   },
   sendBtn: {
-    backgroundColor: '#d81b60',
+    backgroundColor: theme.accent,
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 20,
@@ -575,7 +579,7 @@ const botStyles = StyleSheet.create({
   },
   closeBtn: {
     alignSelf: 'flex-end',
-    backgroundColor: '#d81b60',
+    backgroundColor: theme.accent,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 12,
@@ -620,7 +624,8 @@ const botStyles = StyleSheet.create({
   tabText: { fontWeight: 'bold' },
 });
 
-const local = StyleSheet.create({
+const getStyles = (theme) =>
+  StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -39,6 +39,7 @@ const HomeScreen = ({ navigation }) => {
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
   const [playTarget, setPlayTarget] = useState('match');
+  const local = getStyles(theme);
 
   const shortcutActions = [
     { key: 'startChat', title: 'Start Chat', emoji: '💬' },
@@ -243,7 +244,7 @@ const HomeScreen = ({ navigation }) => {
                 </TouchableOpacity>
               ))}
               <TouchableOpacity onPress={() => setGamePickerVisible(false)} style={{ marginTop: 16 }}>
-                <Text style={{ color: '#d81b60' }}>Cancel</Text>
+                <Text style={{ color: theme.accent }}>Cancel</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -253,7 +254,8 @@ const HomeScreen = ({ navigation }) => {
   );
 };
 
-const local = StyleSheet.create({
+const getStyles = (theme) =>
+  StyleSheet.create({
   welcome: {
     fontSize: 18,
     fontWeight: 'bold',
@@ -266,7 +268,7 @@ const local = StyleSheet.create({
     fontWeight: '700',
     marginHorizontal: 16,
     marginBottom: 8,
-    color: '#ff4081',
+    color: theme.accent,
   },
   progressCard: {
     marginHorizontal: 16,
@@ -371,7 +373,7 @@ const local = StyleSheet.create({
   },
   eventTime: {
     fontSize: 12,
-    color: '#d81b60',
+    color: theme.accent,
     marginBottom: 2,
   },
   eventDesc: {
@@ -389,7 +391,7 @@ const local = StyleSheet.create({
   },
   postTime: {
     fontSize: 12,
-    color: '#d81b60',
+    color: theme.accent,
     marginBottom: 2,
   },
   postDesc: {

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -34,6 +34,7 @@ const paywallFeatures = [
 
 const PremiumScreen = ({ navigation, route }) => {
   const { theme } = useTheme();
+  const paywallStyles = getPaywallStyles(theme);
   const context = route?.params?.context || 'paywall';
 
   const startCheckout = async () => {
@@ -155,7 +156,8 @@ const upgradeStyles = StyleSheet.create({
   },
 });
 
-const paywallStyles = StyleSheet.create({
+const getPaywallStyles = (theme) =>
+  StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
@@ -165,7 +167,7 @@ const paywallStyles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#d81b60',
+    color: theme.accent,
   },
   subtitle: {
     fontSize: 14,

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -71,6 +71,7 @@ const computeMatchPercent = (a, b) => {
 
 const SwipeScreen = () => {
   const { theme } = useTheme();
+  const styles = getStyles(theme);
   const navigation = useNavigation();
   const { showNotification } = useNotification();
   const { user: currentUser } = useUser();
@@ -488,7 +489,8 @@ const SwipeScreen = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const getStyles = (theme) =>
+  StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: 80,
@@ -530,7 +532,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginTop: 4,
     fontWeight: 'bold',
-    color: '#d81b60',
+    color: theme.accent,
   },
   bio: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- reference accent and gradient colors from the theme
- update game UIs and screens to use theme.accent
- update navigation colors to use gradient values

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5174074832d9f884c9282187f78