### PR TITLE
Fix navigation stack after starting a game

### DIFF
--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -87,7 +87,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     }
 
     const toLobby = () =>
-      navigation.navigate('GameSession', {
+      navigation.replace('GameSession', {
         game: { id: gameId, title: gameTitle },
         opponent: { id: user.id, name: user.name, photo: user.photo },
         inviteId,
@@ -233,6 +233,7 @@ const GameInviteScreen = ({ route, navigation }) => {
 GameInviteScreen.propTypes = {
   navigation: PropTypes.shape({
     navigate: PropTypes.func.isRequired,
+    replace: PropTypes.func.isRequired,
   }).isRequired,
   route: PropTypes.shape({
     params: PropTypes.shape({

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -357,7 +357,7 @@ const handleSwipe = async (direction) => {
 
       const gameTitle = allGames.find((g) => g.id === '1')?.title || 'Game';
       const toLobby = () =>
-        navigation.navigate('GameSession', {
+        navigation.replace('GameSession', {
           game: { id: '1', title: gameTitle },
           opponent: {
             id: displayUser.id,


### PR DESCRIPTION
## Summary
- prevent navigating back to invite/lobby screens by using `navigation.replace`
- update propTypes for navigation on `GameInviteScreen`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686201e0101c832d90a5b11c4d1f9694