### PR TITLE
Add loaders, pull-to-refresh and empty states

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -11,6 +11,7 @@ import CommunityScreen from '../screens/CommunityScreen';
 import PremiumScreen from '../screens/PremiumScreen';
 import StatsScreen from '../screens/StatsScreen';
 import PlayScreen from '../screens/PlayScreen';
+import ActiveGamesScreen from '../screens/ActiveGamesScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -25,6 +26,7 @@ export default function AppStack() {
       <Stack.Screen name="GameSession" component={GameSessionScreen} />
       <Stack.Screen name="Community" component={CommunityScreen} />
       <Stack.Screen name="EventChat" component={ChatScreen} />
+      <Stack.Screen name="ActiveGames" component={ActiveGamesScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
       <Stack.Screen name="Stats" component={StatsScreen} />
       <Stack.Screen name="GameWithBot" component={GameSessionScreen} />

--- a/screens/ActiveGamesScreen.js
+++ b/screens/ActiveGamesScreen.js
@@ -1,0 +1,117 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl, SafeAreaView } from 'react-native';
+import GradientBackground from '../components/GradientBackground';
+import Header from '../components/Header';
+import { useTheme } from '../contexts/ThemeContext';
+import { useGameSessions } from '../contexts/GameSessionContext';
+import { useChats } from '../contexts/ChatContext';
+import { useUser } from '../contexts/UserContext';
+import { games } from '../games';
+import { db } from '../firebase';
+import Loader from '../components/Loader';
+import { HEADER_SPACING } from '../layout';
+
+const ActiveGamesScreen = ({ navigation }) => {
+  const { theme } = useTheme();
+  const { sessions } = useGameSessions();
+  const { matches } = useChats();
+  const { user } = useUser();
+  const [list, setList] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    setList(sessions);
+    setLoading(false);
+  }, [sessions]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      const snap = await db
+        .collection('gameSessions')
+        .where('players', 'array-contains', user.uid)
+        .get();
+      const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setList(data);
+    } catch (e) {
+      console.warn('Failed to refresh sessions', e);
+    }
+    setRefreshing(false);
+  };
+
+  const renderItem = ({ item }) => {
+    const otherId = item.players.find((p) => p !== user.uid);
+    const match = matches.find((m) => m.otherUserId === otherId);
+    const opponentName = match?.name || 'Opponent';
+    const title = games[item.gameId]?.meta?.title || 'Game';
+    return (
+      <TouchableOpacity
+        style={[styles.card, { backgroundColor: theme.card }]}
+        onPress={() =>
+          navigation.navigate('GameSession', {
+            sessionId: item.id,
+            game: { id: item.gameId, title },
+            opponent: {
+              id: otherId,
+              name: opponentName,
+              photo: match?.image,
+            },
+          })
+        }
+      >
+        <Text style={[styles.gameText, { color: theme.text }]}>{title}</Text>
+        <Text style={{ color: theme.textSecondary }}>{opponentName}</Text>
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <GradientBackground style={{ flex: 1 }}>
+        <Header />
+        <View style={{ flex: 1, paddingTop: HEADER_SPACING }}>
+          {loading ? (
+            <View style={styles.loader}>
+              <Loader />
+            </View>
+          ) : (
+            <FlatList
+              data={list}
+              keyExtractor={(item) => item.id}
+              renderItem={renderItem}
+              refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+              ListEmptyComponent={
+                <Text style={{ textAlign: 'center', marginTop: 40, color: theme.text }}>
+                  No active games.
+                </Text>
+              }
+              contentContainerStyle={{ paddingBottom: 120 }}
+            />
+          )}
+        </View>
+      </GradientBackground>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    marginHorizontal: 16,
+    marginBottom: 12,
+  },
+  gameText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  loader: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default ActiveGamesScreen;


### PR DESCRIPTION
## Summary
- show loaders, empty states and refresh on MatchesScreen
- show loaders, refresh and placeholders on ChatScreen
- add loading and refreshing logic to CommunityScreen
- expose loading & refreshMatches from ChatContext
- create new ActiveGamesScreen and wire to navigator

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6861ff9ab738832dabeff41bf627e851