### PR TITLE
Add subtle haptic feedback

### DIFF
--- a/components/CategoryChips.js
+++ b/components/CategoryChips.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TouchableOpacity, Text } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 
@@ -10,7 +11,10 @@ export default function CategoryChips({ categories, category, setCategory }) {
       {categories.map((cat) => (
         <TouchableOpacity
           key={cat}
-          onPress={() => setCategory(cat)}
+          onPress={() => {
+            Haptics.selectionAsync().catch(() => {});
+            setCategory(cat);
+          }}
           style={{
             paddingVertical: 3,
             paddingHorizontal: 8,

--- a/components/FavoriteStar.js
+++ b/components/FavoriteStar.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { Ionicons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 
 const FavoriteStar = ({ isFavorite, onPress }) => (
   <TouchableOpacity
-    onPress={onPress}
+    onPress={() => {
+      Haptics.selectionAsync().catch(() => {});
+      onPress();
+    }}
     style={{ position: 'absolute', top: 8, left: 8, zIndex: 10 }}
   >
     <Ionicons

--- a/components/FilterTabs.js
+++ b/components/FilterTabs.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TouchableOpacity, Text, Keyboard } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 
@@ -11,6 +12,7 @@ export default function FilterTabs({ filter, setFilter }) {
         <TouchableOpacity
           key={label}
           onPress={() => {
+            Haptics.selectionAsync().catch(() => {});
             setFilter(label);
             Keyboard.dismiss();
           }}

--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Animated, TouchableOpacity, Dimensions } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 
 const CARD_WIDTH = Dimensions.get('window').width * 0.42;
@@ -25,7 +26,10 @@ const GameCardBase = ({ children, scale, onPress, onPressIn, onPressOut }) => (
       }}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
-      onPress={onPress}
+      onPress={() => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+        onPress?.();
+      }}
     >
       {children}
     </TouchableOpacity>

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { View, Text, Pressable } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import { BUTTON_STYLE, FONT_SIZES } from '../layout';
@@ -29,9 +30,13 @@ export default function GradientButton({
   onPressOut,
 }: GradientButtonProps) {
   const { theme } = useTheme();
+  const handlePress = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    onPress?.();
+  };
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handlePress}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       style={{ width, marginVertical }}

--- a/components/MultiSelectList.js
+++ b/components/MultiSelectList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 
@@ -11,6 +12,7 @@ export default function MultiSelectList({ options = [], selected = [], onChange,
     } else {
       onChange([...selected, val]);
     }
+    Haptics.selectionAsync().catch(() => {});
   };
 
   const styles = getStyles(theme);

--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -6,6 +6,7 @@ import { db } from '../firebase';
 import { serverTimestamp } from 'firebase/firestore';
 import { useListeners } from './ListenerContext';
 import Toast from 'react-native-toast-message';
+import * as Haptics from 'expo-haptics';
 
 const ChatContext = createContext();
 
@@ -174,6 +175,7 @@ export const ChatProvider = ({ children }) => {
         timestamp: serverTimestamp(),
         });
       if (sender === 'you') {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
         Toast.show({ type: 'success', text1: 'Message sent' });
       }
     } catch (e) {

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -19,6 +19,7 @@ import styles from '../styles';
 import { games, gameList } from '../games';
 import { db } from '../firebase';
 import { serverTimestamp, arrayUnion } from 'firebase/firestore';
+import * as Haptics from 'expo-haptics';
 import { uploadVoiceAsync } from '../utils/upload';
 import { useTheme } from '../contexts/ThemeContext';
 import { HEADER_SPACING, FONT_SIZES } from '../layout';
@@ -564,6 +565,7 @@ function GroupChat({ event }) {
         });
       setInput('');
       setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 50);
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
       Toast.show({ type: 'success', text1: 'Message sent' });
     } catch (e) {
       console.warn('Failed to send message', e);

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -23,6 +23,7 @@ import { HEADER_SPACING } from '../layout';
 import { useUser } from '../contexts/UserContext';
 import { db } from '../firebase';
 import { serverTimestamp } from 'firebase/firestore';
+import * as Haptics from 'expo-haptics';
 import styles from '../styles';
 import { games } from '../games';
 import SyncedGame from '../components/SyncedGame';
@@ -343,6 +344,7 @@ function BotSessionScreen({ route }) {
     if (!t) return;
     sendMessage(t);
     setText('');
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
   };
 
   const playAgain = () => {

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -27,6 +27,7 @@ import { avatarSource } from '../utils/avatar';
 import RNPickerSelect from 'react-native-picker-select';
 import Toast from 'react-native-toast-message';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import MultiSelectList from '../components/MultiSelectList';
 import { FONT_SIZES, BUTTON_STYLE } from '../layout';
@@ -351,9 +352,10 @@ export default function OnboardingScreen() {
       }));
       return (
         <RNPickerSelect
-          onValueChange={(val) =>
-            setAnswers((prev) => ({ ...prev, age: val }))
-          }
+          onValueChange={(val) => {
+            Haptics.selectionAsync().catch(() => {});
+            setAnswers((prev) => ({ ...prev, age: val }));
+          }}
           value={answers.age}
           placeholder={{ label: 'Select age', value: null }}
           useNativeAndroidPickerStyle={false}
@@ -371,9 +373,10 @@ export default function OnboardingScreen() {
       return (
         <View>
           <RNPickerSelect
-            onValueChange={(val) =>
-              setAnswers((prev) => ({ ...prev, gender: val }))
-            }
+            onValueChange={(val) => {
+              Haptics.selectionAsync().catch(() => {});
+              setAnswers((prev) => ({ ...prev, gender: val }));
+            }}
             value={answers.gender}
             placeholder={{ label: 'Select gender', value: null }}
             useNativeAndroidPickerStyle={false}
@@ -385,9 +388,10 @@ export default function OnboardingScreen() {
             items={pickerFields.gender}
           />
           <RNPickerSelect
-            onValueChange={(val) =>
-              setAnswers((prev) => ({ ...prev, genderPref: val }))
-            }
+            onValueChange={(val) => {
+              Haptics.selectionAsync().catch(() => {});
+              setAnswers((prev) => ({ ...prev, genderPref: val }));
+            }}
             value={answers.genderPref}
             placeholder={{ label: 'Preferred teammate gender', value: null }}
             useNativeAndroidPickerStyle={false}
@@ -420,9 +424,10 @@ export default function OnboardingScreen() {
     if (pickerFields[currentField]) {
       return (
         <RNPickerSelect
-          onValueChange={(val) =>
-            setAnswers((prev) => ({ ...prev, [currentField]: val }))
-          }
+          onValueChange={(val) => {
+            Haptics.selectionAsync().catch(() => {});
+            setAnswers((prev) => ({ ...prev, [currentField]: val }));
+          }}
           value={answers[currentField]}
           placeholder={{ label: `Select ${currentField}`, value: null }}
           useNativeAndroidPickerStyle={false}


### PR DESCRIPTION
## Summary
- trigger light haptic impact on gradient button presses
- vibrate when toggling favorites, selecting filters and categories, or choosing items
- add haptic feedback when tapping game cards
- use light haptics for sending messages
- provide tactile response for onboarding pickers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861fece66a4832dadc3835776259554