### PR TITLE
Add PropTypes to screen components

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -12,6 +12,7 @@ import {
 import GradientBackground from '../components/GradientBackground';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import PropTypes from 'prop-types';
 import Header from '../components/Header';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import styles from '../styles';
@@ -801,3 +802,16 @@ export default function ChatScreen({ route }) {
 
   return <PrivateChat user={match} />;
 }
+
+ChatScreen.propTypes = {
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      user: PropTypes.shape({
+        id: PropTypes.string,
+        name: PropTypes.string,
+        image: PropTypes.any,
+      }),
+      event: PropTypes.object,
+    }),
+  }).isRequired,
+};

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -18,6 +18,7 @@ import Header from '../components/Header';
 import styles from '../styles';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNavigation } from '@react-navigation/native';
+import PropTypes from 'prop-types';
 import { useUser } from '../contexts/UserContext';
 import { db, firebase } from '../firebase';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
@@ -442,5 +443,7 @@ const getStyles = (theme) =>
     marginBottom: 10
   }
 });
+
+CommunityScreen.propTypes = {};
 
 export default CommunityScreen;

--- a/screens/EmailAuthScreen.js
+++ b/screens/EmailAuthScreen.js
@@ -7,6 +7,7 @@ import { useOnboarding } from '../contexts/OnboardingContext';
 import { snapshotExists } from '../utils/firestore';
 import { isAllowedDomain } from '../utils/email';
 import styles from '../styles';
+import PropTypes from 'prop-types';
 
 export default function EmailAuthScreen({ route, navigation }) {
   const mode = route.params?.mode || (route.name === 'Signup' ? 'signup' : 'login');
@@ -112,3 +113,15 @@ export default function EmailAuthScreen({ route, navigation }) {
     </GradientBackground>
   );
 }
+
+EmailAuthScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      mode: PropTypes.string,
+    }),
+    name: PropTypes.string,
+  }).isRequired,
+};

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -18,6 +18,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useDev } from '../contexts/DevContext';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
+import PropTypes from 'prop-types';
 import styles from '../styles';
 import { useChats } from '../contexts/ChatContext';
 import { useUser } from '../contexts/UserContext';
@@ -208,6 +209,23 @@ const GameInviteScreen = ({ route, navigation }) => {
       </SafeKeyboardView>
     </GradientBackground>
   );
+};
+
+GameInviteScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      game: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({
+          id: PropTypes.string,
+          title: PropTypes.string,
+        }),
+      ]),
+    }),
+  }),
 };
 
 export default GameInviteScreen;

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -34,6 +34,7 @@ import useBotGame from "../hooks/useBotGame";
 import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import PropTypes from 'prop-types';
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
   const type = sessionType || route.params?.sessionType || (route.params?.botId ? "bot" : "live");
   return type === "bot" ? (
@@ -636,5 +637,22 @@ const getStyles = (theme) =>
     fontWeight: 'bold',
   },
 });
+
+GameSessionScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      sessionType: PropTypes.string,
+      botId: PropTypes.string,
+      game: PropTypes.string,
+      opponent: PropTypes.object,
+      status: PropTypes.string,
+      inviteId: PropTypes.string,
+    }),
+  }).isRequired,
+  sessionType: PropTypes.string,
+};
 
 export default GameSessionScreen;

--- a/screens/GameWithBotScreen.js
+++ b/screens/GameWithBotScreen.js
@@ -1,6 +1,14 @@
 import React from 'react';
 import GameSessionScreen from './GameSessionScreen';
+import PropTypes from 'prop-types';
 
 export default function GameWithBotScreen(props) {
   return <GameSessionScreen {...props} sessionType="bot" />;
 }
+
+GameWithBotScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func,
+  }),
+  route: PropTypes.object,
+};

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -18,6 +18,7 @@ import { useGameLimit } from '../contexts/GameLimitContext';
 import { useChats } from '../contexts/ChatContext';
 import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
+import PropTypes from 'prop-types';
 import { getRandomBot } from '../ai/bots';
 import ProgressBar from '../components/ProgressBar';
 import Card from '../components/Card';
@@ -248,6 +249,12 @@ const HomeScreen = ({ navigation }) => {
       </SafeAreaView>
     </GradientBackground>
   );
+};
+
+HomeScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 const getStyles = (theme) =>

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -13,6 +13,7 @@ import Header from '../components/Header';
 import Card from '../components/Card';
 import { useTheme } from '../contexts/ThemeContext';
 import { useChats } from '../contexts/ChatContext';
+import PropTypes from 'prop-types';
 
 const MatchesScreen = ({ navigation }) => {
   const { darkMode, theme } = useTheme();
@@ -136,5 +137,11 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
 });
+
+MatchesScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+};
 
 export default MatchesScreen;

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -17,6 +17,7 @@ import { useUser } from '../contexts/UserContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { db } from '../firebase';
 import { games } from '../games';
