### PR TITLE
Remove matches from HomeScreen and float Swipe button

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -3,7 +3,6 @@ import {
   View,
   Text,
   ScrollView,
-  FlatList,
   TouchableOpacity,
   StyleSheet,
   Modal,
@@ -15,8 +14,7 @@ import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
-import { useChats } from '../contexts/ChatContext';
-import SkeletonPlaceholder from '../components/SkeletonPlaceholder';
+
 import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
 import PropTypes from 'prop-types';
@@ -40,7 +38,6 @@ const CARD_SIZE = 140;
 const HomeScreen = ({ navigation }) => {
   const { theme } = useTheme();
   const { user, loginBonus } = useUser();
-  const { matches, loading: matchesLoading } = useChats();
   const isPremiumUser = !!user?.isPremium;
   const { gamesLeft } = useGameLimit();
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
@@ -139,45 +136,7 @@ const HomeScreen = ({ navigation }) => {
             ))}
           </View>
 
-          <View style={local.group}>
-            <Text style={local.sectionTitle}>Matches</Text>
-            {matchesLoading && matches.length === 0 ? (
-              <FlatList
-                data={[1, 2, 3, 4]}
-                keyExtractor={(item) => item.toString()}
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={local.carousel}
-                renderItem={() => (
-                  <Card style={[local.matchTile, { backgroundColor: theme.card }]}>
-                    <SkeletonPlaceholder
-                      shapes={[
-                        { circle: true, size: 60, style: { alignSelf: 'center', marginBottom: 6 } },
-                        { width: 80, height: 16, borderRadius: 8, style: { alignSelf: 'center' } },
-                      ]}
-                    />
-                  </Card>
-                )}
-              />
-            ) : (
-              <FlatList
-                data={matches}
-                keyExtractor={(item) => item.id}
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={local.carousel}
-                renderItem={({ item }) => (
-                  <Card
-                    onPress={() => navigation.navigate('Chat', { user: item })}
-                    style={[local.matchTile, { backgroundColor: theme.card }]}
-                  >
-                    <Image source={item.image} style={local.matchAvatar} />
-                    <Text style={[local.matchName, { color: theme.text }]}>{item.displayName}</Text>
-                  </Card>
-                )}
-              />
-            )}
-          </View>
+
 
           <View style={local.group}>
             <Card
@@ -345,24 +304,6 @@ const getStyles = (theme) =>
       fontSize: 14,
       fontWeight: '500',
     },
-    matchTile: {
-      width: CARD_SIZE,
-      height: 160,
-      justifyContent: 'center',
-      alignItems: 'center',
-      marginRight: 12,
-      padding: 12,
-    },
-    matchAvatar: {
-      width: 60,
-      height: 60,
-      borderRadius: 30,
-      marginBottom: 6,
-    },
-    matchName: {
-      fontSize: 13,
-      fontWeight: '600',
-    },
     modalBackdrop: {
       flex: 1,
       backgroundColor: 'rgba(0,0,0,0.5)',
@@ -429,7 +370,7 @@ const getStyles = (theme) =>
       position: 'absolute',
       left: 20,
       right: 20,
-      bottom: 90,
+      bottom: 70,
     },
     postCardPreview: {
       borderRadius: 12,


### PR DESCRIPTION
## Summary
- remove Matches section on HomeScreen
- show Swipe Now button as a floating action above the tab bar

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the --jsx flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_686343893068832da2ddabc6378f13b0