### PR TITLE
Refactor header across screens

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
+import { SafeAreaView, View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import useUnreadNotifications from '../hooks/useUnreadNotifications';
-import { HEADER_HEIGHT, HEADER_PADDING_TOP } from '../layout';
+import { HEADER_HEIGHT } from '../layout';
 
 export interface HeaderProps {}
 const Header: React.FC<HeaderProps> = () => {
@@ -12,51 +12,56 @@ const Header: React.FC<HeaderProps> = () => {
   const notificationCount = useUnreadNotifications();
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.headerBackground }]}>
-      {/* Left icon - Gear */}
-      <TouchableOpacity onPress={() => navigation.navigate('Settings')} style={styles.iconWrapper}>
-        <Image
-          source={require('../assets/gear.png')}
-          style={[styles.icon, { tintColor: theme.text }]}
-        />
-      </TouchableOpacity>
-
-      {/* Center logo */}
-      <Image
-        source={require('../assets/logo.png')}
-        style={styles.logo}
-      />
-
-      {/* Right icon - Bell with badge */}
-      <TouchableOpacity onPress={() => navigation.navigate('Notifications')} style={styles.iconWrapper}>
-        <View style={styles.bellWrapper}>
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.headerBackground }]}>
+      <View style={styles.container}>
+        {/* Left icon - Gear */}
+        <TouchableOpacity onPress={() => navigation.navigate('Settings')} style={styles.iconWrapper}>
           <Image
-            source={require('../assets/bell.png')}
+            source={require('../assets/gear.png')}
             style={[styles.icon, { tintColor: theme.text }]}
           />
