### PR TITLE
Apply shared layout pattern across screens

### DIFF
--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+export default function ScreenContainer({ children, style }) {
+  return <SafeAreaView style={[styles.container, style]}>{children}</SafeAreaView>;
+}
+
+ScreenContainer.propTypes = {
+  children: PropTypes.node,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+  },
+});

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -7,7 +7,6 @@ import {
   TouchableOpacity,
   StyleSheet,
   Modal,
-  SafeAreaView,
   RefreshControl,
 } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
@@ -17,6 +16,7 @@ import PropTypes from 'prop-types';
 import Header from '../components/Header';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
+import ScreenContainer from '../components/ScreenContainer';
 import { games, gameList } from '../games';
 import { icebreakers } from '../data/prompts';
 import firebase from '../firebase';
@@ -534,7 +534,7 @@ function PrivateChat({ user }) {
           </View>
         </View>
       </Modal>
-      <SafeAreaView style={{ flex: 1 }}>
+      <ScreenContainer>
         <SafeKeyboardView style={{ flex: 1, paddingTop: HEADER_SPACING }}>
           <View style={{ flex: 1 }}>
             {showPlaceholders ? (
@@ -549,7 +549,7 @@ function PrivateChat({ user }) {
             {gameSection}
           </View>
         </SafeKeyboardView>
-      </SafeAreaView>
+      </ScreenContainer>
     </GradientBackground>
   );
 }

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -6,12 +6,12 @@ import {
   FlatList,
   TouchableOpacity,
   StyleSheet,
-  SafeAreaView,
   Modal,
   Image,
 } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
+import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
@@ -124,7 +124,7 @@ const HomeScreen = ({ navigation }) => {
 
   return (
     <GradientBackground style={{ flex: 1 }}>
-      <SafeAreaView style={{ flex: 1 }}>
+      <ScreenContainer>
         <Header showLogoOnly />
         <ScrollView contentContainerStyle={{ paddingBottom: 100 }}>
           <Text style={[local.welcome, { color: theme.text }]}>
@@ -316,7 +316,7 @@ const HomeScreen = ({ navigation }) => {
             </View>
           </View>
         </Modal>
-      </SafeAreaView>
+      </ScreenContainer>
     </GradientBackground>
   );
 };

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -6,11 +6,11 @@ import {
   TouchableOpacity,
   Image,
   StyleSheet,
-  SafeAreaView,
   RefreshControl,
 } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
+import ScreenContainer from '../components/ScreenContainer';
 import Card from '../components/Card';
 import { useTheme } from '../contexts/ThemeContext';
 import { useChats } from '../contexts/ChatContext';
@@ -104,8 +104,8 @@ const MatchesScreen = ({ navigation }) => {
   );
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <GradientBackground style={{ flex: 1 }}>
+    <GradientBackground style={{ flex: 1 }}>
+      <ScreenContainer>
         <Header />
         <View style={{ flex: 1, paddingTop: HEADER_SPACING }}>
           {loading ? (
@@ -175,8 +175,8 @@ const MatchesScreen = ({ navigation }) => {
             </>
           )}
         </View>
-      </GradientBackground>
-    </SafeAreaView>
+      </ScreenContainer>
+    </GradientBackground>
   );
 };
 

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Text, View } from 'react-native';
+import ScreenContainer from '../components/ScreenContainer';
 import GradientButton from '../components/GradientButton';
 import GradientBackground from '../components/GradientBackground';
 import getStyles from '../styles';
@@ -29,8 +30,9 @@ const SettingsScreen = ({ navigation }) => {
   const handleGoPremium = () => navigation.navigate('Premium', { context: 'paywall' });
 
   return (
-    <GradientBackground style={styles.container}>
-      <Header />
+    <GradientBackground style={{ flex: 1 }}>
+      <ScreenContainer style={styles.container}>
+        <Header />
 
       <Text style={[styles.logoText, { color: theme.text, marginBottom: 10 }]}>
         Settings
@@ -80,6 +82,7 @@ const SettingsScreen = ({ navigation }) => {
           <GradientButton text="Log Out" onPress={handleLogout} />
         </>
       )}
+      </ScreenContainer>
     </GradientBackground>
   );
 };

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import GradientBackground from '../components/GradientBackground';
+import ScreenContainer from '../components/ScreenContainer';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
@@ -424,8 +425,8 @@ const handleSwipe = async (direction) => {
 
   return (
     <GradientBackground colors={gradientColors} style={{ flex: 1 }}>
-      <Header />
-      <View style={styles.container}>
+      <ScreenContainer style={styles.container}>
+        <Header />
         {displayUser ? (
           <Animated.View
             {...panResponder.panHandlers}
@@ -570,7 +571,7 @@ const handleSwipe = async (direction) => {
             </View>
           </Modal>
         )}
-      </View>
+      </ScreenContainer>
     </GradientBackground>
   );
 };


### PR DESCRIPTION
## Summary
- add `ScreenContainer` for a consistent SafeAreaView layout
- wrap Home, Explore(Swipe), Matches, Chat, and Settings screens with the new container

## Testing
- `npm test` *(fails: Missing script and no network)*

------
https://chatgpt.com/codex/tasks/task_e_686235beb908832db6f52dd05bf97abf