### PR TITLE
Refactor screens into reusable components

### DIFF
--- a/components/InviteUserCard.js
+++ b/components/InviteUserCard.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { View, Text, Image, Animated } from 'react-native';
+import PropTypes from 'prop-types';
+import Card from './Card';
+import GradientButton from './GradientButton';
+import Loader from './Loader';
+import useCardPressAnimation from '../hooks/useCardPressAnimation';
+
+const InviteUserCard = ({ item, onInvite, isInvited, isLoading, theme, darkMode, width }) => {
+  const { scale, handlePressIn, handlePressOut, playSuccess } = useCardPressAnimation();
+
+  const handlePress = () => onInvite(item, playSuccess);
+
+  return (
+    <Card
+      style={{
+        backgroundColor: theme.card,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: darkMode ? '#333' : '#eee',
+        padding: 12,
+        margin: 8,
+        width,
+      }}
+    >
+      <View style={{ alignItems: 'center' }}>
+        <Image
+          source={item.photo}
+          style={{ width: 50, height: 50, borderRadius: 25, marginBottom: 8 }}
+        />
+        <Text style={{ fontSize: 15, fontWeight: '600', color: theme.text }}>
+          {item.displayName}
+        </Text>
+        <Text style={{ fontSize: 12, color: item.online ? '#2ecc71' : '#999', marginBottom: 6 }}>
+          {item.online ? 'Online' : 'Offline'}
+        </Text>
+        {isInvited && isLoading ? (
+          <View style={{ alignItems: 'center', marginTop: 8 }}>
+            <Loader size="small" />
+            <Text style={{ color: theme.textSecondary, fontSize: 12, marginTop: 4 }}>
+              Waiting for {item.displayName}...
+            </Text>
+          </View>
+        ) : (
+          <Animated.View style={{ transform: [{ scale }] }}>
+            <GradientButton
+              text="Invite"
+              onPress={handlePress}
+              onPressIn={handlePressIn}
+              onPressOut={handlePressOut}
+              width={120}
+              style={{ marginTop: 6 }}
+            />
+          </Animated.View>
+        )}
+      </View>
+    </Card>
+  );
+};
+
+InviteUserCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  onInvite: PropTypes.func.isRequired,
+  isInvited: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  theme: PropTypes.object.isRequired,
+  darkMode: PropTypes.bool,
+  width: PropTypes.number.isRequired,
+};
+
+export default InviteUserCard;

--- a/components/stats/ProfileCard.js
+++ b/components/stats/ProfileCard.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, Image } from 'react-native';
+import PropTypes from 'prop-types';
+import { avatarSource } from '../../utils/avatar';
+
+const ProfileCard = ({ user, isPremium, styles, accent }) => (
+  <View style={styles.profileCard}>
+    <Image source={avatarSource(user?.photoURL)} style={styles.avatar} />
+    <Text style={styles.name}>{user?.displayName || 'User'}</Text>
+    {isPremium && (
+      <Text style={[styles.premiumBadge, { backgroundColor: accent }]}>★ Premium</Text>
+    )}
+  </View>
+);
+
+ProfileCard.propTypes = {
+  user: PropTypes.object,
+  isPremium: PropTypes.bool,
+  styles: PropTypes.object.isRequired,
+  accent: PropTypes.string.isRequired,
+};
+
+export default ProfileCard;

