### PR TITLE
Refactor Header notifications logic

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,29 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
-import { db } from '../firebase';
-import { useUser } from '../contexts/UserContext';
+import useUnreadNotifications from '../hooks/useUnreadNotifications';
 
 const Header = () => {
   const navigation = useNavigation();
   const { darkMode, theme } = useTheme();
-  const { user } = useUser();
-
-  const [notificationCount, setNotificationCount] = useState(0);
-
-  useEffect(() => {
-    if (!user?.uid) return;
-    const q = db
-      .collection('users')
-      .doc(user.uid)
-      .collection('notifications')
-      .where('read', '==', false);
-    const unsub = q.onSnapshot((snap) => {
-      setNotificationCount(snap.size);
-    });
-    return () => unsub();
-  }, [user?.uid]);
+  const notificationCount = useUnreadNotifications();
 
   return (
     <View style={[styles.container, { backgroundColor: theme.headerBackground }]}>

--- a/hooks/useUnreadNotifications.js
+++ b/hooks/useUnreadNotifications.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { db } from '../firebase';
+import { useUser } from '../contexts/UserContext';
+
+export default function useUnreadNotifications() {
+  const { user } = useUser();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!user?.uid) return;
+    const q = db
+      .collection('users')
+      .doc(user.uid)
+      .collection('notifications')
+      .where('read', '==', false);
+    const unsub = q.onSnapshot((snap) => setCount(snap.size));
+    return unsub;
+  }, [user?.uid]);
+
+  return count;
+}


### PR DESCRIPTION
## Summary
- remove firestore listener logic from `Header`
- add `useUnreadNotifications` hook for unread notifications count

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861e617a2a4832d83c013a5b4e4d43c