### PR TITLE
Fix getStyles error in bot session

### DIFF
--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -295,7 +295,6 @@ function BotSessionScreen({ route }) {
   );
   const { theme } = useTheme();
   const botStyles = getBotStyles(theme);
-  const styles = getStyles(theme);
   const [game, setGame] = useState(initialGame);
 
   const aiKeyMap = { rockPaperScissors: 'rps' };


### PR DESCRIPTION
## Summary
- remove unused `getStyles` call in `GameSessionScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68623602587c832da76b79eb2e584787