### PR TITLE
Consolidate displayName field

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -19,7 +19,7 @@ export const ChatProvider = ({ children }) => {
   const { getMessages } = useListeners();
   const devMatch = {
     id: '__testMatch',
-    name: 'Dev Tester',
+    displayName: 'Dev Tester',
     age: 99,
     image: require('../assets/user1.jpg'),
     messages: [
@@ -76,7 +76,7 @@ export const ChatProvider = ({ children }) => {
           return {
             id: m.id,
             otherUserId: otherId,
-            name: prevMatch.name || 'Match',
+            displayName: prevMatch.displayName || 'Match',
             age: prevMatch.age || 0,
             image: prevMatch.image || require('../assets/user1.jpg'),
             online: prevMatch.online || false,
@@ -118,7 +118,7 @@ export const ChatProvider = ({ children }) => {
                   m.otherUserId === uid
                     ? {
                         ...m,
-                        name: info.displayName || info.name || 'User',
+                        displayName: info.displayName || info.name || 'User',
                         age: info.age || 0,
                         image: info.photoURL
                           ? { uri: info.photoURL }

--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -7,7 +7,6 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `email` (string)
 - `displayName` (string)
 - `photoURL` (string)
-- `name` (string)
 - `age` (number)
 - `gender` (string)
 - `genderPref` (string)

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -204,7 +204,7 @@ function PrivateChat({ user }) {
     if (!result) return;
     addGameXP();
     if (result.winner !== undefined) {
-      const msg = result.winner === '0' ? 'You win!' : `${user.name} wins.`;
+      const msg = result.winner === '0' ? 'You win!' : `${user.displayName} wins.`;
       sendChatMessage(`Game over. ${msg}`, 'system');
     } else if (result.draw) {
       sendChatMessage('Game over. Draw.', 'system');
@@ -234,7 +234,7 @@ function PrivateChat({ user }) {
       return (
         <VoiceMessageBubble
           message={item}
-          userName={user.name}
+          userName={user.displayName}
           otherUserId={otherUserId}
         />
       );
@@ -251,7 +251,7 @@ function PrivateChat({ user }) {
         ]}
       >
         <Text style={privateStyles.sender}>
-          {item.sender === 'you' ? 'You' : item.sender === 'system' ? 'System' : user.name}
+          {item.sender === 'you' ? 'You' : item.sender === 'system' ? 'System' : user.displayName}
         </Text>
         <Text style={privateStyles.messageText}>{item.text}</Text>
         {item.sender === 'you' && (
@@ -280,7 +280,7 @@ function PrivateChat({ user }) {
         inverted
         keyboardShouldPersistTaps="handled"
       />
-      {isTyping && <Text style={privateStyles.typingIndicator}>{user.name} is typing...</Text>}
+      {isTyping && <Text style={privateStyles.typingIndicator}>{user.displayName} is typing...</Text>}
       <View style={privateStyles.gameBar}>
         <TouchableOpacity
           style={activeGameId ? privateStyles.changeButton : privateStyles.playButton}

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -55,7 +55,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     setMatches(
       chatMatches.map((m) => ({
         id: m.otherUserId,
-        name: m.name,
+        displayName: m.displayName,
         photo: m.image,
         online: m.online,
       }))
@@ -85,7 +85,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     const toLobby = () =>
       navigation.navigate('GameSession', {
         game: { id: gameId, title: gameTitle },
-        opponent: { id: user.id, name: user.name, photo: user.photo },
+        opponent: { id: user.id, displayName: user.displayName, photo: user.photo },
         inviteId,
         status: devMode ? 'ready' : 'waiting',
       });
@@ -99,7 +99,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   };
 
   const filtered = matches.filter((u) =>
-    u.name.toLowerCase().includes(search.toLowerCase())
+    u.displayName.toLowerCase().includes(search.toLowerCase())
   );
 
   const renderUserCard = ({ item }) => {
@@ -131,7 +131,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             }}
           />
           <Text style={{ fontSize: 15, fontWeight: '600', color: theme.text }}>
-            {item.name}
+            {item.displayName}
           </Text>
           <Text style={{ fontSize: 12, color: item.online ? '#2ecc71' : '#999', marginBottom: 6 }}>
             {item.online ? 'Online' : 'Offline'}
@@ -141,7 +141,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             <View style={{ alignItems: 'center', marginTop: 8 }}>
               <Loader size="small" />
               <Text style={{ color: theme.textSecondary, fontSize: 12, marginTop: 4 }}>
-                Waiting for {item.name}...
+                Waiting for {item.displayName}...
               </Text>
             </View>
           ) : (

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -256,13 +256,13 @@ const LiveSessionScreen = ({ route, navigation }) => {
           gameResult?.winner === '0'
             ? 'You'
             : gameResult?.winner === '1'
-            ? opponent.name
+            ? opponent.displayName
             : null
         }
         onRematch={handleRematch}
         onChat={() =>
           navigation.navigate('Chat', {
-            user: { id: opponent.id, name: opponent.name, image: opponent.photo },
+            user: { id: opponent.id, displayName: opponent.displayName, image: opponent.photo },
             gameId: game.id,
           })
         }

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -173,7 +173,7 @@ const HomeScreen = ({ navigation }) => {
                 style={[local.matchTile, { backgroundColor: theme.card }]}
               >
                 <Image source={item.image} style={local.matchAvatar} />
-                <Text style={[local.matchName, { color: theme.text }]}>{item.name}</Text>
+                <Text style={[local.matchName, { color: theme.text }]}>{item.displayName}</Text>
               </Card>
             )}
           />

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -30,7 +30,7 @@ const MatchesScreen = ({ navigation }) => {
     >
       <Image source={item.image} style={styles.newAvatar} />
       <Text style={[styles.newName, { color: theme.text }]} numberOfLines={1}>
-        {item.name}
+        {item.displayName}
       </Text>
     </TouchableOpacity>
   );
@@ -42,7 +42,7 @@ const MatchesScreen = ({ navigation }) => {
     >
       <Image source={item.image} style={styles.chatAvatar} />
       <View style={{ flex: 1 }}>
-        <Text style={[styles.chatName, { color: theme.text }]}>{item.name}</Text>
+        <Text style={[styles.chatName, { color: theme.text }]}>{item.displayName}</Text>
         {item.messages?.length ? (
           <Text
             style={[styles.chatPreview, { color: theme.textSecondary }]}

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -67,7 +67,7 @@ const NotificationsScreen = ({ navigation }) => {
         },
         opponent: {
           id: invite.from,
-          name: opp.displayName || 'Opponent',
+          displayName: opp.displayName || 'Opponent',
           photo: opp.photoURL ? { uri: opp.photoURL } : require('../assets/user1.jpg'),
         },
         inviteId: invite.id,

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -34,7 +34,7 @@ import { FONT_SIZES, BUTTON_STYLE } from '../layout';
 const questions = [
   { key: 'avatar', label: 'Upload your photo' },
   // TODO: allow recording a short voice or video intro and store URL in profile
-  { key: 'name', label: 'What’s your name?' },
+  { key: 'displayName', label: 'What’s your name?' },
   { key: 'age', label: 'How old are you?' },
   { key: 'genderInfo', label: 'Gender & preference' },
   { key: 'bio', label: 'Write a short bio' },
@@ -72,7 +72,7 @@ export default function OnboardingScreen() {
   };
   const [answers, setAnswers] = useState({
     avatar: '',
-    name: '',
+    displayName: '',
     age: '',
     gender: '',
     genderPref: '',
@@ -235,9 +235,10 @@ export default function OnboardingScreen() {
         const profile = {
           uid: user.uid,
           email: user.email,
-          displayName: user.displayName || '',
+          displayName: sanitizeText(
+            (answers.displayName || user.displayName || '').trim()
+          ),
           photoURL,
-          name: sanitizeText(answers.name.trim()),
           age: parseInt(answers.age, 10) || null,
           gender: sanitizeText(answers.gender),
         genderPref: sanitizeText(answers.genderPref),

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 const ProfileScreen = ({ navigation, route }) => {
   const { user, updateUser } = useUser();
   const [editMode, setEditMode] = useState(route?.params?.editMode || false);
-  const [name, setName] = useState(user?.displayName || '');
+  const [displayName, setDisplayName] = useState(user?.displayName || '');
   const [age, setAge] = useState(user?.age ? String(user.age) : '');
   const [gender, setGender] = useState(user?.gender || '');
   const [bio, setBio] = useState(user?.bio || '');
@@ -46,7 +46,7 @@ const ProfileScreen = ({ navigation, route }) => {
   };
 
   useEffect(() => {
-    setName(user?.displayName || '');
+    setDisplayName(user?.displayName || '');
     setAge(user?.age ? String(user.age) : '');
     setGender(user?.gender || '');
     setBio(user?.bio || '');
@@ -71,7 +71,7 @@ const ProfileScreen = ({ navigation, route }) => {
     }
 
     const clean = {
-      displayName: sanitizeText(name.trim()),
+      displayName: sanitizeText(displayName.trim()),
       age: parseInt(age, 10) || null,
       gender: sanitizeText(gender),
       bio: sanitizeText(bio.trim()),
@@ -112,8 +112,8 @@ const ProfileScreen = ({ navigation, route }) => {
       <TextInput
         style={styles.input}
         placeholder="Name"
-        value={name}
-        onChangeText={setName}
+        value={displayName}
+        onChangeText={setDisplayName}
       />
 
       <TextInput

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -157,7 +157,7 @@ const SwipeScreen = () => {
           );
           return {
             id: u.uid || u.id,
-            name: u.displayName || 'User',
+            displayName: u.displayName || 'User',
             age: u.age || '',
             bio: u.bio || '',
             favoriteGames: Array.isArray(u.favoriteGames) ? u.favoriteGames : [],
@@ -190,7 +190,7 @@ const SwipeScreen = () => {
       }
 
       setLikesUsed((prev) => prev + 1);
-      showNotification(`You liked ${displayUser.name}`);
+      showNotification(`You liked ${displayUser.displayName}`);
 
       if (currentUser?.uid && displayUser.id && !devMode) {
         try {
@@ -218,7 +218,7 @@ const SwipeScreen = () => {
 
             addMatch({
               id: matchRef.id,
-              name: displayUser.name,
+              displayName: displayUser.displayName,
               age: displayUser.age,
               image: displayUser.images[0],
               messages: [],
@@ -239,7 +239,7 @@ const SwipeScreen = () => {
         // In dev mode instantly match
         addMatch({
           id: displayUser.id,
-          name: displayUser.name,
+          displayName: displayUser.displayName,
           age: displayUser.age,
           image: displayUser.images[0],
           messages: [],
@@ -347,7 +347,7 @@ const SwipeScreen = () => {
           game: { id: '1', title: gameTitle },
           opponent: {
             id: displayUser.id,
-            name: displayUser.name,
+            displayName: displayUser.displayName,
             photo: displayUser.images[0],
           },
           inviteId,
@@ -417,7 +417,7 @@ const SwipeScreen = () => {
             />
             <View style={styles.info}>
               <Text style={styles.name}>
-                {displayUser.name}, {displayUser.age}
+                {displayUser.displayName}, {displayUser.age}
               </Text>
               <Text style={styles.match}>Match: {matchPercent}%</Text>
               <Text style={styles.bio}>{displayUser.bio}</Text>
@@ -484,7 +484,7 @@ const SwipeScreen = () => {
                 loop={false}
                 style={{ width: 300, height: 300 }}
               />
-              <Text style={styles.matchText}>It's a Match with {matchedUser.name}!</Text>
+              <Text style={styles.matchText}>It's a Match with {matchedUser.displayName}!</Text>
             </View>
           </Modal>
         )}


### PR DESCRIPTION
## Summary
- use `displayName` consistently across user flows
- remove obsolete `name` field from Firestore schema
- update onboarding to collect `displayName`
- update profile editing to save `displayName`
- adjust chat and invitation screens to use the new field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861ffbcb260832d8a28377b838bedd4