+import PropTypes from 'prop-types';
 
 const NotificationsScreen = ({ navigation }) => {
   const { incomingInvites, acceptGameInvite, cancelGameInvite } = useMatchmaking();
@@ -147,5 +148,11 @@ const local = StyleSheet.create({
     marginTop: 40
   }
 });
+
+NotificationsScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+};
 
 export default NotificationsScreen;

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -13,6 +13,7 @@ import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import { db, auth, firebase } from '../firebase';
 import { uploadAvatarAsync } from '../utils/upload';
+import PropTypes from 'prop-types';
 import { sanitizeText } from '../utils/sanitize';
 import { snapshotExists } from '../utils/firestore';
 import { useUser } from '../contexts/UserContext';
@@ -582,3 +583,5 @@ const getStyles = (theme) => {
     gradientEnd: theme.gradientEnd,
   });
 };
+
+OnboardingScreen.propTypes = {};

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -18,6 +18,7 @@ import GameCard from '../components/GameCard';
 import GamePreviewModal from '../components/GamePreviewModal';
 import GameFilters from '../components/GameFilters';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import PropTypes from 'prop-types';
 
 
 const getAllCategories = () => {
@@ -147,6 +148,12 @@ const PlayScreen = ({ navigation }) => {
       </SafeKeyboardView>
     </GradientBackground>
   );
+};
+
+PlayScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default PlayScreen;

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -16,6 +16,7 @@ import styles from '../styles';
 import { useTheme } from '../contexts/ThemeContext';
 import { functions } from '../firebase';
 import { httpsCallable } from 'firebase/functions';
+import PropTypes from 'prop-types';
 
 const upgradeFeatures = [
   { icon: require('../assets/icons/unlimited.png'), text: 'Unlimited Game Invites' },
@@ -197,5 +198,16 @@ const getPaywallStyles = (theme) =>
     color: '#888',
   },
 });
+
+PremiumScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      context: PropTypes.string,
+    }),
+  }),
+};
 
 export default PremiumScreen;

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -14,6 +14,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { uploadAvatarAsync } from '../utils/upload';
 import { avatarSource } from '../utils/avatar';
 import { sanitizeText } from '../utils/sanitize';
+import PropTypes from 'prop-types';
 
 const ProfileScreen = ({ navigation, route }) => {
   const { user, updateUser } = useUser();
@@ -159,6 +160,17 @@ const ProfileScreen = ({ navigation, route }) => {
       </SafeKeyboardView>
     </GradientBackground>
   );
+};
+
+ProfileScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      editMode: PropTypes.bool,
+    }),
+  }),
 };
 
 export default ProfileScreen;

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -8,6 +8,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
 import { auth } from '../firebase';
+import PropTypes from 'prop-types';
 
 const SettingsScreen = ({ navigation }) => {
   const { darkMode, toggleTheme, theme } = useTheme();
@@ -68,6 +69,12 @@ const SettingsScreen = ({ navigation }) => {
       <GradientButton text="Log Out" onPress={handleLogout} />
     </GradientBackground>
   );
+};
+
+SettingsScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default SettingsScreen;

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -5,6 +5,7 @@ import LottieView from 'lottie-react-native';
 import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import styles from '../styles';
+import PropTypes from 'prop-types';
 
 const splashDuration = 2000;
 
@@ -47,3 +48,7 @@ export default function SplashScreen({ onFinish }) {
     </GradientBackground>
   );
 }
+
+SplashScreen.propTypes = {
+  onFinish: PropTypes.func.isRequired,
+};

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -10,6 +10,7 @@ import { useUser } from '../contexts/UserContext';
 import { db } from '../firebase';
 import { avatarSource } from '../utils/avatar';
 import ProgressBar from '../components/ProgressBar';
+import PropTypes from 'prop-types';
 
 const StatsScreen = ({ navigation }) => {
   const { theme } = useTheme();
@@ -239,5 +240,11 @@ const getStyles = (theme) => StyleSheet.create({
   }
 
 });
+
+StatsScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+};
 
 export default StatsScreen;

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -29,6 +29,7 @@ import LottieView from 'lottie-react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { imageSource } from '../utils/avatar';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import PropTypes from 'prop-types';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -628,5 +629,7 @@ const getStyles = (theme) =>
     marginTop: 20,
   },
 });
+
+SwipeScreen.propTypes = {};
 
 export default SwipeScreen;

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -13,6 +13,7 @@ import { snapshotExists } from '../../utils/firestore';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useNavigation } from '@react-navigation/native';
 import { useDev } from '../../contexts/DevContext';
+import PropTypes from 'prop-types';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -92,3 +93,4 @@ export default function LoginScreen() {
       </GradientBackground>
     );
   }
+LoginScreen.propTypes = {};


### PR DESCRIPTION
## Summary
- define PropTypes for every screen in the `screens` directory
- describe expected shapes for navigation, route params and data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861eef95f80832db25de51d41e446b5