### PR TITLE
Add basic animations

### DIFF
--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -1,7 +1,7 @@
 // components/GradientButton.tsx
-import React from 'react';
+import React, { useRef } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
-import { View, Text, Pressable } from 'react-native';
+import { View, Text, Pressable, Animated } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
@@ -30,23 +30,38 @@ export default function GradientButton({
   onPressOut,
 }: GradientButtonProps) {
   const { theme } = useTheme();
+  const scale = useRef(new Animated.Value(1)).current;
   const handlePress = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
     onPress?.();
   };
+  const handlePressIn = () => {
+    Animated.spring(scale, {
+      toValue: 0.97,
+      useNativeDriver: true,
+    }).start();
+    onPressIn?.();
+  };
+  const handlePressOut = () => {
+    Animated.spring(scale, {
+      toValue: 1,
+      useNativeDriver: true,
+    }).start();
+    onPressOut?.();
+  };
   return (
-    <Pressable
-      onPress={handlePress}
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
-      style={{ width, marginVertical }}
-      disabled={disabled}
-    >
-      <LinearGradient
-        colors={[theme.gradientStart, theme.gradientEnd]}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 0 }}
-        style={[
+    <Animated.View style={{ transform: [{ scale }], width, marginVertical }}>
+      <Pressable
+        onPress={handlePress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={disabled}
+      >
+        <LinearGradient
+          colors={[theme.gradientStart, theme.gradientEnd]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 0 }}
+          style={[
           {
             borderRadius: 30,
             paddingVertical: BUTTON_STYLE.paddingVertical,
@@ -65,7 +80,8 @@ export default function GradientButton({
           {text}
         </Text>
       </LinearGradient>
-    </Pressable>
+      </Pressable>
+    </Animated.View>
   );
 }
 

--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -1,6 +1,8 @@
-import React from 'react';
-import { SafeAreaView, ScrollView, StyleSheet } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Animated } from 'react-native';
 import PropTypes from 'prop-types';
+
+const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView);
 
 export default function ScreenContainer({
   children,
@@ -9,8 +11,18 @@ export default function ScreenContainer({
   contentContainerStyle,
   ...rest
 }) {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [fadeAnim]);
+
   return (
-    <SafeAreaView style={[styles.container, style]}>
+    <AnimatedSafeAreaView style={[styles.container, style, { opacity: fadeAnim }]}>
       {scroll ? (
         <ScrollView
           contentContainerStyle={[styles.content, contentContainerStyle]}
@@ -21,7 +33,7 @@ export default function ScreenContainer({
       ) : (
         children
       )}
-    </SafeAreaView>
+    </AnimatedSafeAreaView>
   );
 }
 

--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -18,7 +18,9 @@ const Stack = createNativeStackNavigator();
 
 export default function AppStack() {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+    >
       <Stack.Screen name="Main" component={MainTabs} />
       <Stack.Screen name="Profile" component={ProfileScreen} />
       <Stack.Screen name="Chat" component={ChatScreen} />

--- a/navigation/AuthStack.js
+++ b/navigation/AuthStack.js
@@ -8,7 +8,9 @@ const Stack = createNativeStackNavigator();
 
 export default function AuthStack() {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+    >
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen
         name="EmailLogin"

--- a/navigation/OnboardingStack.js
+++ b/navigation/OnboardingStack.js
@@ -7,7 +7,9 @@ const Stack = createNativeStackNavigator();
 
 export default function OnboardingStack() {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+    >
       <Stack.Screen name="Onboarding" component={OnboardingScreen} />
     </Stack.Navigator>
   );


### PR DESCRIPTION
## Summary
- animate screen entries with fade
- add button tap feedback via scale animation
- enable slide transition for navigators

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863469e4934832d8b1fe7123d14446c