### PR TITLE
Add game statistics logging

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -70,6 +70,14 @@ A copy of each invite is also stored under `users/{uid}/gameInvites/{inviteId}` 
 - `createdAt` (timestamp)
 - `updatedAt` (timestamp)
 
+## Game Stats (`gameStats/{statId}`)
+- `gameId` (string)
+- `players` (array of string)
+- `durationSec` (number)
+- `winner` (string|null) – uid of the winner or `null`
+- `moves` (array of map) – `{ action, player, at }`
+- `loggedAt` (timestamp)
+
 ## Chats
 Chat conversations occur inside match documents under the `messages` subcollection (see **Matches** above). Each event also has a chat stored at `events/{eventId}/messages` following the same message shape.
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -60,6 +60,10 @@ service cloud.firestore {
         (request.auth.uid in resource.data.players || request.auth.uid in request.resource.data.players);
     }
 
+    match /gameStats/{statId} {
+      allow read, write: if signedIn();
+    }
+
     match /chats/{chatId} {
       allow read, write: if signedIn() &&
         request.auth.uid in resource.data.participants;

--- a/hooks/useGameSession.js
+++ b/hooks/useGameSession.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { db } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { serverTimestamp, arrayUnion } from 'firebase/firestore';
 import { games } from '../games';
 import { useUser } from '../contexts/UserContext';
 import { snapshotExists } from '../utils/firestore';
@@ -74,6 +74,7 @@ export default function useGameSession(sessionId, gameId, opponentId) {
         currentPlayer: nextPlayer,
         gameover: gameover || null,
         updatedAt: serverTimestamp(),
+        moves: arrayUnion({ action: moveName, player: String(idx), at: serverTimestamp() }),
       });
   }, [session, Game, sessionId, user?.uid]);
 

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -38,6 +38,7 @@ import useBotGame from "../hooks/useBotGame";
 import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 import Loader from "../components/Loader";
+import { logGameStats } from '../utils/gameStats';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PropTypes from 'prop-types';
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
@@ -143,7 +144,10 @@ const LiveSessionScreen = ({ route, navigation }) => {
   }, [countdown, inviteId, user?.uid]);
 
   const handleGameEnd = (result) => {
-    if (result) addGameXP();
+    if (result) {
+      addGameXP();
+      if (inviteId) logGameStats(inviteId);
+    }
     setGameResult(result);
   };
 

--- a/utils/gameStats.js
+++ b/utils/gameStats.js
@@ -1,0 +1,37 @@
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/firestore';
+import { snapshotExists } from './firestore';
+
+export async function logGameStats(sessionId) {
+  if (!sessionId) return;
+  try {
+    const ref = db.collection('gameSessions').doc(sessionId);
+    const snap = await ref.get();
+    if (!snapshotExists(snap)) return;
+    const data = snap.data() || {};
+    if (!data.gameover) return;
+
+    const created = data.createdAt?.toDate?.() || data.createdAt;
+    const updated = data.updatedAt?.toDate?.() || new Date();
+    const duration = created && updated ? Math.round((updated - created) / 1000) : 0;
+    const players = data.players || [];
+    let winner = null;
+    if (data.gameover.winner != null && players[data.gameover.winner]) {
+      winner = players[data.gameover.winner];
+    }
+
+    await db
+      .collection('gameStats')
+      .doc(sessionId)
+      .set({
+        gameId: data.gameId,
+        players,
+        durationSec: duration,
+        winner,
+        moves: data.moves || [],
+        loggedAt: serverTimestamp(),
+      });
+  } catch (e) {
+    console.warn('Failed to log game stats', e);
+  }
+}


### PR DESCRIPTION
## Summary
- track moves in gameSessions documents
- log a summary to `/gameStats` on game end
- update firestore security rules for the new collection
- document `gameStats` in Firestore schema

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_68620759baa8832da39450562a6dd4bc