### PR TITLE
Add AI bot fallback prompts

### DIFF
--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -242,6 +242,13 @@ const LiveSessionScreen = ({ route, navigation }) => {
               <>
                 <Text style={[local.waitText, { color: theme.text }]}>Waiting for opponent...</Text>
                 <Loader size="small" style={{ marginTop: 20 }} />
+                <TouchableOpacity
+                  onPress={() => navigation.navigate('GameWithBot')}
+                >
+                  <Text style={{ color: theme.accent, marginTop: 10 }}>
+                    Play with an AI bot instead
+                  </Text>
+                </TouchableOpacity>
               </>
             ) : (
               <Animated.Text style={[local.countText, { transform: [{ scale: scaleAnim }] }]}>{countdown}</Animated.Text>

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -77,9 +77,24 @@ const MatchesScreen = ({ navigation }) => {
               <Loader />
             </View>
           ) : newMatches.length === 0 && activeChats.length === 0 ? (
-            <Text style={{ textAlign: 'center', marginTop: 40, color: theme.text }}>
-              No matches yet.
-            </Text>
+            <>
+              <Text style={{ textAlign: 'center', marginTop: 40, color: theme.text }}>
+                No matches yet.
+              </Text>
+              <TouchableOpacity
+                onPress={() => navigation.navigate('GameWithBot')}
+              >
+                <Text
+                  style={{
+                    textAlign: 'center',
+                    marginTop: 10,
+                    color: theme.accent,
+                  }}
+                >
+                  Play with an AI bot
+                </Text>
+              </TouchableOpacity>
+            </>
           ) : (
             <>
               {newMatches.length > 0 && (


### PR DESCRIPTION
## Summary
- suggest playing vs AI when no matches
- offer AI bot option while waiting for rematch

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686203e008e0832d8ef8744414d6b7df