### PR TITLE
Use Toast.show in SwipeScreen

### DIFF
--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -9,7 +9,6 @@ import {
   Dimensions,
   Modal,
   StyleSheet,
-  ToastAndroid,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import GradientBackground from '../components/GradientBackground';
@@ -322,7 +321,7 @@ const handleSwipe = async (direction) => {
     }
     setShowSuperLikeAnim(true);
     handleSwipe('right');
-    ToastAndroid.show('🌟 Superliked!', ToastAndroid.SHORT);
+    Toast.show({ type: 'success', text1: '🌟 Superliked!' });
     setTimeout(() => setShowSuperLikeAnim(false), 1500);
   };
 


### PR DESCRIPTION
## Summary
- remove `ToastAndroid` import from `SwipeScreen`
- use `Toast.show` instead of `ToastAndroid.show`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68620ad827a8832d91e76c6ae1272f6c