-          {notificationCount > 0 && (
-            <View style={styles.badge}>
-              <Text style={styles.badgeText}>{notificationCount}</Text>
-            </View>
-          )}
-        </View>
-      </TouchableOpacity>
-    </View>
+        </TouchableOpacity>
+
+        {/* Center logo */}
+        <Image
+          source={require('../assets/logo.png')}
+          style={styles.logo}
+        />
+
+        {/* Right icon - Bell with badge */}
+        <TouchableOpacity onPress={() => navigation.navigate('Notifications')} style={styles.iconWrapper}>
+          <View style={styles.bellWrapper}>
+            <Image
+              source={require('../assets/bell.png')}
+              style={[styles.icon, { tintColor: theme.text }]}
+            />
+            {notificationCount > 0 && (
+              <View style={styles.badge}>
+                <Text style={styles.badgeText}>{notificationCount}</Text>
+              </View>
+            )}
+          </View>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
+  safeArea: {
     position: 'absolute',
     top: 0,
+    left: 0,
+    right: 0,
     width: '100%',
+    zIndex: 1000,
+  },
+  container: {
     height: HEADER_HEIGHT,
     paddingHorizontal: 16,
-    paddingTop: HEADER_PADDING_TOP,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    zIndex: 1000,
     ...Platform.select({
       ios: {
         shadowColor: '#000',
@@ -70,8 +75,8 @@ const styles = StyleSheet.create({
     }),
   },
   iconWrapper: {
-    width: 32,
-    height: 32,
+    width: 40,
+    height: 40,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -81,14 +86,14 @@ const styles = StyleSheet.create({
     resizeMode: 'contain',
   },
   logo: {
-    width: 60,
-    height: 60,
+    width: 40,
+    height: 40,
     resizeMode: 'contain',
   },
   bellWrapper: {
     position: 'relative',
-    width: 32,
-    height: 32,
+    width: 40,
+    height: 40,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/layout.js
+++ b/layout.js
@@ -14,7 +14,6 @@ export const BUTTON_STYLE = {
 };
 
 export const HEADER_HEIGHT = 60;
-export const HEADER_PADDING_TOP = Platform.OS === 'ios' ? 44 : 16;
 export const HEADER_SPACING = Platform.OS === 'ios'
   ? HEADER_HEIGHT + 40
   : HEADER_HEIGHT + 20;

--- a/screens/EmailAuthScreen.js
+++ b/screens/EmailAuthScreen.js
@@ -3,6 +3,8 @@ import { Text, TouchableOpacity, Alert } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import AuthForm from '../components/AuthForm';
 import ScreenContainer from '../components/ScreenContainer';
+import Header from '../components/Header';
+import { HEADER_SPACING } from '../layout';
 import firebase from '../firebase';
 import { useOnboarding } from '../contexts/OnboardingContext';
 import { snapshotExists } from '../utils/firestore';
@@ -100,7 +102,8 @@ export default function EmailAuthScreen({ route, navigation }) {
 
   return (
     <GradientBackground>
-      <ScreenContainer scroll contentContainerStyle={styles.container}>
+      <Header showLogoOnly />
+      <ScreenContainer scroll contentContainerStyle={[styles.container, { paddingTop: HEADER_SPACING }]}>
         <Text style={[styles.logoText, { color: theme.text }]}>
           {mode === 'signup' ? 'Create Account' : 'Log In'}
         </Text>

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -29,7 +29,8 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import MultiSelectList from '../components/MultiSelectList';
-import { FONT_SIZES, BUTTON_STYLE } from '../layout';
+import { FONT_SIZES, BUTTON_STYLE, HEADER_SPACING } from '../layout';
+import Header from '../components/Header';
 import { allGames } from '../data/games';
 
 const questions = [
@@ -433,6 +434,7 @@ export default function OnboardingScreen() {
   };
   return (
     <GradientBackground colors={[styles.gradientStart, styles.gradientEnd]} style={styles.container}>
+      <Header showLogoOnly />
       <SafeKeyboardView style={styles.inner}>
         <Text style={styles.progressText}>{`Step ${step + 1} of ${questions.length}`}</Text>
 
@@ -488,7 +490,7 @@ const getStyles = (theme) => {
   const accent = theme.accent;
 
   return StyleSheet.create({
-    container: { flex: 1, padding: 20, backgroundColor: background },
+    container: { flex: 1, paddingTop: HEADER_SPACING, paddingHorizontal: 20, paddingBottom: 20, backgroundColor: background },
     inner: { flex: 1, justifyContent: 'center' },
     progressText: {
       color: textColor,

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -1,9 +1,12 @@
 // screens/LoginScreen.js
 import React, { useEffect } from 'react';
-import { Image, Text } from 'react-native';
+
 import Toast from 'react-native-toast-message';
 import GradientBackground from '../../components/GradientBackground';
 import GradientButton from '../../components/GradientButton';
+import Header from '../../components/Header';
+import ScreenContainer from '../../components/ScreenContainer';
+import { HEADER_SPACING } from '../../layout';
 import getStyles from '../../styles';
 import { useTheme } from '../../contexts/ThemeContext';
 import * as WebBrowser from 'expo-web-browser';
@@ -76,18 +79,18 @@ export default function LoginScreen() {
 
   return (
     <GradientBackground>
-      <Image source={require('../../assets/logo.png')} style={styles.logoImage} />
-      <Text style={[styles.logoText, { color: theme.text }]}>Pinged</Text>
+      <Header showLogoOnly />
+      <ScreenContainer scroll contentContainerStyle={[styles.container, { paddingTop: HEADER_SPACING }]}>
 
-      <GradientButton
-        text="Sign in with Google"
-        onPress={() => promptAsync({ useProxy: false, prompt: 'select_account' })}
-      />
+        <GradientButton
+          text="Sign in with Google"
+          onPress={() => promptAsync({ useProxy: false, prompt: 'select_account' })}
+        />
 
-      <GradientButton
-        text="Login with Email"
-        onPress={() => navigation.navigate('EmailLogin')}
-      />
+        <GradientButton
+          text="Login with Email"
+          onPress={() => navigation.navigate('EmailLogin')}
+        />
 
         <GradientButton
           text="Sign Up"
@@ -98,7 +101,8 @@ export default function LoginScreen() {
           text="Dev Onboarding"
           onPress={handleDevLogin}
         />
-      </GradientBackground>
-    );
+      </ScreenContainer>
+    </GradientBackground>
+  );
   }
 LoginScreen.propTypes = {};


### PR DESCRIPTION
## Summary
- redesign global header using SafeAreaView
- apply fixed sizing and alignment for icons and logo
- use new header on EmailAuth, Onboarding and Login screens
- remove obsolete HEADER_PADDING_TOP constant

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6862b0bbe80c832db37c560fc05373d1