--- a/components/stats/StatBox.js
+++ b/components/stats/StatBox.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+const StatBox = ({ loading, styles, children }) => (
+  <View style={styles.statBox}>
+    {loading ? (
+      <>
+        <View style={styles.skeletonLabel} />
+        <View style={styles.skeletonValue} />
+      </>
+    ) : (
+      children
+    )}
+  </View>
+);
+
+StatBox.propTypes = {
+  loading: PropTypes.bool,
+  styles: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default StatBox;

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -4,15 +4,11 @@ import {
   Text,
   FlatList,
   TouchableOpacity,
-  Image,
   TextInput,
   Dimensions,
-  Animated,
 } from 'react-native';
 import * as Haptics from 'expo-haptics';
-import Loader from '../components/Loader';
 import SafeKeyboardView from '../components/SafeKeyboardView';
-import Card from '../components/Card';
 import GradientBackground from '../components/GradientBackground';
 import GradientButton from '../components/GradientButton';
 import Header from '../components/Header';
@@ -26,7 +22,7 @@ import { useChats } from '../contexts/ChatContext';
 import { useUser } from '../contexts/UserContext';
 import Toast from 'react-native-toast-message';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
-import useCardPressAnimation from '../hooks/useCardPressAnimation';
+import InviteUserCard from '../components/InviteUserCard';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const CARD_WIDTH = SCREEN_WIDTH / 2 - 24;
@@ -116,63 +112,16 @@ const GameInviteScreen = ({ route, navigation }) => {
     const isInvited = invited[item.id];
     const isLoading = loadingId === item.id;
 
-    const {
-      scale,
-      handlePressIn,
-      handlePressOut,
-      playSuccess,
-    } = useCardPressAnimation();
-
     return (
-      <Card
-        style={{
-          backgroundColor: theme.card,
-          borderRadius: 16,
-          borderWidth: 1,
-          borderColor: darkMode ? '#333' : '#eee',
-          padding: 12,
-          margin: 8,
-          width: CARD_WIDTH
-        }}
-      >
-        <View style={{ alignItems: 'center' }}>
-          <Image
-            source={item.photo}
-            style={{
-              width: 50,
-              height: 50,
-              borderRadius: 25,
-              marginBottom: 8
-            }}
-          />
-          <Text style={{ fontSize: 15, fontWeight: '600', color: theme.text }}>
-            {item.displayName}
-          </Text>
-          <Text style={{ fontSize: 12, color: item.online ? '#2ecc71' : '#999', marginBottom: 6 }}>
-            {item.online ? 'Online' : 'Offline'}
-          </Text>
-
-          {isInvited && isLoading ? (
-            <View style={{ alignItems: 'center', marginTop: 8 }}>
-              <Loader size="small" />
-              <Text style={{ color: theme.textSecondary, fontSize: 12, marginTop: 4 }}>
-                Waiting for {item.displayName}...
-              </Text>
-            </View>
-          ) : (
-            <Animated.View style={{ transform: [{ scale }] }}>
-              <GradientButton
-                text="Invite"
-                onPress={() => handleInvite(item, playSuccess)}
-                onPressIn={handlePressIn}
-                onPressOut={handlePressOut}
-                width={120}
-                style={{ marginTop: 6 }}
-              />
-            </Animated.View>
-          )}
-        </View>
-      </Card>
+      <InviteUserCard
+        item={item}
+        onInvite={handleInvite}
+        isInvited={isInvited}
+        isLoading={isLoading}
+        theme={theme}
+        darkMode={darkMode}
+        width={CARD_WIDTH}
+      />
     );
   };
 

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -1,17 +1,18 @@
 // /screens/StatsScreen.js
 
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, Image, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import GradientButton from '../components/GradientButton';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { db } from '../firebase';
-import { avatarSource } from '../utils/avatar';
 import ProgressBar from '../components/ProgressBar';
 import PropTypes from 'prop-types';
 import { HEADER_SPACING, FONT_SIZES, BUTTON_STYLE } from '../layout';
+import ProfileCard from '../components/stats/ProfileCard';
+import StatBox from '../components/stats/StatBox';
 
 const StatsScreen = ({ navigation }) => {
   const { theme } = useTheme();
@@ -19,12 +20,6 @@ const StatsScreen = ({ navigation }) => {
   const { user } = useUser();
   const isPremium = !!user?.isPremium;
 
-  const StatSkeleton = () => (
-    <>
-      <View style={styles.skeletonLabel} />
-      <View style={styles.skeletonValue} />
-    </>
-  );
 
   const [stats, setStats] = useState({
     gamesPlayed: 0,
@@ -112,114 +107,61 @@ const StatsScreen = ({ navigation }) => {
       <Header showLogoOnly />
       <ScrollView contentContainerStyle={styles.container}>
         {/* Profile Summary */}
-        <View style={styles.profileCard}>
-          <Image source={avatarSource(user?.photoURL)} style={styles.avatar} />
-          <Text style={styles.name}>{user?.displayName || 'User'}</Text>
-          {isPremium && <Text style={styles.premiumBadge}>★ Premium</Text>}
-        </View>
+        <ProfileCard
+          user={user}
+          isPremium={isPremium}
+          styles={styles}
+          accent={theme.accent}
+        />
 
         {/* Game Stats */}
         <Text style={styles.sectionTitle}>🎮 Game Stats</Text>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Games Played</Text>
-              <Text style={styles.statValue}>{stats.gamesPlayed}</Text>
-            </>
-          )}
-        </View>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Games Won</Text>
-              <Text style={styles.statValue}>{stats.gamesWon}</Text>
-            </>
-          )}
-        </View>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Favorite Games</Text>
-              <Text style={styles.statValue}>
-                {stats.favoriteGames.length > 0 ? stats.favoriteGames.join(', ') : 'N/A'}
-              </Text>
-            </>
-          )}
-        </View>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>{`XP Level ${level}`}</Text>
-              <ProgressBar value={xpProgress} max={100} color={theme.accent} />
-              <Text style={styles.statSub}>{stats.xp} XP</Text>
-            </>
-          )}
-        </View>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Games Played</Text>
+          <Text style={styles.statValue}>{stats.gamesPlayed}</Text>
+        </StatBox>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Games Won</Text>
+          <Text style={styles.statValue}>{stats.gamesWon}</Text>
+        </StatBox>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Favorite Games</Text>
+          <Text style={styles.statValue}>
+            {stats.favoriteGames.length > 0 ? stats.favoriteGames.join(', ') : 'N/A'}
+          </Text>
+        </StatBox>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>{`XP Level ${level}`}</Text>
+          <ProgressBar value={xpProgress} max={100} color={theme.accent} />
+          <Text style={styles.statSub}>{stats.xp} XP</Text>
+        </StatBox>
 
         {/* Social Stats */}
         <Text style={styles.sectionTitle}>💬 Social Stats</Text>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Matches</Text>
