### PR TITLE
Add chat placeholders on initial load

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -81,6 +81,7 @@ function PrivateChat({ user }) {
   const [refreshing, setRefreshing] = useState(false);
   const [firstLine, setFirstLine] = useState('');
   const [firstGame, setFirstGame] = useState(null);
+  const showPlaceholders = loading && messages.length === 0;
 
   useEffect(() => {
     setFirstLine(
@@ -319,6 +320,24 @@ function PrivateChat({ user }) {
     </TouchableOpacity>
   );
 
+  const PlaceholderBubbles = () => {
+    const widths = ['60%', '70%', '55%', '80%'];
+    return (
+      <View style={{ flex: 4, padding: 10 }}>
+        {widths.map((w, i) => (
+          <View
+            key={i}
+            style={[
+              privateStyles.messageBubble,
+              i % 2 === 0 ? privateStyles.messageLeft : privateStyles.messageRight,
+              { backgroundColor: darkMode ? '#444' : '#ddd', width: w, height: 20 },
+            ]}
+          />
+        ))}
+      </View>
+    );
+  };
+
   const chatSection = (
     <View style={{ flex: 4, padding: 10 }}>
       <FlatList
@@ -474,7 +493,9 @@ function PrivateChat({ user }) {
       <SafeAreaView style={{ flex: 1 }}>
         <SafeKeyboardView style={{ flex: 1, paddingTop: HEADER_SPACING }}>
           <View style={{ flex: 1 }}>
-            {loading ? (
+            {showPlaceholders ? (
+              <PlaceholderBubbles />
+            ) : loading ? (
               <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
                 <Loader />
               </View>


### PR DESCRIPTION
## Summary
- show bubble placeholders before chat data loads
- hide placeholders once messages arrive

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6862072ffdb4832dbb06b243656a17f2