### PR TITLE
Unify styling and remove Android-only toast

### DIFF
--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { TextInput } from 'react-native';
 import SafeKeyboardView from './SafeKeyboardView';
 import GradientButton from './GradientButton';
-import styles from '../styles';
+import getStyles from '../styles';
+import { useTheme } from '../contexts/ThemeContext';
 
 export interface AuthFormProps {
   email: string;
@@ -23,6 +24,8 @@ export default function AuthForm({
   submitLabel,
   children,
 }: AuthFormProps) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
   return (
     <SafeKeyboardView style={{ flex: 1, justifyContent: 'center', alignItems: 'center', width: '100%' }}>
       <TextInput
@@ -32,7 +35,7 @@ export default function AuthForm({
         onChangeText={onEmailChange}
         keyboardType="email-address"
         autoCapitalize="none"
-        placeholderTextColor="#ccc"
+        placeholderTextColor={theme.textSecondary}
       />
       <TextInput
         style={styles.input}
@@ -41,10 +44,11 @@ export default function AuthForm({
         onChangeText={onPasswordChange}
         secureTextEntry
         autoCapitalize="none"
-        placeholderTextColor="#ccc"
+        placeholderTextColor={theme.textSecondary}
       />
       <GradientButton text={submitLabel} onPress={onSubmit} />
       {children}
     </SafeKeyboardView>
   );
 }
+

--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -3,7 +3,6 @@ import { View, Text, Image, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
-import styles from '../styles';
 import { eventImageSource } from '../utils/avatar';
 import GradientButton from './GradientButton';
 

--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -3,10 +3,11 @@ import React from 'react';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
-import styles from '../styles';
+import getStyles from '../styles';
 
 export default function GradientBackground({ children, colors, style }) {
   const { theme } = useTheme();
+  const styles = getStyles(theme);
   const gradientColors = colors || [theme.gradientStart, theme.gradientEnd];
 
   return (

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -17,7 +17,6 @@ import PropTypes from 'prop-types';
 import Header from '../components/Header';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
-import styles from '../styles';
 import { games, gameList } from '../games';
 import { icebreakers } from '../data/prompts';
 import { db } from '../firebase';

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -18,7 +18,6 @@ import GradientButton from '../components/GradientButton';
 import Card from '../components/Card';
 import { eventImageSource } from '../utils/avatar';
 import Header from '../components/Header';
-import styles from '../styles';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNavigation } from '@react-navigation/native';
 import PropTypes from 'prop-types';

--- a/screens/EmailAuthScreen.js
+++ b/screens/EmailAuthScreen.js
@@ -11,13 +11,16 @@ import { serverTimestamp } from 'firebase/firestore';
 import { useOnboarding } from '../contexts/OnboardingContext';
 import { snapshotExists } from '../utils/firestore';
 import { isAllowedDomain } from '../utils/email';
-import styles from '../styles';
+import getStyles from '../styles';
+import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
 
 export default function EmailAuthScreen({ route, navigation }) {
   const mode = route.params?.mode || (route.name === 'Signup' ? 'signup' : 'login');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
   const { markOnboarded } = useOnboarding();
 
   const ensureUserDoc = async (fbUser) => {
@@ -89,7 +92,7 @@ export default function EmailAuthScreen({ route, navigation }) {
 
   return (
     <GradientBackground>
-      <Text style={[styles.logoText, { color: '#fff' }]}>
+      <Text style={[styles.logoText, { color: theme.text }]}>
         {mode === 'signup' ? 'Create Account' : 'Log In'}
       </Text>
       <AuthForm
@@ -103,15 +106,15 @@ export default function EmailAuthScreen({ route, navigation }) {
         {mode === 'login' ? (
           <>
             <TouchableOpacity onPress={() => navigation.navigate('Signup')}>
-              <Text style={{ color: '#fff', marginTop: 10 }}>Need an account? Sign Up</Text>
+              <Text style={{ color: theme.text, marginTop: 10 }}>Need an account? Sign Up</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={() => navigation.goBack()}>
-              <Text style={{ color: '#fff', marginTop: 10 }}>← Back</Text>
+              <Text style={{ color: theme.text, marginTop: 10 }}>← Back</Text>
             </TouchableOpacity>
           </>
         ) : (
           <TouchableOpacity onPress={() => navigation.goBack()} style={{ marginTop: 20 }}>
-            <Text style={{ color: '#fff' }}>← Back to Login</Text>
+            <Text style={{ color: theme.text }}>← Back to Login</Text>
           </TouchableOpacity>
         )}
       </AuthForm>

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -21,7 +21,7 @@ import { useDev } from '../contexts/DevContext';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
 import PropTypes from 'prop-types';
-import styles from '../styles';
+import getGlobalStyles from '../styles';
 import { useChats } from '../contexts/ChatContext';
 import { useUser } from '../contexts/UserContext';
 import Toast from 'react-native-toast-message';
@@ -37,6 +37,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   const gameTitle = typeof rawGame === 'string' ? rawGame : rawGame?.title || 'a game';
   const gameId = typeof rawGame === 'object' ? rawGame.id : null;
   const { darkMode, theme } = useTheme();
+  const styles = getGlobalStyles(theme);
   const { devMode } = useDev();
   const { user: currentUser } = useUser();
   const { matches: chatMatches } = useChats();

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -24,7 +24,7 @@ import { useUser } from '../contexts/UserContext';
 import { db } from '../firebase';
 import { serverTimestamp } from 'firebase/firestore';
 import * as Haptics from 'expo-haptics';
-import styles from '../styles';
+import getGlobalStyles from '../styles';
 import { games } from '../games';
 import SyncedGame from '../components/SyncedGame';
 import GameOverModal from '../components/GameOverModal';
@@ -53,7 +53,8 @@ const GameSessionScreen = ({ route, navigation, sessionType }) => {
 
 const LiveSessionScreen = ({ route, navigation }) => {
   const { darkMode, theme } = useTheme();
-  const local = getStyles(theme);
+  const globalStyles = getGlobalStyles(theme);
+  const local = createStyles(theme);
   const { devMode } = useDev();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
   const { user, addGameXP } = useUser();
@@ -187,7 +188,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
 
   if (!game || !opponent) {
     return (
-      <GradientBackground style={styles.swipeScreen}>
+      <GradientBackground style={globalStyles.swipeScreen}>
         <Header showLogoOnly />
         <Text style={{ marginTop: 80, color: theme.text }}>
           Invalid game data.
@@ -197,7 +198,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
   }
 
   return (
-    <GradientBackground style={styles.swipeScreen}>
+    <GradientBackground style={globalStyles.swipeScreen}>
       <Header showLogoOnly />
 
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -648,7 +649,7 @@ const getBotStyles = (theme) =>
   tabText: { fontWeight: 'bold' },
 });
 
-const getStyles = (theme) =>
+const createStyles = (theme) =>
   StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -13,7 +13,7 @@ import * as Haptics from 'expo-haptics';
 import GradientButton from '../components/GradientButton';
 import Loader from '../components/Loader';
 import Header from '../components/Header';
-import styles from '../styles';
+import getStyles from '../styles';
 import GradientBackground from '../components/GradientBackground';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { useUser } from '../contexts/UserContext';
@@ -52,6 +52,7 @@ const NotificationsScreen = ({ navigation }) => {
   const { incomingInvites, acceptGameInvite, cancelGameInvite } = useMatchmaking();
   const { user } = useUser();
   const { darkMode, theme } = useTheme();
+  const styles = getStyles(theme);
   const [loadingId, setLoadingId] = useState(null);
   const [invitesLoaded, setInvitesLoaded] = useState(false);
 

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -7,7 +7,7 @@ import {
 } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import SafeKeyboardView from '../components/SafeKeyboardView';
-import styles from '../styles';
+import getGlobalStyles from '../styles';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
@@ -29,6 +29,7 @@ const getAllCategories = () => {
 
 const PlayScreen = ({ navigation }) => {
   const { darkMode, theme } = useTheme();
+  const styles = getGlobalStyles(theme);
   const { user } = useUser();
   const { devMode } = useDev();
   const { gamesLeft } = useGameLimit();

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -12,7 +12,6 @@ import GradientButton from '../components/GradientButton';
 import GradientBackground from '../components/GradientBackground';
 import * as WebBrowser from 'expo-web-browser';
 import Header from '../components/Header';
-import styles from '../styles';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { functions } from '../firebase';

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -5,7 +5,7 @@ import { Text, TextInput, TouchableOpacity, View, Image } from 'react-native';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientBackground from '../components/GradientBackground';
 import GradientButton from '../components/GradientButton';
-import styles from '../styles';
+import getStyles from '../styles';
 import { HEADER_SPACING } from '../layout';
 import Header from '../components/Header';
 import { useUser } from '../contexts/UserContext';
@@ -24,6 +24,7 @@ import { allGames } from '../data/games';
 const ProfileScreen = ({ navigation, route }) => {
   const { user, updateUser } = useUser();
   const { theme } = useTheme();
+  const styles = getStyles(theme);
   const [editMode, setEditMode] = useState(route?.params?.editMode || false);
   const [displayName, setDisplayName] = useState(user?.displayName || '');
   const [age, setAge] = useState(user?.age ? String(user.age) : '');

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Text, View } from 'react-native';
 import GradientButton from '../components/GradientButton';
 import GradientBackground from '../components/GradientBackground';
-import styles from '../styles';
+import getStyles from '../styles';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 
 const SettingsScreen = ({ navigation }) => {
   const { darkMode, toggleTheme, theme } = useTheme();
+  const styles = getStyles(theme);
   const { user } = useUser();
   const isPremium = !!user?.isPremium;
   const { devMode, toggleDevMode } = useDev();

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -4,7 +4,7 @@ import { Animated, Image, StatusBar, Text } from 'react-native';
 import LottieView from 'lottie-react-native';
 import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
-import styles from '../styles';
+import getStyles from '../styles';
 import PropTypes from 'prop-types';
 
 const splashDuration = 2000;
@@ -24,6 +24,7 @@ const useFadeIn = (duration = 1000) => {
 export default function SplashScreen({ onFinish }) {
   const fadeAnim = useFadeIn();
   const { darkMode, theme } = useTheme();
+  const styles = getStyles(theme);
   const colors = [theme.gradientStart, theme.gradientEnd];
 
   useEffect(() => {

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -9,7 +9,6 @@ import {
   Dimensions,
   Modal,
   StyleSheet,
-  ToastAndroid,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import GradientBackground from '../components/GradientBackground';
@@ -322,7 +321,7 @@ const handleSwipe = async (direction) => {
     }
     setShowSuperLikeAnim(true);
     handleSwipe('right');
-    ToastAndroid.show('🌟 Superliked!', ToastAndroid.SHORT);
+    Toast.show({ type: 'success', text1: '🌟 Superliked!' });
     setTimeout(() => setShowSuperLikeAnim(false), 1500);
   };
 

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -4,7 +4,8 @@ import { Image, Text } from 'react-native';
 import Toast from 'react-native-toast-message';
 import GradientBackground from '../../components/GradientBackground';
 import GradientButton from '../../components/GradientButton';
-import styles from '../../styles';
+import getStyles from '../../styles';
+import { useTheme } from '../../contexts/ThemeContext';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
 import * as AuthSession from 'expo-auth-session';
@@ -23,6 +24,8 @@ export default function LoginScreen() {
   const navigation = useNavigation();
   const { markOnboarded } = useOnboarding();
   const { toggleDevMode } = useDev();
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
 
   const redirectUri = AuthSession.makeRedirectUri({ scheme: 'pinged' });
 
@@ -70,7 +73,7 @@ export default function LoginScreen() {
   return (
     <GradientBackground>
       <Image source={require('../../assets/logo.png')} style={styles.logoImage} />
-      <Text style={[styles.logoText, { color: '#fff' }]}>Pinged</Text>
+      <Text style={[styles.logoText, { color: theme.text }]}>Pinged</Text>
 
       <GradientButton
         text="Sign in with Google"

--- a/styles.js
+++ b/styles.js
@@ -1,37 +1,38 @@
 import { StyleSheet } from 'react-native';
 import { BUTTON_STYLE, FONT_SIZES } from './layout';
 
-const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20
-  },
-  logoImage: {
-    width: 100,
-    height: 100,
-    resizeMode: 'contain',
-    marginBottom: 20
-  },
-  logoText: {
-    fontSize: FONT_SIZES.XL + 6,
-    fontWeight: '800',
-    color: '#d81b60',
-    marginBottom: 12,
-    textAlign: 'center'
-  },
-  input: {
-    width: '100%',
-    borderColor: '#d81b60',
-    borderWidth: 1,
-    borderRadius: 10,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    fontSize: FONT_SIZES.MD,
-    marginBottom: 16,
-    backgroundColor: '#fff'
-  },
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: {
+      flexGrow: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    logoImage: {
+      width: 100,
+      height: 100,
+      resizeMode: 'contain',
+      marginBottom: 20,
+    },
+    logoText: {
+      fontSize: FONT_SIZES.XL + 6,
+      fontWeight: '800',
+      color: theme.accent,
+      marginBottom: 12,
+      textAlign: 'center',
+    },
+    input: {
+      width: '100%',
+      borderColor: theme.accent,
+      borderWidth: 1,
+      borderRadius: 10,
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      fontSize: FONT_SIZES.MD,
+      marginBottom: 16,
+      backgroundColor: theme.card,
+    },
   googleBtn: {
     backgroundColor: '#4285F4',
     paddingVertical: BUTTON_STYLE.paddingVertical,
@@ -46,13 +47,13 @@ const styles = StyleSheet.create({
     shadowRadius: 6,
     elevation: 4
   },
-  emailBtn: {
-    backgroundColor: '#d81b60',
-    paddingVertical: BUTTON_STYLE.paddingVertical,
-    paddingHorizontal: BUTTON_STYLE.paddingHorizontal,
-    borderRadius: BUTTON_STYLE.borderRadius,
-    width: '100%',
-    alignItems: 'center',
+    emailBtn: {
+      backgroundColor: theme.accent,
+      paddingVertical: BUTTON_STYLE.paddingVertical,
+      paddingHorizontal: BUTTON_STYLE.paddingHorizontal,
+      borderRadius: BUTTON_STYLE.borderRadius,
+      width: '100%',
+      alignItems: 'center',
     marginBottom: 10,
     shadowColor: '#000',
     shadowOpacity: 0.2,
@@ -60,13 +61,13 @@ const styles = StyleSheet.create({
     shadowRadius: 6,
     elevation: 4
   },
-  btnText: {
-    color: '#fff',
-    fontSize: FONT_SIZES.MD,
-    fontWeight: '600'
-  },
+    btnText: {
+      color: '#fff',
+      fontSize: FONT_SIZES.MD,
+      fontWeight: '600',
+    },
   backLink: {
-    color: '#666',
+    color: theme.textSecondary,
     fontSize: FONT_SIZES.SM,
     marginTop: 20,
     textDecorationLine: 'underline'
@@ -77,25 +78,25 @@ const styles = StyleSheet.create({
     width: '100%',
     marginBottom: 16
   },
-  genderButton: {
-    flex: 1,
-    marginHorizontal: 4,
-    paddingVertical: BUTTON_STYLE.paddingVertical,
-    paddingHorizontal: BUTTON_STYLE.paddingHorizontal,
-    borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: BUTTON_STYLE.borderRadius,
-    alignItems: 'center',
-    backgroundColor: '#fff'
-  },
-  genderSelected: {
-    backgroundColor: '#d81b60',
-    borderColor: '#d81b60'
-  },
-  genderText: {
-    fontSize: FONT_SIZES.MD,
-    color: '#333'
-  },
+    genderButton: {
+      flex: 1,
+      marginHorizontal: 4,
+      paddingVertical: BUTTON_STYLE.paddingVertical,
+      paddingHorizontal: BUTTON_STYLE.paddingHorizontal,
+      borderWidth: 1,
+      borderColor: theme.textSecondary,
+      borderRadius: BUTTON_STYLE.borderRadius,
+      alignItems: 'center',
+      backgroundColor: theme.card,
+    },
+    genderSelected: {
+      backgroundColor: theme.accent,
+      borderColor: theme.accent,
+    },
+    genderText: {
+      fontSize: FONT_SIZES.MD,
+      color: theme.text,
+    },
   genderTextSelected: {
     color: '#fff'
   },
@@ -104,11 +105,11 @@ const styles = StyleSheet.create({
   },
   uploadText: {
     fontSize: FONT_SIZES.MD,
-    color: '#888',
+    color: theme.textSecondary,
     textDecorationLine: 'underline'
   },
   navBtn: {
-    backgroundColor: '#222',
+    backgroundColor: theme.text,
     paddingVertical: BUTTON_STYLE.paddingVertical,
     paddingHorizontal: BUTTON_STYLE.paddingHorizontal,
     borderRadius: BUTTON_STYLE.borderRadius,
@@ -126,8 +127,8 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZES.MD,
     fontWeight: '600'
   },
-  card: {
-    backgroundColor: '#fff',
+    card: {
+      backgroundColor: theme.card,
     borderRadius: 20,
     padding: 20,
     shadowColor: '#000',
@@ -147,38 +148,38 @@ const styles = StyleSheet.create({
   cardName: {
     fontSize: FONT_SIZES.XL,
     fontWeight: 'bold',
-    color: '#222'
+    color: theme.text,
   },
   cardBio: {
     fontSize: FONT_SIZES.MD,
-    color: '#666',
+    color: theme.textSecondary,
     marginTop: 8,
     textAlign: 'center'
   },
-  matchCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#fef2f6',
-    padding: 16,
-    marginVertical: 8,
-    borderRadius: 12,
-    width: '100%'
-  },
+    matchCard: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: theme.card,
+      padding: 16,
+      marginVertical: 8,
+      borderRadius: 12,
+      width: '100%',
+    },
   matchAvatar: {
     width: 60,
     height: 60,
     borderRadius: 30,
     marginRight: 16
   },
-  gameCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#fff0f5',
-    padding: 16,
-    marginBottom: 12,
-    borderRadius: 12,
-    width: '100%'
-  },
+    gameCard: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: theme.card,
+      padding: 16,
+      marginBottom: 12,
+      borderRadius: 12,
+      width: '100%',
+    },
   gameIcon: {
     fontSize: 28,
     marginRight: 16
@@ -187,22 +188,22 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZES.MD,
     fontWeight: '600'
   },
-  notificationBox: {
-    backgroundColor: '#ffe0ec',
-    padding: 14,
-    marginVertical: 6,
-    borderRadius: 10,
-    width: '100%'
-  },
-  notificationText: {
-    fontSize: FONT_SIZES.MD,
-    color: '#d81b60'
-  },
-  settingText: {
-    fontSize: FONT_SIZES.MD,
-    color: '#666',
-    marginBottom: 6
-  },
+    notificationBox: {
+      backgroundColor: theme.card,
+      padding: 14,
+      marginVertical: 6,
+      borderRadius: 10,
+      width: '100%',
+    },
+    notificationText: {
+      fontSize: FONT_SIZES.MD,
+      color: theme.accent,
+    },
+    settingText: {
+      fontSize: FONT_SIZES.MD,
+      color: theme.textSecondary,
+      marginBottom: 6,
+    },
   swipeScreen: {
     flex: 1,
     justifyContent: 'center',
@@ -232,6 +233,6 @@ const styles = StyleSheet.create({
     fontSize: 28,
     color: '#fff'
   }
-});
+  });
 
-export default styles;
+export default getStyles;


### PR DESCRIPTION
## Summary
- centralize styling through a theme based `getStyles`
- use the new style getter across screens and components
- remove the remaining `ToastAndroid` call
- reference theme colors in auth screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68620adcd094832dab460b935f042a5d