### PR TITLE
Fix random dice call and AppState cleanup

### DIFF
--- a/contexts/PresenceContext.js
+++ b/contexts/PresenceContext.js
@@ -8,6 +8,7 @@ export const PresenceProvider = ({ children }) => {
   useEffect(() => {
     let statusRef;
     let appStateHandler;
+    let appStateSubscription;
     const offline = {
       state: 'offline',
       last_changed: firebase.database.ServerValue.TIMESTAMP,
@@ -33,13 +34,15 @@ export const PresenceProvider = ({ children }) => {
           statusRef.set(offline);
         }
       };
-      AppState.addEventListener('change', appStateHandler);
+      appStateSubscription = AppState.addEventListener('change', appStateHandler);
     };
 
     const unsubscribe = auth.onAuthStateChanged((fbUser) => {
       if (statusRef) {
         statusRef.set(offline);
-        AppState.removeEventListener('change', appStateHandler);
+        if (appStateSubscription?.remove) {
+          appStateSubscription.remove();
+        }
         statusRef = null;
       }
       if (fbUser) setup(fbUser.uid);
@@ -49,7 +52,9 @@ export const PresenceProvider = ({ children }) => {
       unsubscribe();
       if (statusRef) {
         statusRef.set(offline);
-        AppState.removeEventListener('change', appStateHandler);
+        if (appStateSubscription?.remove) {
+          appStateSubscription.remove();
+        }
       }
     };
   }, []);

--- a/games/guess-number.js
+++ b/games/guess-number.js
@@ -6,7 +6,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
 
 const GuessNumberGame = {
-  setup: (ctx) => ({ target: ctx.random.D100(), guesses: [] }),
+  setup: (ctx) => ({ target: ctx.random.Die(100), guesses: [] }),
   moves: {
     guess: ({ G }, value) => {
       const num = parseInt(value, 10);


### PR DESCRIPTION
## Summary
- fix game setup to use `ctx.random.Die(100)`
- remove deprecated `removeEventListener` usage in PresenceContext

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6861df7a7040832dbbff677925d67f05