### PR TITLE
Refactor card styles and screen wrappers

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -17,16 +17,18 @@ Card.propTypes = {
   onPress: PropTypes.func,
 };
 
+export const CARD_STYLE = {
+  borderRadius: 16,
+  padding: 16,
+  shadowColor: '#000',
+  shadowOpacity: 0.1,
+  shadowOffset: { width: 0, height: 2 },
+  shadowRadius: 4,
+  elevation: 3,
+};
+
 const styles = StyleSheet.create({
-  card: {
-    borderRadius: 16,
-    padding: 16,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3,
-  },
+  card: CARD_STYLE,
 });
 
 export default Card;

--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -1,14 +1,38 @@
 import React from 'react';
-import { SafeAreaView, StyleSheet } from 'react-native';
+import { SafeAreaView, ScrollView, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-export default function ScreenContainer({ children, style }) {
-  return <SafeAreaView style={[styles.container, style]}>{children}</SafeAreaView>;
+export default function ScreenContainer({
+  children,
+  style,
+  scroll = false,
+  contentContainerStyle,
+  ...rest
+}) {
+  return (
+    <SafeAreaView style={[styles.container, style]}>
+      {scroll ? (
+        <ScrollView
+          contentContainerStyle={[styles.content, contentContainerStyle]}
+          {...rest}
+        >
+          {children}
+        </ScrollView>
+      ) : (
+        children
+      )}
+    </SafeAreaView>
+  );
 }
 
 ScreenContainer.propTypes = {
   children: PropTypes.node,
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  scroll: PropTypes.bool,
+  contentContainerStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+  ]),
 };
 
 const styles = StyleSheet.create({
@@ -16,5 +40,9 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'flex-start',
     alignItems: 'stretch',
+  },
+  content: {
+    flexGrow: 1,
+    padding: 20,
   },
 });

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -16,6 +16,7 @@ import {
 } from 'react-native';
 import GradientButton from '../components/GradientButton';
 import Card from '../components/Card';
+import ScreenContainer from '../components/ScreenContainer';
 import { eventImageSource } from '../utils/avatar';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
