### PR TITLE
Add post-match conversation suggestions

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -19,6 +19,7 @@ import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
 import styles from '../styles';
 import { games, gameList } from '../games';
+import { icebreakers } from '../data/prompts';
 import { db } from '../firebase';
 import { serverTimestamp, arrayUnion } from 'firebase/firestore';
 import * as Haptics from 'expo-haptics';
@@ -78,6 +79,17 @@ function PrivateChat({ user }) {
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [firstLine, setFirstLine] = useState('');
+  const [firstGame, setFirstGame] = useState(null);
+
+  useEffect(() => {
+    setFirstLine(
+      icebreakers[Math.floor(Math.random() * icebreakers.length)] || ''
+    );
+    setFirstGame(
+      gameList[Math.floor(Math.random() * gameList.length)] || null
+    );
+  }, []);
 
   const sendChatMessage = async (msgText = '', sender = 'user', extras = {}) => {
     if (!msgText.trim() && !extras.voice) return;
@@ -322,9 +334,33 @@ function PrivateChat({ user }) {
         }
         ListEmptyComponent={
           !loading && (
-            <Text style={{ textAlign: 'center', marginTop: 20, color: theme.text }}>
-              No messages yet.
-            </Text>
+            <View style={{ alignItems: 'center', marginTop: 20 }}>
+              <Text style={{ textAlign: 'center', color: theme.text }}>
+                No messages yet.
+              </Text>
+              {firstLine ? (
+                <Text
+                  style={{
+                    textAlign: 'center',
+                    color: theme.textSecondary,
+                    marginTop: 4,
+                  }}
+                >
+                  {`Try: "${firstLine}"`}
+                </Text>
+              ) : null}
+              {firstGame ? (
+                <Text
+                  style={{
+                    textAlign: 'center',
+                    color: theme.textSecondary,
+                    marginTop: 2,
+                  }}
+                >
+                  {`Or invite them to play ${firstGame.title}`}
+                </Text>
+              ) : null}
+            </View>
           )
         }
       />

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -23,6 +23,7 @@ import { useDev } from '../contexts/DevContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { allGames } from '../data/games';
+import { icebreakers } from '../data/prompts';
 import { useChats } from '../contexts/ChatContext';
 import { db } from '../firebase';
 import { serverTimestamp } from 'firebase/firestore';
@@ -94,6 +95,8 @@ const SwipeScreen = () => {
   const [imageIndex, setImageIndex] = useState(0);
   const [history, setHistory] = useState([]);
   const [showSuperLikeAnim, setShowSuperLikeAnim] = useState(false);
+  const [matchLine, setMatchLine] = useState('');
+  const [matchGame, setMatchGame] = useState(null);
 
   const pan = useRef(new Animated.ValueXY()).current;
   const scaleRefs = useRef(Array(5).fill(null).map(() => new Animated.Value(1))).current;
@@ -232,6 +235,12 @@ const handleSwipe = async (direction) => {
             });
 
             setMatchedUser(displayUser);
+            setMatchLine(
+              icebreakers[Math.floor(Math.random() * icebreakers.length)] || ''
+            );
+            setMatchGame(
+              allGames[Math.floor(Math.random() * allGames.length)] || null
+            );
             // Provide a stronger haptic pulse when a match occurs
             Haptics.notificationAsync(
               Haptics.NotificationFeedbackType.Success
@@ -257,6 +266,10 @@ const handleSwipe = async (direction) => {
           pendingInvite: null,
         });
         setMatchedUser(displayUser);
+        setMatchLine(
+          icebreakers[Math.floor(Math.random() * icebreakers.length)] || ''
+        );
+        setMatchGame(allGames[Math.floor(Math.random() * allGames.length)] || null);
         // Provide a stronger haptic pulse when a match occurs
         Haptics.notificationAsync(
           Haptics.NotificationFeedbackType.Success
@@ -499,6 +512,12 @@ const handleSwipe = async (direction) => {
                 style={{ width: 300, height: 300 }}
               />
               <Text style={styles.matchText}>It's a Match with {matchedUser.displayName}!</Text>
+              {matchLine ? (
+                <Text style={styles.suggestText}>{`Try: "${matchLine}"`}</Text>
+              ) : null}
+              {matchGame ? (
+                <Text style={styles.suggestText}>{`Or invite them to play ${matchGame.title}`}</Text>
+              ) : null}
             </View>
           </Modal>
         )}
@@ -643,6 +662,13 @@ const getStyles = (theme) =>
     fontWeight: 'bold',
     color: '#fff',
     marginTop: 20,
+  },
+  suggestText: {
+    fontSize: 14,
+    color: '#fff',
+    marginTop: 6,
+    textAlign: 'center',
+    paddingHorizontal: 20,
   },
 });
 


### PR DESCRIPTION
## Summary
- import icebreaker prompts
- show a random icebreaker and game suggestion when opening a new chat
- surface the same suggestions in the match fireworks modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686203d46c0c832db348e57d38c2408f