### PR TITLE
Fix header width

### DIFF
--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -14,7 +14,6 @@ ScreenContainer.propTypes = {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingHorizontal: 16,
     justifyContent: 'flex-start',
     alignItems: 'stretch',
   },


### PR DESCRIPTION
## Summary
- ensure header container inside `ScreenContainer` does not get padded

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686248fa278c832dac9d385f68ec45b7