### PR TITLE
Consolidate visible name on displayName field

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -20,7 +20,7 @@ export const ChatProvider = ({ children }) => {
   const { getMessages } = useListeners();
   const devMatch = {
     id: '__testMatch',
-    name: 'Dev Tester',
+    displayName: 'Dev Tester',
     age: 99,
     image: require('../assets/user1.jpg'),
     messages: [
@@ -77,7 +77,7 @@ export const ChatProvider = ({ children }) => {
           return {
             id: m.id,
             otherUserId: otherId,
-            name: prevMatch.name || 'Match',
+            displayName: prevMatch.displayName || 'Match',
             age: prevMatch.age || 0,
             image: prevMatch.image || require('../assets/user1.jpg'),
             online: prevMatch.online || false,
@@ -119,7 +119,7 @@ export const ChatProvider = ({ children }) => {
                   m.otherUserId === uid
                     ? {
                         ...m,
-                        name: info.displayName || info.name || 'User',
+                        displayName: info.displayName || 'User',
                         age: info.age || 0,
                         image: info.photoURL
                           ? { uri: info.photoURL }

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -205,7 +205,7 @@ function PrivateChat({ user }) {
     if (!result) return;
     addGameXP();
     if (result.winner !== undefined) {
-      const msg = result.winner === '0' ? 'You win!' : `${user.name} wins.`;
+      const msg = result.winner === '0' ? 'You win!' : `${user.displayName} wins.`;
       sendChatMessage(`Game over. ${msg}`, 'system');
     } else if (result.draw) {
       sendChatMessage('Game over. Draw.', 'system');
@@ -235,7 +235,7 @@ function PrivateChat({ user }) {
       return (
         <VoiceMessageBubble
           message={item}
-          userName={user.name}
+          userName={user.displayName}
           otherUserId={otherUserId}
         />
       );
@@ -252,7 +252,7 @@ function PrivateChat({ user }) {
         ]}
       >
         <Text style={privateStyles.sender}>
-          {item.sender === 'you' ? 'You' : item.sender === 'system' ? 'System' : user.name}
+          {item.sender === 'you' ? 'You' : item.sender === 'system' ? 'System' : user.displayName}
         </Text>
         <Text style={privateStyles.messageText}>{item.text}</Text>
         {item.sender === 'you' && (
@@ -281,7 +281,7 @@ function PrivateChat({ user }) {
         inverted
         keyboardShouldPersistTaps="handled"
       />
-      {isTyping && <Text style={privateStyles.typingIndicator}>{user.name} is typing...</Text>}
+      {isTyping && <Text style={privateStyles.typingIndicator}>{user.displayName} is typing...</Text>}
       <View style={privateStyles.gameBar}>
         <TouchableOpacity
           style={activeGameId ? privateStyles.changeButton : privateStyles.playButton}
@@ -812,7 +812,7 @@ ChatScreen.propTypes = {
     params: PropTypes.shape({
       user: PropTypes.shape({
         id: PropTypes.string,
-        name: PropTypes.string,
+        displayName: PropTypes.string,
         image: PropTypes.any,
       }),
       event: PropTypes.object,

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -55,7 +55,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     setMatches(
       chatMatches.map((m) => ({
         id: m.otherUserId,
-        name: m.name,
+        displayName: m.displayName,
         photo: m.image,
         online: m.online,
       }))
@@ -89,7 +89,7 @@ const GameInviteScreen = ({ route, navigation }) => {
     const toLobby = () =>
       navigation.navigate('GameSession', {
         game: { id: gameId, title: gameTitle },
-        opponent: { id: user.id, name: user.name, photo: user.photo },
+        opponent: { id: user.id, displayName: user.displayName, photo: user.photo },
         inviteId,
         status: devMode ? 'ready' : 'waiting',
       });
@@ -103,7 +103,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   };
 
   const filtered = matches.filter((u) =>
-    u.name.toLowerCase().includes(search.toLowerCase())
+    u.displayName.toLowerCase().includes(search.toLowerCase())
   );
 
   const renderUserCard = ({ item }) => {
@@ -140,7 +140,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             }}
           />
           <Text style={{ fontSize: 15, fontWeight: '600', color: theme.text }}>
-            {item.name}
+            {item.displayName}
           </Text>
           <Text style={{ fontSize: 12, color: item.online ? '#2ecc71' : '#999', marginBottom: 6 }}>
             {item.online ? 'Online' : 'Offline'}
@@ -150,7 +150,7 @@ const GameInviteScreen = ({ route, navigation }) => {
             <View style={{ alignItems: 'center', marginTop: 8 }}>
               <Loader size="small" />
               <Text style={{ color: theme.textSecondary, fontSize: 12, marginTop: 4 }}>
-                Waiting for {item.name}...
+                Waiting for {item.displayName}...
               </Text>
             </View>
           ) : (

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -257,13 +257,13 @@ const LiveSessionScreen = ({ route, navigation }) => {
           gameResult?.winner === '0'
             ? 'You'
             : gameResult?.winner === '1'
-            ? opponent.name
+            ? opponent.displayName
             : null
         }
         onRematch={handleRematch}
         onChat={() =>
           navigation.navigate('Chat', {
-            user: { id: opponent.id, name: opponent.name, image: opponent.photo },
+            user: { id: opponent.id, displayName: opponent.displayName, image: opponent.photo },
             gameId: game.id,
           })
         }

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -173,7 +173,7 @@ const HomeScreen = ({ navigation }) => {
                 style={[local.matchTile, { backgroundColor: theme.card }]}
               >
                 <Image source={item.image} style={local.matchAvatar} />
-                <Text style={[local.matchName, { color: theme.text }]}>{item.name}</Text>
+                <Text style={[local.matchName, { color: theme.text }]}>{item.displayName}</Text>
               </Card>
             )}
           />

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -30,7 +30,7 @@ const MatchesScreen = ({ navigation }) => {
     >
       <Image source={item.image} style={styles.newAvatar} />
       <Text style={[styles.newName, { color: theme.text }]} numberOfLines={1}>
-        {item.name}
+        {item.displayName}
       </Text>
     </TouchableOpacity>
   );
@@ -42,7 +42,7 @@ const MatchesScreen = ({ navigation }) => {
     >
       <Image source={item.image} style={styles.chatAvatar} />
       <View style={{ flex: 1 }}>
-        <Text style={[styles.chatName, { color: theme.text }]}>{item.name}</Text>
+        <Text style={[styles.chatName, { color: theme.text }]}>{item.displayName}</Text>
         {item.messages?.length ? (
           <Text
             style={[styles.chatPreview, { color: theme.textSecondary }]}

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -236,9 +236,8 @@ export default function OnboardingScreen() {
         const profile = {
           uid: user.uid,
           email: user.email,
-          displayName: user.displayName || '',
+          displayName: sanitizeText(answers.name.trim()),
           photoURL,
-          name: sanitizeText(answers.name.trim()),
           age: parseInt(answers.age, 10) || null,
           gender: sanitizeText(answers.gender),
         genderPref: sanitizeText(answers.genderPref),

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -158,7 +158,7 @@ const SwipeScreen = () => {
           );
           return {
             id: u.uid || u.id,
-            name: u.displayName || 'User',
+            displayName: u.displayName || 'User',
             age: u.age || '',
             bio: u.bio || '',
             favoriteGames: Array.isArray(u.favoriteGames) ? u.favoriteGames : [],
@@ -194,7 +194,7 @@ const handleSwipe = async (direction) => {
       }
 
       setLikesUsed((prev) => prev + 1);
-      showNotification(`You liked ${displayUser.name}`);
+      showNotification(`You liked ${displayUser.displayName}`);
 
       if (currentUser?.uid && displayUser.id && !devMode) {
         try {
@@ -222,7 +222,7 @@ const handleSwipe = async (direction) => {
 
             addMatch({
               id: matchRef.id,
-              name: displayUser.name,
+              displayName: displayUser.displayName,
               age: displayUser.age,
               image: displayUser.images[0],
               messages: [],
@@ -248,7 +248,7 @@ const handleSwipe = async (direction) => {
         // In dev mode instantly match
         addMatch({
           id: displayUser.id,
-          name: displayUser.name,
+          displayName: displayUser.displayName,
           age: displayUser.age,
           image: displayUser.images[0],
           messages: [],
@@ -361,7 +361,7 @@ const handleSwipe = async (direction) => {
           game: { id: '1', title: gameTitle },
           opponent: {
             id: displayUser.id,
-            name: displayUser.name,
+            displayName: displayUser.displayName,
             photo: displayUser.images[0],
           },
           inviteId,
@@ -431,7 +431,7 @@ const handleSwipe = async (direction) => {
             />
             <View style={styles.info}>
               <Text style={styles.name}>
-                {displayUser.name}, {displayUser.age}
+                {displayUser.displayName}, {displayUser.age}
               </Text>
               <Text style={styles.match}>Match: {matchPercent}%</Text>
               <Text style={styles.bio}>{displayUser.bio}</Text>
@@ -498,7 +498,7 @@ const handleSwipe = async (direction) => {
                 loop={false}
                 style={{ width: 300, height: 300 }}
               />
-              <Text style={styles.matchText}>It's a Match with {matchedUser.name}!</Text>
+              <Text style={styles.matchText}>It's a Match with {matchedUser.displayName}!</Text>
             </View>
           </Modal>
         )}


### PR DESCRIPTION
## Summary
- choose `displayName` as the canonical visible name field
- use `displayName` when saving onboarding data
- update ChatContext to store matches with `displayName`
- reference `displayName` across chat and invite flows

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68620177abbc832d994d4f52adb1da1e