### PR TITLE
Fix AI play selection

### DIFF
--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -314,9 +314,12 @@ function BotSessionScreen({ route }) {
     return acc;
   }, {});
 
-  const { G, ctx, moves, reset } = gameMap[game].state;
-  const BoardComponent = gameMap[game].board;
-  const title = gameMap[game].title;
+  const fallbackKey = 'ticTacToe';
+  const activeKey = gameMap[game] ? game : fallbackKey;
+  if (!gameMap[game]) console.warn('Unknown game key', game);
+  const { G, ctx, moves, reset } = gameMap[activeKey].state;
+  const BoardComponent = gameMap[activeKey].board;
+  const title = gameMap[activeKey].title;
 
   const [gameOver, setGameOver] = useState(false);
   const [messages, setMessages] = useState([
@@ -382,6 +385,10 @@ function BotSessionScreen({ route }) {
   };
 
   const switchGame = (g) => {
+    if (!gameMap[g]) {
+      console.warn('Unknown game key', g);
+      return;
+    }
     if (g === game) return;
     setGame(g);
     gameMap[g].state.reset();

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -26,12 +26,14 @@ import Card from '../components/Card';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { eventImageSource } from '../utils/avatar';
 
-const games = allGames.map((g) => {
+// Map app game IDs to boardgame registry keys for AI play
+const aiGameMap = allGames.reduce((acc, g) => {
   const key = Object.keys(gameRegistry).find(
     (k) => gameRegistry[k].meta.title === g.title
   );
-  return { id: g.id, key };
-});
+  if (key) acc[g.id] = key;
+  return acc;
+}, {});
 
 const HomeScreen = ({ navigation }) => {
   const { theme } = useTheme();
@@ -90,13 +92,12 @@ const HomeScreen = ({ navigation }) => {
     if (playTarget === 'ai') {
       const bot = getRandomBot();
       const aiKeyMap = { rockPaperScissors: 'rps' };
-      const aiGames = games
-        .filter((g) => g.key && gameRegistry[g.key])
-        .reduce((m, g) => ({ ...m, [g.id]: aiKeyMap[g.key] || g.key }), {});
-      const gameKey = aiGames[game.id];
+      const key = aiGameMap[game.id];
+      if (!key) console.warn('No AI mapping for game id', game.id);
+      const gameKey = key ? aiKeyMap[key] || key : 'ticTacToe';
       navigation.navigate('GameWithBot', {
         botId: bot.id,
-        game: gameKey || 'ticTacToe',
+        game: gameKey,
       });
     } else {
       navigation.navigate('GameInvite', { game: { id: game.id, title: game.title } });


### PR DESCRIPTION
## Summary
- clean up AI game mapping and add warnings on missing config
- add fallback logic when loading bot sessions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686235b67124832dacaab91fa74c8b74