### PR TITLE
Switch to Firebase compat APIs

### DIFF
--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -3,16 +3,8 @@ import * as WebBrowser from "expo-web-browser";
 import * as Google from "expo-auth-session/providers/google";
 import * as AuthSession from "expo-auth-session";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { auth, firestore } from "../firebase";
+import firebase, { auth, db } from "../firebase";
 import { clearStoredOnboarding } from "./OnboardingContext";
-import {
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-  onAuthStateChanged,
-  signInWithCredential,
-  signOut,
-  GoogleAuthProvider,
-} from "firebase/auth";
 import { serverTimestamp } from "firebase/firestore";
 import { snapshotExists } from "../utils/firestore";
 import { isAllowedDomain } from "../utils/email";
@@ -33,7 +25,7 @@ export const AuthProvider = ({ children }) => {
 
   const ensureUserDoc = async (fbUser) => {
     try {
-      const ref = firestore.collection("users").doc(fbUser.uid);
+      const ref = db.collection("users").doc(fbUser.uid);
       const snap = await ref.get();
       if (!snapshotExists(snap)) {
         await ref.set({
@@ -51,8 +43,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   const loginWithEmail = async (email, password) => {
-    const userCred = await signInWithEmailAndPassword(
-      auth,
+    const userCred = await auth.signInWithEmailAndPassword(
       email.trim(),
       password,
     );
@@ -63,8 +54,7 @@ export const AuthProvider = ({ children }) => {
     if (!isAllowedDomain(email)) {
       throw new Error("Email domain not supported");
     }
-    const userCred = await createUserWithEmailAndPassword(
-      auth,
+    const userCred = await auth.createUserWithEmailAndPassword(
       email.trim(),
       password,
     );
@@ -75,7 +65,7 @@ export const AuthProvider = ({ children }) => {
     } catch (e) {
       console.warn("Failed to clear stored matches", e);
     }
-    await firestore
+    await db
       .collection("users")
       .doc(userCred.user.uid)
       .set({
@@ -93,11 +83,11 @@ export const AuthProvider = ({ children }) => {
 
   const logout = async () => {
     if (user?.uid) await clearStoredOnboarding(user.uid);
-    return signOut(auth);
+    return auth.signOut();
   };
 
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, async (fbUser) => {
+    const unsub = firebase.auth().onAuthStateChanged(async (fbUser) => {
       setUser(fbUser);
       if (fbUser) await ensureUserDoc(fbUser);
       setLoading(false);
@@ -108,8 +98,9 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     if (response?.type === "success") {
       const { id_token } = response.params;
-      const credential = GoogleAuthProvider.credential(id_token);
-      signInWithCredential(auth, credential)
+      const credential = firebase.auth.GoogleAuthProvider.credential(id_token);
+      auth
+        .signInWithCredential(credential)
         .then((res) => ensureUserDoc(res.user))
         .catch((err) => console.warn("Google login failed", err));
     }

--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -2,8 +2,8 @@ import React, { createContext, useContext, useState, useEffect, useRef } from 'r
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useDev } from './DevContext';
 import { useUser } from './UserContext';
-import { firestore } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 import { useListeners } from './ListenerContext';
 import Toast from 'react-native-toast-message';
 import * as Haptics from 'expo-haptics';
@@ -80,7 +80,7 @@ export const ChatProvider = ({ children }) => {
   const userUnsubs = useRef({});
   useEffect(() => {
     if (!user?.uid) return;
-    const q = firestore.collection('matches').where('users', 'array-contains', user.uid);
+    const q = db.collection('matches').where('users', 'array-contains', user.uid);
     const unsub = q.onSnapshot((snap) => {
       const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 
@@ -127,7 +127,7 @@ export const ChatProvider = ({ children }) => {
       // Subscribe to each user's profile for presence
       userIds.forEach((uid) => {
         if (!userUnsubs.current[uid]) {
-          userUnsubs.current[uid] = firestore
+          userUnsubs.current[uid] = db
             .collection('users')
             .doc(uid)
             .onSnapshot((doc) => {
@@ -183,7 +183,7 @@ export const ChatProvider = ({ children }) => {
   const sendMessage = async (matchId, text, sender = 'you') => {
     if (!text || !matchId || !user?.uid) return;
     try {
-      await firestore
+      await db
         .collection('matches')
         .doc(matchId)
         .collection('messages')
@@ -277,7 +277,7 @@ export const ChatProvider = ({ children }) => {
     if (!user?.uid) return;
     setLoading(true);
     try {
-      const snap = await firestore
+      const snap = await db
         .collection('matches')
         .where('users', 'array-contains', user.uid)
         .get();

--- a/contexts/GameLimitContext.js
+++ b/contexts/GameLimitContext.js
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useUser } from './UserContext';
 import { useDev } from './DevContext';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import { serverTimestamp } from 'firebase/firestore';
 
 const GameLimitContext = createContext();
@@ -40,7 +40,7 @@ export const GameLimitProvider = ({ children }) => {
     }
     setGamesLeft(Math.max(DAILY_LIMIT - count, 0));
     try {
-      await firestore
+      await db
         .collection('users')
         .doc(user.uid)
         .update({

--- a/contexts/ListenerContext.js
+++ b/contexts/ListenerContext.js
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import * as Haptics from 'expo-haptics';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import { useUser } from './UserContext';
 
 const ListenerContext = createContext();
@@ -21,7 +21,7 @@ export const ListenerProvider = ({ children }) => {
   // Subscribe to match messages for current user
   useEffect(() => {
     if (!user?.uid) return;
-    const matchQ = firestore
+    const matchQ = db
       .collection('matches')
       .where('users', 'array-contains', user.uid);
     const unsubMatches = matchQ.onSnapshot((snap) => {
@@ -30,7 +30,7 @@ export const ListenerProvider = ({ children }) => {
       Object.values(messageUnsubs.current).forEach((u) => u && u());
       messageUnsubs.current = {};
       ids.forEach((id) => {
-        const q = firestore
+        const q = db
           .collection('matches')
           .doc(id)
           .collection('messages')
@@ -64,7 +64,7 @@ export const ListenerProvider = ({ children }) => {
   // Subscribe to invites and match requests
   useEffect(() => {
     if (!user?.uid) return;
-    const reqRef = firestore.collection('matchRequests');
+    const reqRef = db.collection('matchRequests');
     const outQ = reqRef.where('from', '==', user.uid);
     const inQ = reqRef.where('to', '==', user.uid);
 
@@ -78,7 +78,7 @@ export const ListenerProvider = ({ children }) => {
       setIncomingRequests(data);
     });
 
-    const inviteRef = firestore.collection('gameInvites');
+    const inviteRef = db.collection('gameInvites');
     const outInvQ = inviteRef.where('from', '==', user.uid);
     const inInvQ = inviteRef.where('to', '==', user.uid);
 
@@ -103,7 +103,7 @@ export const ListenerProvider = ({ children }) => {
   // Subscribe to game sessions for current user
   useEffect(() => {
     if (!user?.uid) return;
-    const q = firestore
+    const q = db
       .collection('gameSessions')
       .where('players', 'array-contains', user.uid);
     const unsub = q.onSnapshot((snap) => {

--- a/contexts/MatchmakingContext.js
+++ b/contexts/MatchmakingContext.js
@@ -1,9 +1,9 @@
 import React, { createContext, useContext } from 'react';
-import { firestore } from '../firebase';
-import { serverTimestamp, arrayUnion } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp, arrayUnion } from 'firebase/db';
 import { useUser } from './UserContext';
 import { useListeners } from './ListenerContext';
-import { snapshotExists } from '../utils/firestore';
+import { snapshotExists } from '../utils/db';
 import { createMatchIfMissing } from '../utils/matches';
 
 const MatchmakingContext = createContext();
@@ -19,7 +19,7 @@ export const MatchmakingProvider = ({ children }) => {
 
   const sendMatchRequest = async (to) => {
     if (!user?.uid || !to) return null;
-    const ref = await firestore.collection('matchRequests').add({
+    const ref = await db.collection('matchRequests').add({
       from: user.uid,
       to,
       status: 'pending',
@@ -30,7 +30,7 @@ export const MatchmakingProvider = ({ children }) => {
 
   const acceptMatchRequest = async (id) => {
     if (!user?.uid || !id) return;
-    const ref = firestore.collection('matchRequests').doc(id);
+    const ref = db.collection('matchRequests').doc(id);
     const snap = await ref.get();
     const data = snap.data();
     if (!snapshotExists(snap) || (data.from !== user.uid && data.to !== user.uid)) return;
@@ -39,7 +39,7 @@ export const MatchmakingProvider = ({ children }) => {
 
   const cancelMatchRequest = async (id) => {
     if (!user?.uid || !id) return;
-    const ref = firestore.collection('matchRequests').doc(id);
+    const ref = db.collection('matchRequests').doc(id);
     const snap = await ref.get();
     const data = snap.data();
     if (!snapshotExists(snap) || (data.from !== user.uid && data.to !== user.uid)) return;
@@ -57,16 +57,16 @@ export const MatchmakingProvider = ({ children }) => {
       acceptedBy: [user.uid],
       createdAt: serverTimestamp(),
     };
-    const ref = await firestore.collection('gameInvites').add(payload);
+    const ref = await db.collection('gameInvites').add(payload);
     const inviteData = { ...payload, inviteId: ref.id };
     try {
-      await firestore
+      await db
         .collection('users')
         .doc(user.uid)
         .collection('gameInvites')
         .doc(ref.id)
         .set(inviteData);
-      await firestore
+      await db
         .collection('users')
         .doc(to)
         .collection('gameInvites')
@@ -80,7 +80,7 @@ export const MatchmakingProvider = ({ children }) => {
 
   const acceptGameInvite = async (id) => {
     if (!user?.uid || !id) return;
-    const ref = firestore.collection('gameInvites').doc(id);
+    const ref = db.collection('gameInvites').doc(id);
     const snap = await ref.get();
     const data = snap.data();
     if (!snapshotExists(snap) || (data.from !== user.uid && data.to !== user.uid)) return;
@@ -95,7 +95,7 @@ export const MatchmakingProvider = ({ children }) => {
     }
 
     try {
-      await firestore
+      await db
         .collection('users')
         .doc(user.uid)
         .collection('gameInvites')
@@ -111,7 +111,7 @@ export const MatchmakingProvider = ({ children }) => {
   const cancelGameInvite = async (id) => {
     if (!user?.uid || !id) return;
 
-    const ref = firestore.collection('gameInvites').doc(id);
+    const ref = db.collection('gameInvites').doc(id);
     const snap = await ref.get();
 
     if (!snapshotExists(snap)) return;
@@ -122,7 +122,7 @@ export const MatchmakingProvider = ({ children }) => {
     try {
       await ref.update({ status: 'cancelled' });
 
-      await firestore
+      await db
         .collection('users')
         .doc(user.uid)
         .collection('gameInvites')

--- a/contexts/PresenceContext.js
+++ b/contexts/PresenceContext.js
@@ -1,7 +1,6 @@
 import React, { createContext, useContext, useEffect } from 'react';
 import { AppState } from 'react-native';
-import { auth, realtimeDB } from '../firebase';
-import { onAuthStateChanged } from 'firebase/auth';
+import firebase, { realtimeDB } from '../firebase';
 import { ref, onValue, onDisconnect, set, serverTimestamp } from 'firebase/database';
 
 const PresenceContext = createContext();
@@ -39,7 +38,7 @@ export const PresenceProvider = ({ children }) => {
       appStateSubscription = AppState.addEventListener('change', appStateHandler);
     };
 
-    const unsubscribe = onAuthStateChanged(auth, (fbUser) => {
+    const unsubscribe = firebase.auth().onAuthStateChanged((fbUser) => {
       if (statusRef) {
         set(statusRef, offline);
         if (appStateSubscription?.remove) {

--- a/contexts/UserContext.js
+++ b/contexts/UserContext.js
@@ -2,8 +2,7 @@ import React, { createContext, useContext, useState, useEffect, useRef } from "r
 import { View } from "react-native";
 import Toast from "react-native-toast-message";
 import Loader from "../components/Loader";
-import { auth, firestore } from "../firebase";
-import { onAuthStateChanged } from "firebase/auth";
+import firebase, { db } from "../firebase";
 import { serverTimestamp } from "firebase/firestore";
 import { useDev } from "./DevContext";
 import { useOnboarding, clearStoredOnboarding } from "./OnboardingContext";
@@ -31,7 +30,7 @@ export const UserProvider = ({ children }) => {
   useEffect(() => {
     let unsubProfile;
     let currentUid = null;
-    const unsubAuth = onAuthStateChanged(auth, (fbUser) => {
+    const unsubAuth = firebase.auth().onAuthStateChanged((fbUser) => {
       if (fbUser?.uid !== currentUid) {
         if (!fbUser && currentUid) clearStoredOnboarding(currentUid);
         clearOnboarding();
@@ -45,7 +44,7 @@ export const UserProvider = ({ children }) => {
 
       if (fbUser) {
         setLoading(true);
-        const ref = firestore.collection("users").doc(fbUser.uid);
+        const ref = db.collection("users").doc(fbUser.uid);
         unsubProfile = ref.onSnapshot(
           (snap) => {
             if (snapshotExists(snap)) {
@@ -117,7 +116,7 @@ export const UserProvider = ({ children }) => {
     if (opts.markPlayed) updates.lastPlayedAt = new Date();
     updateUser(updates);
     try {
-      await firestore.collection("users").doc(user.uid).update({
+      await db.collection("users").doc(user.uid).update({
         ...updates,
         lastActiveAt: serverTimestamp(),
         ...(opts.markPlayed ? { lastPlayedAt: serverTimestamp() } : {}),

--- a/firebase.js
+++ b/firebase.js
@@ -1,10 +1,9 @@
-// firebase.js
-import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
-import { getFunctions } from 'firebase/functions';
-import { getDatabase } from 'firebase/database';
+import firebase from 'firebase/compat/app';
+import 'firebase/compat/auth';
+import 'firebase/compat/firestore';
+import 'firebase/compat/storage';
+import 'firebase/compat/functions';
+import 'firebase/compat/database';
 
 const firebaseConfig = {
   apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
@@ -15,26 +14,15 @@ const firebaseConfig = {
   appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
 };
 
-if (__DEV__) {
-  console.log('Firebase config loaded', firebaseConfig);
+if (!firebase.apps.length) {
+  firebase.initializeApp(firebaseConfig);
 }
 
-let app;
-try {
-  app = initializeApp(firebaseConfig);
-} catch (e) {
-  console.log('Firebase init error', e);
-}
+const auth = firebase.auth();
+const db = firebase.firestore();
+const storage = firebase.storage();
+const functions = firebase.functions();
+const realtimeDB = firebase.database();
 
-const auth = getAuth(app);
-let firestore;
-try {
-  firestore = getFirestore(app);
-} catch (e) {
-  console.log('Firestore init error', e);
-}
-const storage = getStorage(app);
-const functions = getFunctions(app);
-const realtimeDB = getDatabase(app);
-
-export { app, auth, firestore, storage, functions, realtimeDB };
+export default firebase;
+export { auth, db, storage, functions, realtimeDB };

--- a/hooks/useGameSession.js
+++ b/hooks/useGameSession.js
@@ -1,10 +1,10 @@
 import { useEffect, useState, useCallback } from 'react';
 import { INVALID_MOVE } from 'boardgame.io/core';
-import { firestore } from '../firebase';
-import { serverTimestamp, arrayUnion } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp, arrayUnion } from 'firebase/db';
 import { games } from '../games';
 import { useUser } from '../contexts/UserContext';
-import { snapshotExists } from '../utils/firestore';
+import { snapshotExists } from '../utils/db';
 
 export default function useGameSession(sessionId, gameId, opponentId) {
   const { user } = useUser();
@@ -15,7 +15,7 @@ export default function useGameSession(sessionId, gameId, opponentId) {
 
   useEffect(() => {
     if (!Game || !sessionId || !user?.uid) return;
-    const ref = firestore.collection('gameSessions').doc(sessionId);
+    const ref = db.collection('gameSessions').doc(sessionId);
     let initialized = false;
     const unsub = ref.onSnapshot(async (snap) => {
       if (snapshotExists(snap)) {
@@ -66,7 +66,7 @@ export default function useGameSession(sessionId, gameId, opponentId) {
 
     const gameover = Game.endIf ? Game.endIf({ G, ctx: { currentPlayer: nextPlayer } }) : undefined;
 
-    await firestore
+    await db
       .collection('gameSessions')
       .doc(sessionId)
       .update({

--- a/hooks/usePushNotifications.js
+++ b/hooks/usePushNotifications.js
@@ -1,16 +1,15 @@
 import { useEffect } from 'react';
 import { registerForPushNotificationsAsync } from '../utils/notifications';
-import { auth, firestore } from '../firebase';
-import { onAuthStateChanged } from 'firebase/auth';
+import firebase, { db } from '../firebase';
 
 export default function usePushNotifications() {
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (fbUser) => {
+    const unsub = firebase.auth().onAuthStateChanged((fbUser) => {
       if (!fbUser) return;
       registerForPushNotificationsAsync()
         .then((token) => {
           if (token) {
-            firestore
+            db
               .collection('users')
               .doc(fbUser.uid)
               .update({ expoPushToken: token })

--- a/hooks/useUnreadNotifications.js
+++ b/hooks/useUnreadNotifications.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import { useUser } from '../contexts/UserContext';
 
 export default function useUnreadNotifications() {
@@ -8,7 +8,7 @@ export default function useUnreadNotifications() {
 
   useEffect(() => {
     if (!user?.uid) return;
-    const q = firestore
+    const q = db
       .collection('users')
       .doc(user.uid)
       .collection('notifications')

--- a/screens/ActiveGamesScreen.js
+++ b/screens/ActiveGamesScreen.js
@@ -7,7 +7,7 @@ import { useGameSessions } from '../contexts/GameSessionContext';
 import { useChats } from '../contexts/ChatContext';
 import { useUser } from '../contexts/UserContext';
 import { games } from '../games';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import Loader from '../components/Loader';
 import { HEADER_SPACING } from '../layout';
 
@@ -28,7 +28,7 @@ const ActiveGamesScreen = ({ navigation }) => {
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
-      const snap = await firestore
+      const snap = await db
         .collection('gameSessions')
         .where('players', 'array-contains', user.uid)
         .get();

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -19,8 +19,8 @@ import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
 import { games, gameList } from '../games';
 import { icebreakers } from '../data/prompts';
-import { firestore } from '../firebase';
-import { serverTimestamp, arrayUnion } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp, arrayUnion } from 'firebase/db';
 import * as Haptics from 'expo-haptics';
 import { uploadVoiceAsync } from '../utils/upload';
 import { useTheme } from '../contexts/ThemeContext';
@@ -96,7 +96,7 @@ function PrivateChat({ user }) {
     if (!msgText.trim() && !extras.voice) return;
     if (!user?.id) return;
     try {
-      await firestore
+      await db
         .collection('matches')
         .doc(user.id)
         .collection('messages')
@@ -120,7 +120,7 @@ function PrivateChat({ user }) {
 
   const updateTyping = (state) => {
     if (!user?.id || !currentUser?.uid) return;
-    firestore.collection('matches')
+    db.collection('matches')
       .doc(user.id)
       .set({ typing: { [currentUser.uid]: state } }, { merge: true });
   };
@@ -142,7 +142,7 @@ function PrivateChat({ user }) {
 
   useEffect(() => {
     if (!user?.id || !currentUser?.uid) return;
-    const ref = firestore.collection('matches').doc(user.id);
+    const ref = db.collection('matches').doc(user.id);
     const unsub = ref.onSnapshot((doc) => {
       const data = doc.data();
       if (data?.users && !otherUserId) {
@@ -167,7 +167,7 @@ function PrivateChat({ user }) {
   useEffect(() => {
     if (!user?.id || !currentUser?.uid) return;
     setLoading(true);
-    const msgRef = firestore
+    const msgRef = db
       .collection('matches')
       .doc(user.id)
       .collection('messages')
@@ -226,7 +226,7 @@ function PrivateChat({ user }) {
     if (!user?.id || !currentUser?.uid) return;
     setRefreshing(true);
     try {
-      const snap = await firestore
+      const snap = await db
         .collection('matches')
         .doc(user.id)
         .collection('messages')
@@ -687,7 +687,7 @@ function GroupChat({ event }) {
   const [reactionTarget, setReactionTarget] = useState(null);
 
   useEffect(() => {
-    const q = firestore
+    const q = db
       .collection('events')
       .doc(event.id)
       .collection('messages')
@@ -720,7 +720,7 @@ function GroupChat({ event }) {
   const sendMessage = async () => {
     if (!input.trim()) return;
     try {
-      await firestore
+      await db
         .collection('events')
         .doc(event.id)
         .collection('messages')
@@ -744,7 +744,7 @@ function GroupChat({ event }) {
 
   const addReaction = async (msgId, emoji) => {
     try {
-      await firestore
+      await db
         .collection('events')
         .doc(event.id)
         .collection('messages')
@@ -760,7 +760,7 @@ function GroupChat({ event }) {
     const msg = messages.find((m) => m.id === msgId);
     if (!msg) return;
     try {
-      await firestore
+      await db
         .collection('events')
         .doc(event.id)
         .collection('messages')
@@ -774,7 +774,7 @@ function GroupChat({ event }) {
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
-      const snap = await firestore
+      const snap = await db
         .collection('events')
         .doc(event.id)
         .collection('messages')

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -22,8 +22,8 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useNavigation } from '@react-navigation/native';
 import PropTypes from 'prop-types';
 import { useUser } from '../contexts/UserContext';
-import { firestore } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { HEADER_SPACING, FONT_SIZES, BUTTON_STYLE } from '../layout';
 import * as Haptics from 'expo-haptics';
@@ -73,7 +73,7 @@ const CommunityScreen = () => {
   }, [firstJoin, badgeAnim]);
 
   useEffect(() => {
-    const q = firestore.collection('events').orderBy('createdAt', 'desc');
+    const q = db.collection('events').orderBy('createdAt', 'desc');
     const unsub = q.onSnapshot((snap) => {
       const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
       setEvents(data.length ? data : SAMPLE_EVENTS);
@@ -84,7 +84,7 @@ const CommunityScreen = () => {
   }, []);
 
   useEffect(() => {
-    const q = firestore.collection('communityPosts').orderBy('createdAt', 'desc');
+    const q = db.collection('communityPosts').orderBy('createdAt', 'desc');
     const unsub = q.onSnapshot((snap) => {
       const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
       setPosts(data.length ? data : SAMPLE_POSTS);
@@ -112,10 +112,10 @@ const CommunityScreen = () => {
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
-      const eventSnap = await firestore.collection('events').orderBy('createdAt', 'desc').get();
+      const eventSnap = await db.collection('events').orderBy('createdAt', 'desc').get();
       const eventData = eventSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
       setEvents(eventData.length ? eventData : SAMPLE_EVENTS);
-      const postSnap = await firestore.collection('communityPosts').orderBy('createdAt', 'desc').get();
+      const postSnap = await db.collection('communityPosts').orderBy('createdAt', 'desc').get();
       const postData = postSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
       setPosts(postData.length ? postData : SAMPLE_POSTS);
     } catch (e) {
@@ -338,7 +338,7 @@ const CommunityScreen = () => {
               text="Submit Event"
               onPress={async () => {
                 try {
-                  await firestore.collection('events').add({
+                  await db.collection('events').add({
                     title: newTitle,
                     time: newTime,
                     description: newDesc,
@@ -387,7 +387,7 @@ const CommunityScreen = () => {
               text="Submit Post"
               onPress={async () => {
                 try {
-                  await firestore.collection('communityPosts').add({
+                  await db.collection('communityPosts').add({
                     title: postTitle,
                     time: 'Just now',
                     description: postDesc,

--- a/screens/EmailAuthScreen.js
+++ b/screens/EmailAuthScreen.js
@@ -2,14 +2,10 @@ import React, { useState } from 'react';
 import { Text, TouchableOpacity, Alert } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import AuthForm from '../components/AuthForm';
-import { auth, firestore } from '../firebase';
-import {
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-} from 'firebase/auth';
-import { serverTimestamp } from 'firebase/firestore';
+import firebase, { auth, db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 import { useOnboarding } from '../contexts/OnboardingContext';
-import { snapshotExists } from '../utils/firestore';
+import { snapshotExists } from '../utils/db';
 import { isAllowedDomain } from '../utils/email';
 import getStyles from '../styles';
 import { useTheme } from '../contexts/ThemeContext';
@@ -25,7 +21,7 @@ export default function EmailAuthScreen({ route, navigation }) {
 
   const ensureUserDoc = async (fbUser) => {
     try {
-      const ref = firestore.collection('users').doc(fbUser.uid);
+      const ref = db.collection('users').doc(fbUser.uid);
       const snap = await ref.get();
       if (!snapshotExists(snap)) {
         await ref.set({
@@ -44,9 +40,9 @@ export default function EmailAuthScreen({ route, navigation }) {
 
   const handleLogin = async () => {
     try {
-      const userCred = await signInWithEmailAndPassword(auth, email, password);
+      const userCred = await auth.signInWithEmailAndPassword(email, password);
       await ensureUserDoc(userCred.user);
-      const snap = await firestore.collection('users').doc(userCred.user.uid).get();
+      const snap = await db.collection('users').doc(userCred.user.uid).get();
       if (snapshotExists(snap) && snap.data().onboardingComplete) {
         markOnboarded();
       }
@@ -72,8 +68,8 @@ export default function EmailAuthScreen({ route, navigation }) {
       return;
     }
     try {
-      const userCred = await createUserWithEmailAndPassword(auth, email.trim(), password);
-      await firestore.collection('users').doc(userCred.user.uid).set({
+      const userCred = await auth.createUserWithEmailAndPassword(email.trim(), password);
+      await db.collection('users').doc(userCred.user.uid).set({
         uid: userCred.user.uid,
         email: userCred.user.email,
         displayName: userCred.user.displayName || '',

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -21,15 +21,15 @@ import { useDev } from '../contexts/DevContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
 import { HEADER_SPACING } from '../layout';
 import { useUser } from '../contexts/UserContext';
-import { firestore } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 import * as Haptics from 'expo-haptics';
 import getGlobalStyles from '../styles';
 import { games } from '../games';
 import SyncedGame from '../components/SyncedGame';
 import GameOverModal from '../components/GameOverModal';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
-import { snapshotExists } from '../utils/firestore';
+import { snapshotExists } from '../utils/db';
 import { createMatchIfMissing } from '../utils/matches';
 import Toast from 'react-native-toast-message';
 import { bots, getRandomBot } from "../ai/bots";
@@ -79,7 +79,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
   // Listen for Firestore invite status
   useEffect(() => {
     if (!inviteId || !user?.uid) return;
-    const ref = firestore.collection('gameInvites').doc(inviteId);
+    const ref = db.collection('gameInvites').doc(inviteId);
     const unsub = ref.onSnapshot((snap) => {
       if (snapshotExists(snap)) {
         const data = snap.data();
@@ -126,7 +126,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
         await createMatchIfMissing(user.uid, opponent.id);
       }
       if (inviteId && user?.uid) {
-        const ref = firestore.collection('gameInvites').doc(inviteId);
+        const ref = db.collection('gameInvites').doc(inviteId);
         const snap = await ref.get();
         const data = snap.data();
         if (snapshotExists(snap) && (data.from === user.uid || data.to === user.uid)) {
@@ -157,7 +157,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
   const handleRematch = async () => {
     if (!requireCredits()) return;
     if (inviteId && user?.uid) {
-      const ref = firestore.collection('gameInvites').doc(inviteId);
+      const ref = db.collection('gameInvites').doc(inviteId);
         const snap = await ref.get();
         const data = snap.data();
         if (snapshotExists(snap) && (data.from === user.uid || data.to === user.uid)) {
@@ -165,7 +165,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
             status: 'finished',
             endedAt: serverTimestamp(),
           });
-          await firestore
+          await db
           .collection('gameSessions')
           .doc(inviteId)
           .update({

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -18,7 +18,7 @@ import GradientBackground from '../components/GradientBackground';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { useUser } from '../contexts/UserContext';
 import { useTheme } from '../contexts/ThemeContext';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import { games } from '../games';
 import PropTypes from 'prop-types';
 import useCardPressAnimation from '../hooks/useCardPressAnimation';
@@ -66,13 +66,13 @@ const NotificationsScreen = ({ navigation }) => {
     setLoadingId(invite.id);
     await acceptGameInvite(invite.id);
     try {
-      await firestore
+      await db
         .collection('users')
         .doc(user.uid)
         .collection('gameInvites')
         .doc(invite.id)
         .update({ status: 'accepted' });
-      const snap = await firestore.collection('users').doc(invite.from).get();
+      const snap = await db.collection('users').doc(invite.from).get();
       const opp = snap.data() || {};
       navigation.navigate('GameSession', {
         game: {
@@ -101,7 +101,7 @@ const NotificationsScreen = ({ navigation }) => {
   const handleDecline = async (invite) => {
     setLoadingId(invite.id + '_decline');
     cancelGameInvite(invite.id);
-    await firestore
+    await db
       .collection('users')
       .doc(user.uid)
       .collection('gameInvites')

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -13,12 +13,12 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
-import { firestore, auth } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { db, auth } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 import { uploadAvatarAsync } from '../utils/upload';
 import PropTypes from 'prop-types';
 import { sanitizeText } from '../utils/sanitize';
-import { snapshotExists } from '../utils/firestore';
+import { snapshotExists } from '../utils/db';
 import { useUser } from '../contexts/UserContext';
 import { useOnboarding } from '../contexts/OnboardingContext';
 import * as ImagePicker from 'expo-image-picker';
@@ -91,7 +91,7 @@ export default function OnboardingScreen() {
   const [gameOptions, setGameOptions] = useState(defaultGameOptions);
 
   useEffect(() => {
-    const unsub = firestore
+    const unsub = db
       .collection('games')
       .orderBy('title')
       .onSnapshot(
@@ -139,7 +139,7 @@ export default function OnboardingScreen() {
     const checkExisting = async () => {
       const uid = auth.currentUser?.uid;
       if (!uid) return;
-      const ref = firestore.collection('users').doc(uid);
+      const ref = db.collection('users').doc(uid);
       const snap = await ref.get();
       if (snapshotExists(snap) && snap.data().onboardingComplete) {
         updateUser(snap.data());
@@ -180,7 +180,7 @@ export default function OnboardingScreen() {
         onboardingComplete: true,
         createdAt: serverTimestamp(),
       };
-      await firestore.collection('users').doc(user.uid).set(profile, { merge: true });
+      await db.collection('users').doc(user.uid).set(profile, { merge: true });
       updateUser(profile);
       markOnboarded();
       Toast.show({ type: 'success', text1: 'Profile saved!' });

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -14,8 +14,7 @@ import * as WebBrowser from 'expo-web-browser';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
-import { functions } from '../firebase';
-import { httpsCallable } from 'firebase/functions';
+import firebase from '../firebase';
 import PropTypes from 'prop-types';
 import { HEADER_SPACING, FONT_SIZES } from '../layout';
 
@@ -42,7 +41,9 @@ const PremiumScreen = ({ navigation, route }) => {
 
   const startCheckout = async () => {
     try {
-      const createSession = httpsCallable(functions, 'createCheckoutSession');
+      const createSession = firebase
+        .functions()
+        .httpsCallable('createCheckoutSession');
       const result = await createSession({
         successUrl: process.env.EXPO_PUBLIC_SUCCESS_URL,
         cancelUrl: process.env.EXPO_PUBLIC_CANCEL_URL,

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -9,7 +9,7 @@ import getStyles from '../styles';
 import { HEADER_SPACING } from '../layout';
 import Header from '../components/Header';
 import { useUser } from '../contexts/UserContext';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import Toast from 'react-native-toast-message';
 import * as ImagePicker from 'expo-image-picker';
 import { uploadAvatarAsync } from '../utils/upload';
@@ -73,7 +73,7 @@ const ProfileScreen = ({ navigation, route }) => {
   }, [route?.params?.editMode]);
 
   useEffect(() => {
-    const unsub = firestore
+    const unsub = db
       .collection('games')
       .orderBy('title')
       .onSnapshot(
@@ -112,7 +112,7 @@ const ProfileScreen = ({ navigation, route }) => {
       photoURL,
     };
     try {
-      await firestore
+      await db
         .collection('users')
         .doc(user.uid)
         .set(clean, { merge: true });

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -8,7 +8,6 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
 import { auth } from '../firebase';
-import { signOut } from 'firebase/auth';
 import PropTypes from 'prop-types';
 
 const SettingsScreen = ({ navigation }) => {
@@ -23,7 +22,7 @@ const SettingsScreen = ({ navigation }) => {
 
   const handleEditProfile = () => navigation.navigate('Profile', { editMode: true });
   const handleLogout = async () => {
-    await signOut(auth);
+    await auth.signOut();
     // RootNavigator will detect the auth change and present the AuthStack
     // so no manual navigation reset is required here.
   };

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -7,7 +7,7 @@ import Header from '../components/Header';
 import GradientButton from '../components/GradientButton';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
-import { firestore } from '../firebase';
+import { db } from '../firebase';
 import ProgressBar from '../components/ProgressBar';
 import PropTypes from 'prop-types';
 import { HEADER_SPACING, FONT_SIZES, BUTTON_STYLE } from '../layout';
@@ -42,7 +42,7 @@ const StatsScreen = ({ navigation }) => {
         return;
       }
       try {
-        const sessionsSnap = await firestore
+        const sessionsSnap = await db
           .collection('gameSessions')
           .where('players', 'array-contains', user.uid)
           .get();
@@ -62,7 +62,7 @@ const StatsScreen = ({ navigation }) => {
           }
         });
 
-        const matchSnap = await firestore
+        const matchSnap = await db
           .collection('matches')
           .where('users', 'array-contains', user.uid)
           .get();
@@ -74,7 +74,7 @@ const StatsScreen = ({ navigation }) => {
           messagesSent += counts[user.uid] || 0;
         });
 
-        const userSnap = await firestore.collection('users').doc(user.uid).get();
+        const userSnap = await db.collection('users').doc(user.uid).get();
         const data = userSnap.data() || {};
 
         setStats({

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -24,8 +24,8 @@ import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { allGames } from '../data/games';
 import { icebreakers } from '../data/prompts';
 import { useChats } from '../contexts/ChatContext';
-import { firestore } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 import { useNavigation } from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
@@ -140,7 +140,7 @@ const SwipeScreen = () => {
       }
       setLoadingUsers(true);
       try {
-        let userQuery = firestore
+        let userQuery = db
           .collection('users')
           .where('uid', '!=', currentUser.uid);
         if (currentUser.location) {
@@ -222,14 +222,14 @@ const handleSwipe = async (direction) => {
 
       if (currentUser?.uid && displayUser.id && !devMode) {
         try {
-          await firestore
+          await db
             .collection('likes')
             .doc(currentUser.uid)
             .collection('liked')
             .doc(displayUser.id)
             .set({ createdAt: serverTimestamp() });
 
-          const reciprocal = await firestore
+          const reciprocal = await db
             .collection('likes')
             .doc(displayUser.id)
             .collection('liked')
@@ -237,7 +237,7 @@ const handleSwipe = async (direction) => {
             .get();
 
           if (reciprocal.exists) {
-            const matchRef = await firestore
+            const matchRef = await db
               .collection('matches')
               .add({
                 users: [currentUser.uid, displayUser.id],

--- a/utils/gameStats.js
+++ b/utils/gameStats.js
@@ -1,11 +1,11 @@
-import { firestore } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
-import { snapshotExists } from './firestore';
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
+import { snapshotExists } from './db';
 
 export async function logGameStats(sessionId) {
   if (!sessionId) return;
   try {
-    const ref = firestore.collection('gameSessions').doc(sessionId);
+    const ref = db.collection('gameSessions').doc(sessionId);
     const snap = await ref.get();
     if (!snapshotExists(snap)) return;
     const data = snap.data() || {};
@@ -20,7 +20,7 @@ export async function logGameStats(sessionId) {
       winner = players[data.gameover.winner];
     }
 
-    await firestore
+    await db
       .collection('gameStats')
       .doc(sessionId)
       .set({

--- a/utils/matches.js
+++ b/utils/matches.js
@@ -1,16 +1,16 @@
-import { firestore } from '../firebase';
-import { serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import { serverTimestamp } from 'firebase/db';
 
 export async function createMatchIfMissing(uid, otherUid) {
   if (!uid || !otherUid) return null;
   try {
-    const q = await firestore
+    const q = await db
       .collection('matches')
       .where('users', 'array-contains', uid)
       .get();
     const exists = q.docs.some((d) => (d.data().users || []).includes(otherUid));
     if (!exists) {
-      const ref = await firestore.collection('matches').add({
+      const ref = await db.collection('matches').add({
         users: [uid, otherUid],
         createdAt: serverTimestamp(),
       });


### PR DESCRIPTION
## Summary
- use Firebase compat modules for initialization
- export `db`, `auth`, `storage`, `functions` and `realtimeDB`
- update all modules to use compat imports
- rely on `firebase.auth().onAuthStateChanged` and `db.collection()`

## Testing
- `npx expo start -c` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686220c86a34832d83c0af39b6bf6535