@@ -195,8 +196,8 @@ const CommunityScreen = () => {
   return (
     <View style={{ flex: 1, backgroundColor: darkMode ? '#333' : '#fce4ec' }}>
       <Header />
-
-      <ScrollView
+      <ScreenContainer
+        scroll
         contentContainerStyle={{ paddingTop: HEADER_SPACING, paddingBottom: 150 }}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
       >
@@ -274,7 +275,7 @@ const CommunityScreen = () => {
             </Text>
           </Animated.View>
         )}
-      </ScrollView>
+      </ScreenContainer>
 
       {/* Floating actions */}
       {showFabMenu && (
@@ -449,8 +450,8 @@ const getStyles = (theme, skeletonColor) =>
   header: {
     fontSize: FONT_SIZES.XL,
     fontWeight: 'bold',
-    marginLeft: 16,
-    marginBottom: 12
+    textAlign: 'center',
+    marginVertical: 16,
   },
   banner: {
     marginHorizontal: 16,

--- a/screens/EmailAuthScreen.js
+++ b/screens/EmailAuthScreen.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Text, TouchableOpacity, Alert } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import AuthForm from '../components/AuthForm';
+import ScreenContainer from '../components/ScreenContainer';
 import firebase from '../firebase';
 import { useOnboarding } from '../contexts/OnboardingContext';
 import { snapshotExists } from '../utils/firestore';
@@ -99,16 +100,17 @@ export default function EmailAuthScreen({ route, navigation }) {
 
   return (
     <GradientBackground>
-      <Text style={[styles.logoText, { color: theme.text }]}>
-        {mode === 'signup' ? 'Create Account' : 'Log In'}
-      </Text>
-      <AuthForm
-        email={email}
-        onEmailChange={setEmail}
-        password={password}
-        onPasswordChange={setPassword}
-        onSubmit={onSubmit}
-        submitLabel={submitLabel}
+      <ScreenContainer scroll contentContainerStyle={styles.container}>
+        <Text style={[styles.logoText, { color: theme.text }]}>
+          {mode === 'signup' ? 'Create Account' : 'Log In'}
+        </Text>
+        <AuthForm
+          email={email}
+          onEmailChange={setEmail}
+          password={password}
+          onPasswordChange={setPassword}
+          onSubmit={onSubmit}
+          submitLabel={submitLabel}
       >
         {mode === 'login' ? (
           <>
@@ -124,7 +126,8 @@ export default function EmailAuthScreen({ route, navigation }) {
             <Text style={{ color: theme.text }}>← Back to Login</Text>
           </TouchableOpacity>
         )}
-      </AuthForm>
+        </AuthForm>
+      </ScreenContainer>
     </GradientBackground>
   );
 }

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -10,6 +10,7 @@ import {
 import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientBackground from '../components/GradientBackground';
+import ScreenContainer from '../components/ScreenContainer';
 import GradientButton from '../components/GradientButton';
 import Header from '../components/Header';
 import SkeletonPlaceholder from '../components/SkeletonPlaceholder';
@@ -154,7 +155,8 @@ const GameInviteScreen = ({ route, navigation }) => {
   return (
     <GradientBackground style={styles.swipeScreen}>
       <Header showLogoOnly />
-      <SafeKeyboardView style={{ flex: 1 }}>
+      <ScreenContainer scroll contentContainerStyle={{ paddingBottom: 100 }}>
+        <SafeKeyboardView style={{ flex: 1 }}>
           <Text
             style={{
               fontSize: 18,
@@ -227,7 +229,8 @@ const GameInviteScreen = ({ route, navigation }) => {
               ) : null
             }
           />
-      </SafeKeyboardView>
+        </SafeKeyboardView>
+      </ScreenContainer>
     </GradientBackground>
   );
 };

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -3,7 +3,6 @@ import {
   View,
   Text,
   TouchableOpacity,
-  ScrollView,
   FlatList,
   StyleSheet,
   Image
@@ -12,6 +11,7 @@ import GradientButton from '../components/GradientButton';
 import GradientBackground from '../components/GradientBackground';
 import * as WebBrowser from 'expo-web-browser';
 import Header from '../components/Header';
+import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import firebase from '../firebase';
@@ -61,7 +61,7 @@ const PremiumScreen = ({ navigation, route }) => {
     return (
       <GradientBackground style={{ flex: 1 }}>
         <Header />
-        <ScrollView contentContainerStyle={{ paddingTop: HEADER_SPACING, paddingBottom: 100 }}>
+        <ScreenContainer scroll contentContainerStyle={{ paddingTop: HEADER_SPACING, paddingBottom: 100 }}>
           <View style={upgradeStyles.container}>
             <Text style={upgradeStyles.title}>Upgrade to Premium</Text>
             <Text style={upgradeStyles.subtitle}>
@@ -84,7 +84,7 @@ const PremiumScreen = ({ navigation, route }) => {
               1 free game/day included on free plan. Cancel anytime. All prices in CAD.
             </Text>
           </View>
-        </ScrollView>
+        </ScreenContainer>
       </GradientBackground>
     );
   }
@@ -92,7 +92,7 @@ const PremiumScreen = ({ navigation, route }) => {
   return (
     <GradientBackground style={{ flex: 1 }}>
       <Header />
-      <View style={paywallStyles.container}>
+      <ScreenContainer scroll contentContainerStyle={paywallStyles.container}>
         {user?.isPremium && user.premiumUpdatedAt && (
           <Text style={paywallStyles.memberSince}>{
             `Member since ${new Date(
@@ -121,7 +121,7 @@ const PremiumScreen = ({ navigation, route }) => {
         <TouchableOpacity onPress={() => navigation.goBack()}>
           <Text style={paywallStyles.cancel}>Maybe Later</Text>
         </TouchableOpacity>
-      </View>
+      </ScreenContainer>
     </GradientBackground>
   );
 };

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -1,7 +1,7 @@
 // /screens/StatsScreen.js
 
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import GradientButton from '../components/GradientButton';
@@ -13,6 +13,8 @@ import PropTypes from 'prop-types';
 import { HEADER_SPACING, FONT_SIZES, BUTTON_STYLE } from '../layout';
 import ProfileCard from '../components/stats/ProfileCard';
 import StatBox from '../components/stats/StatBox';
+import ScreenContainer from '../components/ScreenContainer';
+import { CARD_STYLE } from '../components/Card';
 
 const StatsScreen = ({ navigation }) => {
   const { theme } = useTheme();
@@ -107,7 +109,7 @@ const StatsScreen = ({ navigation }) => {
   return (
     <GradientBackground style={{ flex: 1 }}>
       <Header showLogoOnly />
-      <ScrollView contentContainerStyle={styles.container}>
+      <ScreenContainer scroll contentContainerStyle={styles.container}>
         {/* Profile Summary */}
         <ProfileCard
           user={user}
@@ -172,7 +174,7 @@ const StatsScreen = ({ navigation }) => {
             style={styles.premiumButton}
           />
         )}
-      </ScrollView>
+      </ScreenContainer>
     </GradientBackground>
   );
 };
@@ -185,7 +187,9 @@ const getStyles = (theme) => StyleSheet.create({
   },
   profileCard: {
     alignItems: 'center',
-    marginBottom: 20
+    marginBottom: 20,
+    backgroundColor: theme.card,
+    ...CARD_STYLE,
   },
   avatar: {
     width: 90,
@@ -212,18 +216,14 @@ const getStyles = (theme) => StyleSheet.create({
     fontWeight: '700',
     marginTop: 20,
     marginBottom: 8,
-    color: theme.text
+    color: theme.text,
+    textAlign: 'center',
   },
   statBox: {
     backgroundColor: theme.card,
-    borderRadius: 12,
     padding: 14,
     marginBottom: 10,
-    shadowColor: '#000',
-    shadowOpacity: 0.05,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3
+    ...CARD_STYLE,
   },
   statLabel: {
     fontSize: FONT_SIZES.SM,


### PR DESCRIPTION
## Summary
- unify card styling with `CARD_STYLE`
- enhance `ScreenContainer` with optional scrolling
- wrap various screens with the new container
- center headers on community and stats screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862a955526c832db3733eb75250cbd3