### PR TITLE
Record like initiator on match creation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -259,6 +259,7 @@ exports.onMatchCreated = functions.firestore
   .onCreate(async (snap, context) => {
     const data = snap.data();
     if (!data || !Array.isArray(data.users)) return null;
+    await ensureMatchHistory(data.users);
     await Promise.all(
       data.users.map((uid) =>
         pushToUser(uid, 'New Match', 'You have a new match!', {


### PR DESCRIPTION
## Summary
- ensure match history is created when a match is formed
- this stores the `likeInitiator` for later analytics

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68620a264418832db5c14ffa30fd3840