### PR TITLE
Add useNotificationBanner hook

### DIFF
--- a/components/NotificationCenter.js
+++ b/components/NotificationCenter.js
@@ -1,35 +1,16 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React from 'react';
 import { Animated, Text, StyleSheet, Dimensions, View } from 'react-native';
-import { NotificationContext } from '../contexts/NotificationContext';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
+import useNotificationBanner from '../hooks/useNotificationBanner';
 
 const screenWidth = Dimensions.get('window').width;
 
 const NotificationCenter = ({ color }) => {
-  const { visible, notification } = useContext(NotificationContext);
   const { theme } = useTheme();
-  const slideAnim = useRef(new Animated.Value(-100)).current;
+  const { notification, isVisible, slideAnim } = useNotificationBanner();
 
-  useEffect(() => {
-    if (visible) {
-      Animated.timing(slideAnim, {
-        toValue: 0,
-        duration: 300,
-        useNativeDriver: true
-      }).start(() => {
-        setTimeout(() => {
-          Animated.timing(slideAnim, {
-            toValue: -100,
-            duration: 300,
-            useNativeDriver: true
-          }).start();
-        }, 2500);
-      });
-    }
-  }, [visible]);
-
-  if (!visible || !notification) return null;
+  if (!isVisible) return null;
 
   const bannerColor = color || theme.accent;
 

--- a/hooks/useNotificationBanner.js
+++ b/hooks/useNotificationBanner.js
@@ -1,0 +1,30 @@
+import { useContext, useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+import { NotificationContext } from '../contexts/NotificationContext';
+
+export default function useNotificationBanner() {
+  const { visible, notification } = useContext(NotificationContext);
+  const slideAnim = useRef(new Animated.Value(-100)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(() => {
+        setTimeout(() => {
+          Animated.timing(slideAnim, {
+            toValue: -100,
+            duration: 300,
+            useNativeDriver: true,
+          }).start();
+        }, 2500);
+      });
+    }
+  }, [visible, slideAnim]);
+
+  const isVisible = visible && notification;
+
+  return { notification, isVisible, slideAnim };
+}


### PR DESCRIPTION
## Summary
- extract notification banner visibility and animation logic into `useNotificationBanner`
- simplify `NotificationCenter` component to use the new hook

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861e62d681c832d8959fa01c991bf2b