### PR TITLE
Add smooth UI transitions

### DIFF
--- a/components/ProgressBar.js
+++ b/components/ProgressBar.js
@@ -1,11 +1,32 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { View, Text, Animated, Easing } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
 
 export default function ProgressBar({ label, value = 0, max = 100, color }) {
   const { theme } = useTheme();
   const pct = Math.min(value / max, 1);
+
+  const widthAnim = useRef(new Animated.Value(pct)).current;
+
+  useEffect(() => {
+    Animated.timing(widthAnim, {
+      toValue: pct,
+      duration: 300,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: false,
+    }).start();
+  }, [pct, widthAnim]);
+
+  const barStyle = {
+    height: '100%',
+    width: widthAnim.interpolate({
+      inputRange: [0, 1],
+      outputRange: ['0%', '100%'],
+    }),
+    backgroundColor: color || theme.accent,
+  };
+
   return (
     <View style={{ marginVertical: 4 }}>
       {label && (
@@ -20,13 +41,7 @@ export default function ProgressBar({ label, value = 0, max = 100, color }) {
           overflow: 'hidden',
         }}
       >
-        <View
-          style={{
-            height: '100%',
-            width: `${pct * 100}%`,
-            backgroundColor: color || theme.accent,
-          }}
-        />
+        <Animated.View style={barStyle} />
       </View>
     </View>
   );

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -9,7 +9,9 @@ import {
   Alert,
   Modal,
   TextInput,
-  Dimensions
+  Dimensions,
+  Animated,
+  Easing
 } from 'react-native';
 import GradientButton from '../components/GradientButton';
 import Card from '../components/Card';
@@ -40,12 +42,25 @@ const CommunityScreen = () => {
   const [showHostModal, setShowHostModal] = useState(false);
   const [showPostModal, setShowPostModal] = useState(false);
   const [firstJoin, setFirstJoin] = useState(false);
+  const badgeAnim = useRef(new Animated.Value(0)).current;
   const [newTitle, setNewTitle] = useState('');
   const [newTime, setNewTime] = useState('');
   const [newDesc, setNewDesc] = useState('');
   const [posts, setPosts] = useState([]);
   const [postTitle, setPostTitle] = useState('');
   const [postDesc, setPostDesc] = useState('');
+
+  useEffect(() => {
+    if (firstJoin) {
+      badgeAnim.setValue(0);
+      Animated.timing(badgeAnim, {
+        toValue: 1,
+        duration: 300,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [firstJoin, badgeAnim]);
 
   useEffect(() => {
     const q = db.collection('events').orderBy('createdAt', 'desc');
@@ -181,11 +196,18 @@ const CommunityScreen = () => {
 
         {/* First Join Badge */}
         {firstJoin && (
-          <View style={local.badgePopup}>
+          <Animated.View
+            style={[
+              local.badgePopup,
+              { opacity: badgeAnim, transform: [{ scale: badgeAnim }] },
+            ]}
+          >
             <Text style={local.badgeEmoji}>🏅</Text>
             <Text style={local.badgeTitle}>New Badge Unlocked!</Text>
-            <Text style={local.badgeText}>You earned the “Social Butterfly” badge.</Text>
-          </View>
+            <Text style={local.badgeText}>
+              You earned the “Social Butterfly” badge.
+            </Text>
+          </Animated.View>
         )}
       </ScrollView>
 

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -11,7 +11,8 @@ import {
   StyleSheet,
   SafeAreaView,
   KeyboardAvoidingView,
-  Platform
+  Platform,
+  Easing,
 } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
@@ -33,6 +34,7 @@ import { generateReply } from "../ai/chatBot";
 import useBotGame from "../hooks/useBotGame";
 import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
+import Loader from "../components/Loader";
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PropTypes from 'prop-types';
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
@@ -66,6 +68,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
   const GameComponent = game?.id ? games[game.id]?.Client : null;
   const isReady = devMode || inviteStatus === 'ready';
   const scaleAnim = useRef(new Animated.Value(1)).current;
+  const overlayOpacity = useRef(new Animated.Value(1)).current;
 
   // Listen for Firestore invite status
   useEffect(() => {
@@ -95,6 +98,15 @@ const LiveSessionScreen = ({ route, navigation }) => {
       Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true }).start();
     }
   }, [countdown]);
+
+  useEffect(() => {
+    Animated.timing(overlayOpacity, {
+      toValue: showGame ? 0 : 1,
+      duration: 300,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
+    }).start();
+  }, [showGame, overlayOpacity]);
 
   // Countdown logic
   useEffect(() => {
@@ -222,7 +234,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
           </View>
         )}
         {!showGame && (
-          <View style={local.overlay}>
+          <Animated.View style={[local.overlay, { opacity: overlayOpacity }]}>
             {countdown === null ? (
               <>
                 <Text style={[local.waitText, { color: theme.text }]}>Waiting for opponent...</Text>
@@ -231,7 +243,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
             ) : (
               <Animated.Text style={[local.countText, { transform: [{ scale: scaleAnim }] }]}>{countdown}</Animated.Text>
             )}
-          </View>
+          </Animated.View>
         )}
       </View>
 

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -1,5 +1,5 @@
 // screens/OnboardingScreen.js
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -7,6 +7,8 @@ import {
   TouchableOpacity,
   StyleSheet,
   Image,
+  Animated,
+  Easing,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import GradientBackground from '../components/GradientBackground';
@@ -46,6 +48,26 @@ export default function OnboardingScreen() {
   const styles = getStyles(theme);
 
   const [step, setStep] = useState(0);
+  const cardOpacity = useRef(new Animated.Value(1)).current;
+  const progressAnim = useRef(new Animated.Value(1 / questions.length)).current;
+
+  const animateStepChange = (newStep) => {
+    Animated.timing(cardOpacity, {
+      toValue: 0,
+      duration: 200,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
+    }).start(() => {
+      setStep(newStep);
+      cardOpacity.setValue(0);
+      Animated.timing(cardOpacity, {
+        toValue: 1,
+        duration: 200,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      }).start();
+    });
+  };
   const [answers, setAnswers] = useState({
     avatar: '',
     name: '',
@@ -135,6 +157,15 @@ export default function OnboardingScreen() {
   const currentField = questions[step].key;
   const progress = (step + 1) / questions.length;
 
+  useEffect(() => {
+    Animated.timing(progressAnim, {
+      toValue: progress,
+      duration: 300,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: false,
+    }).start();
+  }, [progress, progressAnim]);
+
   const validateField = () => {
     const value = answers[currentField];
     if (currentField === 'age') return /^\d+$/.test(value) && parseInt(value, 10) >= 18;
@@ -187,7 +218,7 @@ export default function OnboardingScreen() {
           return;
         }
       }
-      setStep(step + 1);
+      animateStepChange(step + 1);
     } else {
       try {
         let photoURL = answers.avatar;
@@ -226,7 +257,7 @@ export default function OnboardingScreen() {
   };
 
   const handleBack = () => {
-    if (step > 0) setStep(step - 1);
+    if (step > 0) animateStepChange(step - 1);
   };
 
   const pickImage = async () => {
@@ -439,13 +470,23 @@ export default function OnboardingScreen() {
         <Text style={styles.progressText}>{`Step ${step + 1} of ${questions.length}`}</Text>
 
         <View style={styles.progressContainer}>
-          <View style={[styles.progressBar, { width: `${progress * 100}%` }]} />
+          <Animated.View
+            style={[
+              styles.progressBar,
+              {
+                width: progressAnim.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ['0%', '100%'],
+                }),
+              },
+            ]}
+          />
         </View>
 
-        <View style={styles.card}>
+        <Animated.View style={[styles.card, { opacity: cardOpacity }]}>
           <Text style={styles.questionText}>{questions[step].label}</Text>
           {renderInput()}
-        </View>
+        </Animated.View>
 
         <View style={styles.buttonRow}>
           {step > 0 && (


### PR DESCRIPTION
## Summary
- animate progress bar width changes
- fade between onboarding steps and animate progress bar
- animate community badge popup
- fade countdown overlay in game sessions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861f9154868832d879e9cc856dd3a5c