### PR TITLE
Add haptic feedback

### DIFF
--- a/components/DevBanner.js
+++ b/components/DevBanner.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 import { useDev } from '../contexts/DevContext';
 import DevPanel from './DevPanel';
@@ -12,7 +13,10 @@ export default function DevBanner() {
     <>
       <TouchableOpacity
         style={styles.banner}
-        onPress={() => setShowPanel(true)}
+        onPress={() => {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+          setShowPanel(true);
+        }}
       >
         <Text style={styles.text}>DEV MODE</Text>
       </TouchableOpacity>

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -90,6 +90,7 @@ function PrivateChat({ user }) {
           timestamp: serverTimestamp(),
         });
       if (sender === 'user') {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
         Toast.show({ type: 'success', text1: 'Message sent' });
       }
     } catch (e) {
@@ -289,6 +290,7 @@ function PrivateChat({ user }) {
             if (!requireCredits()) {
               return;
             }
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
             setShowGameModal(true);
           }}
         >

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -26,6 +26,7 @@ import { db } from '../firebase';
 import { serverTimestamp } from 'firebase/firestore';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { HEADER_SPACING, FONT_SIZES, BUTTON_STYLE } from '../layout';
+import * as Haptics from 'expo-haptics';
 
 const screenWidth = Dimensions.get('window').width;
 const cardWidth = (screenWidth - 48) / 2;
@@ -172,7 +173,10 @@ const CommunityScreen = () => {
         {/* Host your own */}
         <GradientButton
           text="Host Your Own Event"
-          onPress={() => setShowHostModal(true)}
+          onPress={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+            setShowHostModal(true);
+          }}
           marginVertical={20}
           icon={<Text style={{ fontSize: 16 }}>🎤</Text>}
           style={{ marginHorizontal: 16 }}
@@ -181,7 +185,10 @@ const CommunityScreen = () => {
         {/* Create Post */}
         <GradientButton
           text="New Post"
-          onPress={() => setShowPostModal(true)}
+          onPress={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+            setShowPostModal(true);
+          }}
           marginVertical={20}
           icon={<Text style={{ fontSize: 16 }}>✏️</Text>}
           style={{ marginHorizontal: 16 }}

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -18,6 +18,7 @@ import GameCard from '../components/GameCard';
 import GamePreviewModal from '../components/GamePreviewModal';
 import GameFilters from '../components/GameFilters';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 
 
@@ -93,6 +94,7 @@ const PlayScreen = ({ navigation }) => {
         toggleFavorite={() => toggleFavorite(item.id)}
         onPress={() => {
           Keyboard.dismiss();
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
           setPreviewGame(item);
         }}
       />


### PR DESCRIPTION
## Summary
- send light haptics when sending chat messages
- add tactile feedback when opening game picker modal
- give host/post buttons haptic feedback
- use haptics for PlayScreen previews and Dev panel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686201463250832d8a6cbea89326aa12