### PR TITLE
Log like initiator for new matches

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -61,6 +61,12 @@ A copy of each invite is also stored under `users/{uid}/gameInvites/{inviteId}` 
   - `timestamp` (timestamp)
   - `readBy` (array of string)
 
+## Match History (`matchHistory/{entryId}`)
+- `matchId` (string) – id of the related match
+- `users` (array of string) – the two user ids in the match
+- `likeInitiator` (string) – uid of the user who liked first
+- `createdAt` (timestamp)
+
 ## Game Sessions (`gameSessions/{sessionId}`)
 - `gameId` (string)
 - `players` (array of string) – user ids

--- a/firestore.rules
+++ b/firestore.rules
@@ -79,6 +79,10 @@ service cloud.firestore {
       allow read, write: if signedIn();
     }
 
+    match /matchHistory/{entryId} {
+      allow read, write: if signedIn();
+    }
+
     // List of available games for onboarding
     match /games/{gameId} {
       allow read: if true;

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -231,6 +231,17 @@ const handleSwipe = async (direction) => {
                 createdAt: serverTimestamp(),
               });
 
+            try {
+              await db.collection('matchHistory').add({
+                matchId: matchRef.id,
+                users: [currentUser.uid, displayUser.id],
+                likeInitiator: displayUser.id,
+                createdAt: serverTimestamp(),
+              });
+            } catch (historyErr) {
+              console.warn('Failed to log match history', historyErr);
+            }
+
             addMatch({
               id: matchRef.id,
               displayName: displayUser.displayName,


### PR DESCRIPTION
## Summary
- record who first liked when creating a match
- allow read/write access to `matchHistory`
- document the new collection in Firestore schema

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686207690a9c832db6e5e0863d3f3334