### PR TITLE
Add haptic feedback to common actions

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { lightFeedback } from '../utils/haptics';
 import PropTypes from 'prop-types';
 
 const Card = ({ children, style, onPress, ...rest }) => {
   const Container = onPress ? TouchableOpacity : View;
   return (
-    <Container style={[styles.card, style]} onPress={onPress} {...rest}>
+    <Container
+      style={[styles.card, style]}
+      onPress={onPress ? () => { lightFeedback(); onPress(); } : undefined}
+      {...rest}
+    >
       {children}
     </Container>
   );

--- a/components/CategoryChips.js
+++ b/components/CategoryChips.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, TouchableOpacity, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
+import { selectionFeedback } from '../utils/haptics';
 
 export default function CategoryChips({ categories, category, setCategory }) {
   const { theme } = useTheme();
@@ -10,7 +11,10 @@ export default function CategoryChips({ categories, category, setCategory }) {
       {categories.map((cat) => (
         <TouchableOpacity
           key={cat}
-          onPress={() => setCategory(cat)}
+          onPress={() => {
+            selectionFeedback();
+            setCategory(cat);
+          }}
           style={{
             paddingVertical: 3,
             paddingHorizontal: 8,

--- a/components/DevBanner.js
+++ b/components/DevBanner.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { selectionFeedback } from '../utils/haptics';
 import PropTypes from 'prop-types';
 import { useDev } from '../contexts/DevContext';
 import DevPanel from './DevPanel';
@@ -12,7 +13,10 @@ export default function DevBanner() {
     <>
       <TouchableOpacity
         style={styles.banner}
-        onPress={() => setShowPanel(true)}
+        onPress={() => {
+          selectionFeedback();
+          setShowPanel(true);
+        }}
       >
         <Text style={styles.text}>DEV MODE</Text>
       </TouchableOpacity>

--- a/components/FavoriteStar.js
+++ b/components/FavoriteStar.js
@@ -2,10 +2,14 @@ import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
+import { selectionFeedback } from '../utils/haptics';
 
 const FavoriteStar = ({ isFavorite, onPress }) => (
   <TouchableOpacity
-    onPress={onPress}
+    onPress={() => {
+      selectionFeedback();
+      onPress && onPress();
+    }}
     style={{ position: 'absolute', top: 8, left: 8, zIndex: 10 }}
   >
     <Ionicons

--- a/components/FilterTabs.js
+++ b/components/FilterTabs.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, TouchableOpacity, Text, Keyboard } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
+import { selectionFeedback } from '../utils/haptics';
 
 export default function FilterTabs({ filter, setFilter }) {
   const { theme } = useTheme();
@@ -11,6 +12,7 @@ export default function FilterTabs({ filter, setFilter }) {
         <TouchableOpacity
           key={label}
           onPress={() => {
+            selectionFeedback();
             setFilter(label);
             Keyboard.dismiss();
           }}

--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Animated, TouchableOpacity, Dimensions } from 'react-native';
+import { lightFeedback } from '../utils/haptics';
 import PropTypes from 'prop-types';
 
 const CARD_WIDTH = Dimensions.get('window').width * 0.42;
@@ -25,7 +26,10 @@ const GameCardBase = ({ children, scale, onPress, onPressIn, onPressOut }) => (
       }}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
-      onPress={onPress}
+      onPress={() => {
+        lightFeedback();
+        onPress && onPress();
+      }}
     >
       {children}
     </TouchableOpacity>

--- a/components/GameOverModal.js
+++ b/components/GameOverModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import { lightFeedback } from '../utils/haptics';
 
 export default function GameOverModal({ visible, winnerName, onRematch, onChat }) {
   return (
@@ -9,10 +10,22 @@ export default function GameOverModal({ visible, winnerName, onRematch, onChat }
         <View style={styles.card}>
           <Text style={styles.emoji}>🏆</Text>
           <Text style={styles.title}>{winnerName ? `${winnerName} wins!` : 'Draw'}</Text>
-          <TouchableOpacity style={styles.rematchBtn} onPress={onRematch}>
+          <TouchableOpacity
+            style={styles.rematchBtn}
+            onPress={() => {
+              lightFeedback();
+              onRematch();
+            }}
+          >
             <Text style={styles.rematchText}>Rematch</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.chatBtn} onPress={onChat}>
+          <TouchableOpacity
+            style={styles.chatBtn}
+            onPress={() => {
+              lightFeedback();
+              onChat();
+            }}
+          >
             <Text style={styles.chatText}>Chat</Text>
           </TouchableOpacity>
         </View>

--- a/components/GamePreviewModal.js
+++ b/components/GamePreviewModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Modal, View, Text, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
+import { lightFeedback } from '../utils/haptics';
 import GradientButton from './GradientButton';
 
 export default function GamePreviewModal({ visible, game, onStart, onClose }) {
@@ -37,7 +38,13 @@ export default function GamePreviewModal({ visible, game, onStart, onClose }) {
             disabled={!game?.route}
             style={{ borderRadius: 10 }}
           />
-          <TouchableOpacity onPress={onClose} style={{ marginTop: 12 }}>
+          <TouchableOpacity
+            onPress={() => {
+              lightFeedback();
+              onClose();
+            }}
+            style={{ marginTop: 12 }}
+          >
             <Text style={{ textAlign: 'center', color: '#888' }}>Cancel</Text>
           </TouchableOpacity>
         </View>

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -4,6 +4,7 @@ import type { StyleProp, ViewStyle } from 'react-native';
 import { View, Text, Pressable } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
+import { lightFeedback } from '../utils/haptics';
 
 export interface GradientButtonProps {
   text: string;
@@ -24,8 +25,12 @@ export default function GradientButton({
   disabled,
 }: GradientButtonProps) {
   const { theme } = useTheme();
+  const handlePress = () => {
+    lightFeedback();
+    onPress && onPress();
+  };
   return (
-    <Pressable onPress={onPress} style={{ width, marginVertical }} disabled={disabled}>
+    <Pressable onPress={handlePress} style={{ width, marginVertical }} disabled={disabled}>
       <LinearGradient
         colors={[theme.gradientStart, theme.gradientEnd]}
         start={{ x: 0, y: 0 }}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
+import { selectionFeedback } from '../utils/haptics';
 import useUnreadNotifications from '../hooks/useUnreadNotifications';
 import { HEADER_HEIGHT } from '../theme';
 
@@ -14,7 +15,13 @@ const Header: React.FC<HeaderProps> = () => {
   return (
     <View style={[styles.container, { backgroundColor: theme.headerBackground }]}>
       {/* Left icon - Gear */}
-      <TouchableOpacity onPress={() => navigation.navigate('Settings')} style={styles.iconWrapper}>
+      <TouchableOpacity
+        onPress={() => {
+          selectionFeedback();
+          navigation.navigate('Settings');
+        }}
+        style={styles.iconWrapper}
+      >
         <Image
           source={require('../assets/gear.png')}
           style={[styles.icon, { tintColor: theme.text }]}
@@ -28,7 +35,13 @@ const Header: React.FC<HeaderProps> = () => {
       />
 
       {/* Right icon - Bell with badge */}
-      <TouchableOpacity onPress={() => navigation.navigate('Notifications')} style={styles.iconWrapper}>
+      <TouchableOpacity
+        onPress={() => {
+          selectionFeedback();
+          navigation.navigate('Notifications');
+        }}
+        style={styles.iconWrapper}
+      >
         <View style={styles.bellWrapper}>
           <Image
             source={require('../assets/bell.png')}

--- a/components/MultiSelectList.js
+++ b/components/MultiSelectList.js
@@ -2,10 +2,12 @@ import React from 'react';
 import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
+import { selectionFeedback } from '../utils/haptics';
 
 export default function MultiSelectList({ options = [], selected = [], onChange, theme }) {
   const toggle = (val) => {
     if (!onChange) return;
+    selectionFeedback();
     if (selected.includes(val)) {
       onChange(selected.filter((v) => v !== val));
     } else {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-screens": "^4.11.1",
     "react-native-toast-message": "^2.3.0",
     "expo-notifications": "~0.31.3",
-    "expo-device": "~7.1.4"
+    "expo-device": "~7.1.4",
+    "expo-haptics": "~11.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -29,6 +29,7 @@ import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
 import VoiceMessageBubble from '../components/VoiceMessageBubble';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
+import { lightFeedback } from '../utils/haptics';
 // TODO: add support for sending short voice or video intro clips in chat
 import Toast from 'react-native-toast-message';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
@@ -177,6 +178,7 @@ function PrivateChat({ user }) {
 
   const handleSend = () => {
     if (text.trim()) {
+      lightFeedback();
       sendChatMessage(text);
       setText('');
       updateTyping(false);
@@ -218,6 +220,7 @@ function PrivateChat({ user }) {
       setShowGameModal(false);
       return;
     }
+    lightFeedback();
     const title = games[gameId].meta.title;
     if (activeGameId && activeGameId !== gameId) {
       sendChatMessage(`Switched game to ${title}`, 'system');
@@ -264,7 +267,13 @@ function PrivateChat({ user }) {
   };
 
   const renderGameOption = ({ item }) => (
-    <TouchableOpacity style={privateStyles.gameOption} onPress={() => handleGameSelect(item.id)}>
+    <TouchableOpacity
+      style={privateStyles.gameOption}
+      onPress={() => {
+        lightFeedback();
+        handleGameSelect(item.id);
+      }}
+    >
       <Text style={privateStyles.gameOptionText}>{item.title}</Text>
     </TouchableOpacity>
   );
@@ -288,6 +297,7 @@ function PrivateChat({ user }) {
             if (!requireCredits()) {
               return;
             }
+            lightFeedback();
             setShowGameModal(true);
           }}
         >
@@ -298,7 +308,10 @@ function PrivateChat({ user }) {
       </View>
       <View style={privateStyles.inputBar}>
         <TouchableOpacity
-          onLongPress={startRecording}
+          onLongPress={() => {
+            lightFeedback();
+            startRecording();
+          }}
           onPressOut={handleVoiceFinish}
           style={{ marginRight: 6 }}
         >
@@ -379,7 +392,10 @@ function PrivateChat({ user }) {
             <FlatList data={gameList} keyExtractor={(item) => item.id} renderItem={renderGameOption} />
             <TouchableOpacity
               style={[privateStyles.sendButton, { marginTop: 10 }]}
-              onPress={() => setShowGameModal(false)}
+              onPress={() => {
+                lightFeedback();
+                setShowGameModal(false);
+              }}
             >
               <Text style={{ color: '#fff', fontWeight: 'bold' }}>Close</Text>
             </TouchableOpacity>
@@ -549,6 +565,7 @@ function GroupChat({ event }) {
 
   const sendMessage = async () => {
     if (!input.trim()) return;
+    lightFeedback();
     try {
       await db
         .collection('events')

--- a/utils/haptics.js
+++ b/utils/haptics.js
@@ -1,0 +1,17 @@
+import * as Haptics from 'expo-haptics';
+
+export const lightFeedback = () => {
+  try {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  } catch (e) {
+    // ignore errors on unsupported platforms
+  }
+};
+
+export const selectionFeedback = () => {
+  try {
+    Haptics.selectionAsync();
+  } catch (e) {
+    // ignore errors on unsupported platforms
+  }
+};


### PR DESCRIPTION
## Summary
- implement `utils/haptics` helpers
- wire up subtle haptic feedback in numerous UI components (buttons, lists, modals, chat)
- add `expo-haptics` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861fcf9878c832dac5cd0a8b5889765