### PR TITLE
Unify user displayName field

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -49,7 +49,20 @@ export const ChatProvider = ({ children }) => {
         try {
           const parsed = JSON.parse(data);
           if (Array.isArray(parsed)) {
-            setMatches(devMode ? [...parsed, devMatch].filter((v, i, a) => a.findIndex(x => x.id === v.id) === i) : parsed);
+            const converted = parsed.map((m) => {
+              const { name, ...rest } = m;
+              return {
+                ...rest,
+                displayName: m.displayName || name || 'Match',
+              };
+            });
+            setMatches(
+              devMode
+                ? [...converted, devMatch].filter(
+                    (v, i, a) => a.findIndex((x) => x.id === v.id) === i
+                  )
+                : converted
+            );
           } else {
             setMatches(devMode ? [devMatch] : []);
           }
@@ -124,7 +137,7 @@ export const ChatProvider = ({ children }) => {
                   m.otherUserId === uid
                     ? {
                         ...m,
-                        displayName: info.displayName || info.name || 'User',
+            displayName: info.displayName || 'User',
                         age: info.age || 0,
                         image: info.photoURL
                           ? { uri: info.photoURL }
@@ -279,7 +292,7 @@ export const ChatProvider = ({ children }) => {
           return {
             id: m.id,
             otherUserId: otherId,
-            name: prevMatch.name || 'Match',
+            displayName: prevMatch.displayName || 'Match',
             age: prevMatch.age || 0,
             image: prevMatch.image || require('../assets/user1.jpg'),
             online: prevMatch.online || false,

--- a/screens/ActiveGamesScreen.js
+++ b/screens/ActiveGamesScreen.js
@@ -43,7 +43,7 @@ const ActiveGamesScreen = ({ navigation }) => {
   const renderItem = ({ item }) => {
     const otherId = item.players.find((p) => p !== user.uid);
     const match = matches.find((m) => m.otherUserId === otherId);
-    const opponentName = match?.name || 'Opponent';
+    const opponentName = match?.displayName || 'Opponent';
     const title = games[item.gameId]?.meta?.title || 'Game';
     return (
       <TouchableOpacity
@@ -54,7 +54,7 @@ const ActiveGamesScreen = ({ navigation }) => {
             game: { id: item.gameId, title },
             opponent: {
               id: otherId,
-              name: opponentName,
+              displayName: opponentName,
               photo: match?.image,
             },
           })

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -918,7 +918,7 @@ ChatScreen.propTypes = {
     params: PropTypes.shape({
       user: PropTypes.shape({
         id: PropTypes.string,
-        name: PropTypes.string,
+        displayName: PropTypes.string,
         image: PropTypes.any,
       }),
       event: PropTypes.object,


### PR DESCRIPTION
## Summary
- remove legacy `name` usage in chat context
- normalize stored matches to `displayName`
- update active games screen and chat prop types for the unified field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686203a71a24832daa5e8c5b87c7b930