### PR TITLE
Fix screen layout padding

### DIFF
--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -11,7 +11,7 @@ export default function GradientBackground({ children, colors, style }) {
   const gradientColors = colors || [theme.gradientStart, theme.gradientEnd];
 
   return (
-    <LinearGradient colors={gradientColors} style={[styles.container, style]}>
+    <LinearGradient colors={gradientColors} style={[{ flex: 1 }, style]}>
       {children}
     </LinearGradient>
   );

--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -43,6 +43,6 @@ const styles = StyleSheet.create({
   },
   content: {
     flexGrow: 1,
-    padding: 20,
+    paddingVertical: 20,
   },
 });

--- a/styles.js
+++ b/styles.js
@@ -7,7 +7,7 @@ const getStyles = (theme) =>
       flexGrow: 1,
       justifyContent: 'center',
       alignItems: 'center',
-      padding: 20,
+      paddingVertical: 20,
     },
     logoImage: {
       width: 100,


### PR DESCRIPTION
## Summary
- remove default container padding in `GradientBackground`
- switch global container style to vertical-only padding
- update `ScreenContainer` scroll content style

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862b451485c832d909ba106ba12690e