### PR TITLE
Use GradientButton for unified buttons

### DIFF
--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, Image, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import styles from '../styles';
 import { eventImageSource } from '../utils/avatar';
+import GradientButton from './GradientButton';
 
 const NEXT_EVENT = {
   title: 'Checkers Blitz Tournament',
@@ -28,12 +29,11 @@ export default function EventBanner() {
         <Text style={local.title}>{NEXT_EVENT.title}</Text>
         <Text style={local.time}>{NEXT_EVENT.time}</Text>
       </View>
-      <TouchableOpacity
-        style={[styles.emailBtn, { marginLeft: 10 }]}
+      <GradientButton
+        text="Join Now"
         onPress={() => navigation.navigate('Community')}
-      >
-        <Text style={styles.btnText}>Join Now</Text>
-      </TouchableOpacity>
+        style={{ marginLeft: 10 }}
+      />
     </View>
   );
 }

--- a/components/GamePreviewModal.js
+++ b/components/GamePreviewModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
+import GradientButton from './GradientButton';
 
 export default function GamePreviewModal({ visible, game, onStart, onClose }) {
   const { theme } = useTheme();
@@ -29,15 +30,12 @@ export default function GamePreviewModal({ visible, game, onStart, onClose }) {
               </Text>
             )}
           </View>
-          <TouchableOpacity
-            style={{ backgroundColor: game?.route ? theme.accent : '#ccc', borderRadius: 10, paddingVertical: 12, alignItems: 'center' }}
-            disabled={!game?.route}
+          <GradientButton
+            text={game?.route ? 'Start Game' : 'Coming Soon'}
             onPress={onStart}
-          >
-            <Text style={{ color: '#fff', fontWeight: 'bold' }}>
-              {game?.route ? 'Start Game' : 'Coming Soon'}
-            </Text>
-          </TouchableOpacity>
+            disabled={!game?.route}
+            style={{ borderRadius: 10 }}
+          />
           <TouchableOpacity onPress={onClose} style={{ marginTop: 12 }}>
             <Text style={{ textAlign: 'center', color: '#888' }}>Cancel</Text>
           </TouchableOpacity>

--- a/components/GradientButton.js
+++ b/components/GradientButton.js
@@ -11,10 +11,11 @@ export default function GradientButton({
   marginVertical = 8,
   icon,
   style,
+  disabled,
 }) {
   const { theme } = useTheme();
   return (
-    <Pressable onPress={onPress} style={{ width, marginVertical }}>
+    <Pressable onPress={onPress} style={{ width, marginVertical }} disabled={disabled}>
       <LinearGradient
         colors={[theme.gradientStart, theme.gradientEnd]}
         start={{ x: 0, y: 0 }}
@@ -28,6 +29,7 @@ export default function GradientButton({
             alignItems: 'center',
             justifyContent: 'center',
             elevation: 2,
+            opacity: disabled ? 0.6 : 1,
           },
           style,
         ]}

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -12,6 +12,7 @@ import Loader from '../components/Loader';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import Card from '../components/Card';
 import GradientBackground from '../components/GradientBackground';
+import GradientButton from '../components/GradientButton';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useDev } from '../contexts/DevContext';
@@ -137,18 +138,12 @@ const GameInviteScreen = ({ route, navigation }) => {
               </Text>
             </View>
           ) : (
-            <TouchableOpacity
-              style={{
-                backgroundColor: theme.accent,
-                borderRadius: 20,
-                paddingHorizontal: 12,
-                paddingVertical: 6,
-                marginTop: 6
-              }}
+            <GradientButton
+              text="Invite"
               onPress={() => handleInvite(item)}
-            >
-              <Text style={{ color: '#fff', fontWeight: '600' }}>Invite</Text>
-            </TouchableOpacity>
+              width={120}
+              style={{ marginTop: 6 }}
+            />
           )}
         </View>
       </Card>

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   StyleSheet
 } from 'react-native';
+import GradientButton from '../components/GradientButton';
 import Loader from '../components/Loader';
 import Header from '../components/Header';
 import styles from '../styles';
@@ -90,17 +91,14 @@ const NotificationsScreen = ({ navigation }) => {
                 {inv.fromName ? `${inv.fromName} invited you to play ${games[inv.gameId]?.meta?.title || 'a game'}` : 'Game invite received'}
               </Text>
               <View style={local.actions}>
-                <TouchableOpacity
-                  style={[styles.emailBtn, { marginRight: 10, flexDirection: 'row', justifyContent: 'center' }]}
+                <GradientButton
+                  text={loadingId === inv.id ? '' : 'Accept'}
                   onPress={() => handleAccept(inv)}
+                  width={120}
+                  style={{ marginRight: 10, flexDirection: 'row', justifyContent: 'center' }}
                   disabled={loadingId === inv.id}
-                >
-                  {loadingId === inv.id ? (
-                    <Loader size="small" />
-                  ) : (
-                    <Text style={styles.btnText}>Accept</Text>
-                  )}
-                </TouchableOpacity>
+                  icon={loadingId === inv.id ? <Loader size="small" /> : null}
+                />
                 <TouchableOpacity
                   onPress={() => handleDecline(inv)}
                   disabled={loadingId === inv.id + '_decline'}

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Text, TextInput, TouchableOpacity, View, Image } from 'react-native';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientBackground from '../components/GradientBackground';
+import GradientButton from '../components/GradientButton';
 import styles from '../styles';
 import Header from '../components/Header';
 import { useUser } from '../contexts/UserContext';
@@ -154,9 +155,7 @@ const ProfileScreen = ({ navigation, route }) => {
         value={location}
         onChangeText={setLocation}
       />
-      <TouchableOpacity style={styles.emailBtn} onPress={handleSave}>
-        <Text style={styles.btnText}>{saveLabel}</Text>
-      </TouchableOpacity>
+      <GradientButton text={saveLabel} onPress={handleSave} />
       </SafeKeyboardView>
     </GradientBackground>
   );

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Image, TouchableOpacity } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
+import GradientButton from '../components/GradientButton';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { db } from '../firebase';
@@ -151,12 +152,11 @@ const StatsScreen = ({ navigation }) => {
         </View>
 
         {!isPremium && (
-          <TouchableOpacity
+          <GradientButton
+            text="Upgrade to Premium"
             onPress={() => navigation.navigate('Premium', { context: 'paywall' })}
             style={styles.premiumButton}
-          >
-            <Text style={styles.premiumText}>Upgrade to Premium</Text>
-          </TouchableOpacity>
+          />
         )}
       </ScrollView>
     </GradientBackground>


### PR DESCRIPTION
## Summary
- update GradientButton to support `disabled`
- swap EventBanner CTA button
- use GradientButton for Accept button
- use GradientButton for Save Profile button
- use GradientButton in game invite flow
- upgrade button now uses GradientButton
- use GradientButton in GamePreviewModal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861e64daa98832db58f88ee2a6c1526