-              <Text style={styles.statValue}>{stats.matches}</Text>
-            </>
-          )}
-        </View>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Swipes</Text>
-              <Text style={styles.statValue}>{stats.swipes}</Text>
-            </>
-          )}
-        </View>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Messages Sent</Text>
-              <Text style={styles.statValue}>{stats.messagesSent}</Text>
-            </>
-          )}
-        </View>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Matches</Text>
+          <Text style={styles.statValue}>{stats.matches}</Text>
+        </StatBox>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Swipes</Text>
+          <Text style={styles.statValue}>{stats.swipes}</Text>
+        </StatBox>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Messages Sent</Text>
+          <Text style={styles.statValue}>{stats.messagesSent}</Text>
+        </StatBox>
 
         {/* Bonus + Upgrade */}
         <Text style={styles.sectionTitle}>🔥 Activity</Text>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Daily Streak</Text>
-              <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
-              <Text style={styles.statSub}>{stats.streak} days</Text>
-            </>
-          )}
-        </View>
-        <View style={styles.statBox}>
-          {loading ? (
-            <StatSkeleton />
-          ) : (
-            <>
-              <Text style={styles.statLabel}>Badge</Text>
-              <Text style={styles.statValue}>{stats.badge}</Text>
-            </>
-          )}
-        </View>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Daily Streak</Text>
+          <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
+          <Text style={styles.statSub}>{stats.streak} days</Text>
+        </StatBox>
+        <StatBox loading={loading} styles={styles}>
+          <Text style={styles.statLabel}>Badge</Text>
+          <Text style={styles.statValue}>{stats.badge}</Text>
+        </StatBox>
 
         {!isPremium && (
           <GradientButton


### PR DESCRIPTION
## Summary
- extract `ProfileCard` and `StatBox` widgets for statistics
- use new widgets inside `StatsScreen`
- add `InviteUserCard` widget for user invites
- update `GameInviteScreen` to use `InviteUserCard`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68620ad99740832da573446978798ec3