### PR TITLE
Fix profile navigation

### DIFF
--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -118,7 +118,10 @@ const ProfileScreen = ({ navigation, route }) => {
       updateUser(clean);
       setAvatar(photoURL);
       Toast.show({ type: 'success', text1: 'Profile updated!' });
-      navigation.navigate('Main');
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Main' }],
+      });
     } catch (e) {
       console.warn('Failed to update profile', e);
       Toast.show({ type: 'error', text1: 'Update failed' });


### PR DESCRIPTION
## Summary
- reset navigation stack after profile save to remove extra routes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686201df6298832dabdbcb58a1915c3f