### PR TITLE
Add PropTypes to component library

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TextInput } from 'react-native';
+import PropTypes from 'prop-types';
 import SafeKeyboardView from './SafeKeyboardView';
 import GradientButton from './GradientButton';
 import styles from '../styles';
@@ -38,3 +39,13 @@ export default function AuthForm({
     </SafeKeyboardView>
   );
 }
+
+AuthForm.propTypes = {
+  email: PropTypes.string.isRequired,
+  onEmailChange: PropTypes.func.isRequired,
+  password: PropTypes.string.isRequired,
+  onPasswordChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  submitLabel: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};

--- a/components/Card.js
+++ b/components/Card.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 
 const Card = ({ children, style, onPress, ...rest }) => {
   const Container = onPress ? TouchableOpacity : View;
@@ -8,6 +9,12 @@ const Card = ({ children, style, onPress, ...rest }) => {
       {children}
     </Container>
   );
+};
+
+Card.propTypes = {
+  children: PropTypes.node,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  onPress: PropTypes.func,
 };
 
 const styles = StyleSheet.create({

--- a/components/CategoryChips.js
+++ b/components/CategoryChips.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TouchableOpacity, Text } from 'react-native';
+import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 
 export default function CategoryChips({ categories, category, setCategory }) {
@@ -31,3 +32,9 @@ export default function CategoryChips({ categories, category, setCategory }) {
     </View>
   );
 }
+
+CategoryChips.propTypes = {
+  categories: PropTypes.arrayOf(PropTypes.string).isRequired,
+  category: PropTypes.string.isRequired,
+  setCategory: PropTypes.func.isRequired,
+};

--- a/components/DevBanner.js
+++ b/components/DevBanner.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 import { useDev } from '../contexts/DevContext';
 
 export default function DevBanner() {
@@ -11,6 +12,8 @@ export default function DevBanner() {
     </View>
   );
 }
+
+DevBanner.propTypes = {};
 
 const styles = StyleSheet.create({
   banner: {

--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, Image, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import styles from '../styles';
@@ -37,6 +38,8 @@ export default function EventBanner() {
     </View>
   );
 }
+
+EventBanner.propTypes = {};
 
 const getStyles = (theme) =>
   StyleSheet.create({

--- a/components/FavoriteStar.js
+++ b/components/FavoriteStar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
 
 const FavoriteStar = ({ isFavorite, onPress }) => (
   <TouchableOpacity
@@ -14,5 +15,10 @@ const FavoriteStar = ({ isFavorite, onPress }) => (
     />
   </TouchableOpacity>
 );
+
+FavoriteStar.propTypes = {
+  isFavorite: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
 
 export default FavoriteStar;

--- a/components/FilterTabs.js
+++ b/components/FilterTabs.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TouchableOpacity, Text, Keyboard } from 'react-native';
+import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 
 export default function FilterTabs({ filter, setFilter }) {
@@ -35,3 +36,8 @@ export default function FilterTabs({ filter, setFilter }) {
     </View>
   );
 }
+
+FilterTabs.propTypes = {
+  filter: PropTypes.string.isRequired,
+  setFilter: PropTypes.func.isRequired,
+};

--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import GameCardBase from './GameCardBase';
@@ -47,3 +48,10 @@ export default function GameCard({ item, onPress, toggleFavorite, isFavorite }) 
     </GameCardBase>
   );
 }
+
+GameCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  onPress: PropTypes.func.isRequired,
+  toggleFavorite: PropTypes.func.isRequired,
+  isFavorite: PropTypes.bool.isRequired,
+};

--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Animated, TouchableOpacity, Dimensions } from 'react-native';
+import PropTypes from 'prop-types';
 
 const CARD_WIDTH = Dimensions.get('window').width * 0.42;
 
@@ -30,5 +31,13 @@ const GameCardBase = ({ children, scale, onPress, onPressIn, onPressOut }) => (
     </TouchableOpacity>
   </Animated.View>
 );
+
+GameCardBase.propTypes = {
+  children: PropTypes.node.isRequired,
+  scale: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
+  onPress: PropTypes.func,
+  onPressIn: PropTypes.func,
+  onPressOut: PropTypes.func,
+};
 
 export default GameCardBase;

--- a/components/GameFilters.js
+++ b/components/GameFilters.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SearchInput from './SearchInput';
 import FilterTabs from './FilterTabs';
 import CategoryChips from './CategoryChips';
@@ -24,3 +25,13 @@ export default function GameFilters({
     </>
   );
 }
+
+GameFilters.propTypes = {
+  search: PropTypes.string.isRequired,
+  setSearch: PropTypes.func.isRequired,
+  filter: PropTypes.string.isRequired,
+  setFilter: PropTypes.func.isRequired,
+  category: PropTypes.string.isRequired,
+  setCategory: PropTypes.func.isRequired,
+  categories: PropTypes.arrayOf(PropTypes.string).isRequired,
+};

--- a/components/GameOverModal.js
+++ b/components/GameOverModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 
 export default function GameOverModal({ visible, winnerName, onRematch, onChat }) {
   return (
@@ -19,6 +20,13 @@ export default function GameOverModal({ visible, winnerName, onRematch, onChat }
     </Modal>
   );
 }
+
+GameOverModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  winnerName: PropTypes.string,
+  onRematch: PropTypes.func.isRequired,
+  onChat: PropTypes.func.isRequired,
+};
 
 const styles = StyleSheet.create({
   backdrop: {

--- a/components/GamePreviewModal.js
+++ b/components/GamePreviewModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Modal, View, Text, TouchableOpacity } from 'react-native';
+import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 import GradientButton from './GradientButton';
 
@@ -44,3 +45,10 @@ export default function GamePreviewModal({ visible, game, onStart, onClose }) {
     </Modal>
   );
 }
+
+GamePreviewModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  game: PropTypes.object,
+  onStart: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
+import PropTypes from 'prop-types';
 import styles from '../styles';
 
 export default function GradientBackground({ children, colors, style }) {
@@ -14,3 +15,9 @@ export default function GradientBackground({ children, colors, style }) {
     </LinearGradient>
   );
 }
+
+GradientBackground.propTypes = {
+  children: PropTypes.node,
+  colors: PropTypes.arrayOf(PropTypes.string),
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};

--- a/components/GradientButton.js
+++ b/components/GradientButton.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
+import PropTypes from 'prop-types';
 
 export default function GradientButton({
   text,
@@ -42,3 +43,13 @@ export default function GradientButton({
     </Pressable>
   );
 }
+
+GradientButton.propTypes = {
+  text: PropTypes.string.isRequired,
+  onPress: PropTypes.func,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  marginVertical: PropTypes.number,
+  icon: PropTypes.node,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  disabled: PropTypes.bool,
+};

--- a/components/Header.js
+++ b/components/Header.js
@@ -3,6 +3,7 @@ import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import useUnreadNotifications from '../hooks/useUnreadNotifications';
+import PropTypes from 'prop-types';
 
 const Header = () => {
   const navigation = useNavigation();
@@ -42,6 +43,8 @@ const Header = () => {
     </View>
   );
 };
+
+Header.propTypes = {};
 
 const styles = StyleSheet.create({
   container: {

--- a/components/Loader.js
+++ b/components/Loader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import LottieView from 'lottie-react-native';
+import PropTypes from 'prop-types';
 
 export default function Loader({ size = 'large', style }) {
   const dimension = size === 'small' ? 40 : 80;
@@ -12,3 +13,8 @@ export default function Loader({ size = 'large', style }) {
     />
   );
 }
+
+Loader.propTypes = {
+  size: PropTypes.oneOf(['small', 'large']),
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};

--- a/components/MultiSelectList.js
+++ b/components/MultiSelectList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
 
 export default function MultiSelectList({ options = [], selected = [], onChange, theme }) {
   const toggle = (val) => {
@@ -28,6 +29,15 @@ export default function MultiSelectList({ options = [], selected = [], onChange,
     </ScrollView>
   );
 }
+
+MultiSelectList.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({ value: PropTypes.any.isRequired, label: PropTypes.string.isRequired })
+  ),
+  selected: PropTypes.array,
+  onChange: PropTypes.func,
+  theme: PropTypes.object,
+};
 
 const getStyles = (theme) =>
   StyleSheet.create({

--- a/components/NotificationCenter.js
+++ b/components/NotificationCenter.js
@@ -3,6 +3,7 @@ import { Animated, Text, StyleSheet, Dimensions, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import useNotificationBanner from '../hooks/useNotificationBanner';
+import PropTypes from 'prop-types';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -24,6 +25,10 @@ const NotificationCenter = ({ color }) => {
       </View>
     </Animated.View>
   );
+};
+
+NotificationCenter.propTypes = {
+  color: PropTypes.string,
 };
 
 const styles = StyleSheet.create({

--- a/components/PremiumBadge.js
+++ b/components/PremiumBadge.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
 
 const PremiumBadge = ({ premium, route, accent }) => {
   if (route) return null;
@@ -20,6 +21,12 @@ const PremiumBadge = ({ premium, route, accent }) => {
       </Text>
     </View>
   );
+};
+
+PremiumBadge.propTypes = {
+  premium: PropTypes.bool,
+  route: PropTypes.string,
+  accent: PropTypes.string,
 };
 
 export default PremiumBadge;

--- a/components/ProgressBar.js
+++ b/components/ProgressBar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
+import PropTypes from 'prop-types';
 
 export default function ProgressBar({ label, value = 0, max = 100, color }) {
   const { theme } = useTheme();
@@ -30,3 +31,10 @@ export default function ProgressBar({ label, value = 0, max = 100, color }) {
     </View>
   );
 }
+
+ProgressBar.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.number,
+  max: PropTypes.number,
+  color: PropTypes.string,
+};

--- a/components/SafeKeyboardView.js
+++ b/components/SafeKeyboardView.js
@@ -1,5 +1,6 @@
 import { KeyboardAvoidingView, Platform } from 'react-native';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function SafeKeyboardView({ children, style }) {
   return (
@@ -12,3 +13,8 @@ export default function SafeKeyboardView({ children, style }) {
     </KeyboardAvoidingView>
   );
 }
+
+SafeKeyboardView.propTypes = {
+  children: PropTypes.node,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};

--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TextInput } from 'react-native';
+import PropTypes from 'prop-types';
 
 export default function SearchInput({ search, setSearch }) {
   return (
@@ -24,3 +25,8 @@ export default function SearchInput({ search, setSearch }) {
     </View>
   );
 }
+
+SearchInput.propTypes = {
+  search: PropTypes.string.isRequired,
+  setSearch: PropTypes.func.isRequired,
+};

--- a/components/SyncedGame.js
+++ b/components/SyncedGame.js
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import Loader from './Loader';
 import useGameSession from '../hooks/useGameSession';
 import { games } from '../games';
+import PropTypes from 'prop-types';
 
 export default function SyncedGame({ sessionId, gameId, opponentId, onGameEnd }) {
   const { Board } = games[gameId] || {};
@@ -19,3 +20,10 @@ export default function SyncedGame({ sessionId, gameId, opponentId, onGameEnd })
 
   return <Board G={G} ctx={ctx} moves={moves} onGameEnd={onGameEnd} />;
 }
+
+SyncedGame.propTypes = {
+  sessionId: PropTypes.string.isRequired,
+  gameId: PropTypes.string.isRequired,
+  opponentId: PropTypes.string.isRequired,
+  onGameEnd: PropTypes.func.isRequired,
+};

--- a/components/VoiceMessageBubble.js
+++ b/components/VoiceMessageBubble.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import useVoicePlayback from '../hooks/useVoicePlayback';
+import PropTypes from 'prop-types';
 
 export default function VoiceMessageBubble({ message, userName, otherUserId }) {
   const { theme, darkMode } = useTheme();
@@ -44,6 +45,17 @@ export default function VoiceMessageBubble({ message, userName, otherUserId }) {
     </View>
   );
 }
+
+VoiceMessageBubble.propTypes = {
+  message: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    duration: PropTypes.number,
+    sender: PropTypes.string.isRequired,
+    readBy: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }).isRequired,
+  userName: PropTypes.string.isRequired,
+  otherUserId: PropTypes.string.isRequired,
+};
 
 const styles = StyleSheet.create({
   bubble: {


### PR DESCRIPTION
## Summary
- add `prop-types` usage across all components in `/components`
- define prop types and mark required ones

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861eef20b58832db149d4d7a58b8f54