### PR TITLE
Show skeleton card during swipe loading

### DIFF
--- a/components/SkeletonUserCard.js
+++ b/components/SkeletonUserCard.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, StyleSheet, Dimensions } from 'react-native';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+const CARD_HEIGHT = SCREEN_HEIGHT * 0.75;
+
+export default function SkeletonUserCard() {
+  return (
+    <View style={styles.card}>
+      <View style={styles.image} />
+      <View style={styles.info}>
+        <View style={styles.name} />
+        <View style={styles.bio} />
+        <View style={[styles.bio, { width: '60%' }]} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: SCREEN_WIDTH * 0.9,
+    height: CARD_HEIGHT,
+    borderRadius: 20,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+    elevation: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+  },
+  image: {
+    width: '100%',
+    height: '75%',
+    backgroundColor: '#eee',
+  },
+  info: {
+    padding: 15,
+  },
+  name: {
+    width: '50%',
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#ddd',
+    marginBottom: 8,
+  },
+  bio: {
+    width: '80%',
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: '#eee',
+    marginTop: 4,
+  },
+});

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -34,6 +34,7 @@ import { imageSource } from '../utils/avatar';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PropTypes from 'prop-types';
 import * as Haptics from 'expo-haptics';
+import SkeletonUserCard from '../components/SkeletonUserCard';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -97,6 +98,7 @@ const SwipeScreen = () => {
   const [showSuperLikeAnim, setShowSuperLikeAnim] = useState(false);
   const [matchLine, setMatchLine] = useState('');
   const [matchGame, setMatchGame] = useState(null);
+  const [loadingUsers, setLoadingUsers] = useState(true);
 
   const pan = useRef(new Animated.ValueXY()).current;
   const scaleRefs = useRef(Array(5).fill(null).map(() => new Animated.Value(1))).current;
@@ -126,7 +128,11 @@ const SwipeScreen = () => {
 
   useEffect(() => {
     const fetchUsers = async () => {
-      if (!currentUser?.uid) return;
+      if (!currentUser?.uid) {
+        setLoadingUsers(false);
+        return;
+      }
+      setLoadingUsers(true);
       try {
         let userQuery = db
           .collection('users')
@@ -183,6 +189,7 @@ const SwipeScreen = () => {
       } catch (e) {
         console.warn('Failed to load users', e);
       }
+      setLoadingUsers(false);
     };
     fetchUsers();
   }, [currentUser?.uid, devMode]);
@@ -471,7 +478,11 @@ const handleSwipe = async (direction) => {
           </View>
         ) : null}
         {!displayUser && (
-          <Text style={styles.noMoreText}>No more swipes</Text>
+          loadingUsers ? (
+            <SkeletonUserCard />
+          ) : (
+            <Text style={styles.noMoreText}>No more swipes</Text>
+          )
         )}
 
         <View style={styles.buttonRow}>


### PR DESCRIPTION
## Summary
- create `SkeletonUserCard` component for placeholder cards
- use skeleton card while loading users in `SwipeScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68620732133c832dbd37650749706871