### PR TITLE
Add haptics for key interactions

### DIFF
--- a/components/DevBanner.js
+++ b/components/DevBanner.js
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import { useDev } from '../contexts/DevContext';
 import DevPanel from './DevPanel';
+import { triggerLightHaptic } from '../utils/haptics';
 
 export default function DevBanner() {
   const { devMode } = useDev();
@@ -12,7 +13,10 @@ export default function DevBanner() {
     <>
       <TouchableOpacity
         style={styles.banner}
-        onPress={() => setShowPanel(true)}
+        onPress={() => {
+          triggerLightHaptic();
+          setShowPanel(true);
+        }}
       >
         <Text style={styles.text}>DEV MODE</Text>
       </TouchableOpacity>

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -5,6 +5,7 @@ import { View, Text, Pressable } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import { BUTTON_STYLE, FONT_SIZES } from '../layout';
+import { triggerLightHaptic } from '../utils/haptics';
 
 export interface GradientButtonProps {
   text: string;
@@ -29,9 +30,15 @@ export default function GradientButton({
   onPressOut,
 }: GradientButtonProps) {
   const { theme } = useTheme();
+  const handlePress = () => {
+    if (!disabled) {
+      triggerLightHaptic();
+    }
+    onPress?.();
+  };
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handlePress}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       style={{ width, marginVertical }}

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -29,6 +29,7 @@ import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
 import VoiceMessageBubble from '../components/VoiceMessageBubble';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
+import { triggerLightHaptic } from '../utils/haptics';
 // TODO: add support for sending short voice or video intro clips in chat
 import Toast from 'react-native-toast-message';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
@@ -177,6 +178,7 @@ function PrivateChat({ user }) {
 
   const handleSend = () => {
     if (text.trim()) {
+      triggerLightHaptic();
       sendChatMessage(text);
       setText('');
       updateTyping(false);
@@ -288,6 +290,7 @@ function PrivateChat({ user }) {
             if (!requireCredits()) {
               return;
             }
+            triggerLightHaptic();
             setShowGameModal(true);
           }}
         >
@@ -549,6 +552,7 @@ function GroupChat({ event }) {
 
   const sendMessage = async () => {
     if (!input.trim()) return;
+    triggerLightHaptic();
     try {
       await db
         .collection('events')

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -38,6 +38,7 @@ import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 import Loader from "../components/Loader";
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import { triggerLightHaptic } from '../utils/haptics';
 import PropTypes from 'prop-types';
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
   const type = sessionType || route.params?.sessionType || (route.params?.botId ? "bot" : "live");
@@ -143,6 +144,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
 
   const handleGameEnd = (result) => {
     if (result) addGameXP();
+    triggerLightHaptic();
     setGameResult(result);
   };
 
@@ -315,6 +317,7 @@ function BotSessionScreen({ route }) {
     let msg = 'Draw.';
     if (res.winner === '0') msg = 'You win!';
     else if (res.winner === '1') msg = `${bot.name} wins.`;
+    triggerLightHaptic();
     setGameOver(true);
     addSystemMessage(`Game over. ${msg}`);
   }
@@ -341,6 +344,7 @@ function BotSessionScreen({ route }) {
   const handleSend = () => {
     const t = text.trim();
     if (!t) return;
+    triggerLightHaptic();
     sendMessage(t);
     setText('');
   };

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -24,6 +24,7 @@ import ProgressBar from '../components/ProgressBar';
 import Card from '../components/Card';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { eventImageSource } from '../utils/avatar';
+import { triggerLightHaptic } from '../utils/haptics';
 
 const games = allGames.map((g) => {
   const key = Object.keys(gameRegistry).find(
@@ -61,6 +62,7 @@ const HomeScreen = ({ navigation }) => {
     }
     if (target === 'ai' || gamesLeft > 0 || isPremiumUser) {
       setPlayTarget(target);
+      triggerLightHaptic();
       setGamePickerVisible(true);
     } else {
       navigation.navigate('Premium', { context: 'paywall' });

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -18,6 +18,7 @@ import GameCard from '../components/GameCard';
 import GamePreviewModal from '../components/GamePreviewModal';
 import GameFilters from '../components/GameFilters';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import { triggerLightHaptic } from '../utils/haptics';
 import PropTypes from 'prop-types';
 
 
@@ -93,6 +94,7 @@ const PlayScreen = ({ navigation }) => {
         toggleFavorite={() => toggleFavorite(item.id)}
         onPress={() => {
           Keyboard.dismiss();
+          triggerLightHaptic();
           setPreviewGame(item);
         }}
       />

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -31,6 +31,7 @@ import LottieView from 'lottie-react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { imageSource } from '../utils/avatar';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import { triggerLightHaptic } from '../utils/haptics';
 import PropTypes from 'prop-types';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -229,6 +230,7 @@ const SwipeScreen = () => {
 
             setMatchedUser(displayUser);
             Toast.show({ type: 'success', text1: "It's a match!" });
+            triggerLightHaptic();
             setShowFireworks(true);
             setTimeout(() => setShowFireworks(false), 2000);
           }
@@ -249,6 +251,7 @@ const SwipeScreen = () => {
         });
         setMatchedUser(displayUser);
         Toast.show({ type: 'success', text1: "It's a match!" });
+        triggerLightHaptic();
         setShowFireworks(true);
         setTimeout(() => setShowFireworks(false), 2000);
       }

--- a/utils/haptics.js
+++ b/utils/haptics.js
@@ -1,0 +1,5 @@
+import * as Haptics from 'expo-haptics';
+
+export function triggerLightHaptic() {
+  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+}


### PR DESCRIPTION
## Summary
- add a small haptic helper
- vibrate on GradientButton presses
- vibrate when sending chat messages
- vibrate when opening game picker and preview modals
- vibrate on game over and matchmaking events
- vibrate when opening the developer panel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861ff3cd198832d927937f33f81d03b