### PR TITLE
Add trending badges to game cards

### DIFF
--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -6,9 +6,10 @@ import { useTheme } from '../contexts/ThemeContext';
 import GameCardBase from './GameCardBase';
 import FavoriteStar from './FavoriteStar';
 import PremiumBadge from './PremiumBadge';
+import TrendingBadge from './TrendingBadge';
 import useCardPressAnimation from '../hooks/useCardPressAnimation';
 
-export default function GameCard({ item, onPress, toggleFavorite, isFavorite }) {
+export default function GameCard({ item, onPress, toggleFavorite, isFavorite, trending }) {
   const { theme } = useTheme();
   const { scale, handlePressIn, handlePressOut } = useCardPressAnimation();
 
@@ -26,6 +27,7 @@ export default function GameCard({ item, onPress, toggleFavorite, isFavorite }) 
         route={item.route}
         accent={theme.accent}
       />
+      <TrendingBadge trending={trending} />
 
       {item.premium && (
         <Ionicons
@@ -54,4 +56,5 @@ GameCard.propTypes = {
   onPress: PropTypes.func.isRequired,
   toggleFavorite: PropTypes.func.isRequired,
   isFavorite: PropTypes.bool.isRequired,
+  trending: PropTypes.bool,
 };

--- a/components/TrendingBadge.js
+++ b/components/TrendingBadge.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+const TrendingBadge = ({ trending }) => {
+  if (!trending) return null;
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        bottom: 8,
+        left: 8,
+        backgroundColor: '#ef4444',
+        paddingHorizontal: 6,
+        paddingVertical: 2,
+        borderRadius: 8,
+      }}
+    >
+      <Text style={{ color: '#fff', fontSize: 10 }}>Trending</Text>
+    </View>
+  );
+};
+
+TrendingBadge.propTypes = {
+  trending: PropTypes.bool,
+};
+
+export default TrendingBadge;

--- a/contexts/Providers.js
+++ b/contexts/Providers.js
@@ -11,6 +11,7 @@ import { GameLimitProvider } from './GameLimitContext';
 import { ChatProvider } from './ChatContext';
 import { MatchmakingProvider } from './MatchmakingContext';
 import { GameSessionProvider } from './GameSessionContext';
+import { TrendingProvider } from './TrendingContext';
 
 const Providers = ({ children }) => (
   <DevProvider>
@@ -24,7 +25,9 @@ const Providers = ({ children }) => (
                 <GameLimitProvider>
                   <ChatProvider>
                     <MatchmakingProvider>
-                      <GameSessionProvider>{children}</GameSessionProvider>
+                      <TrendingProvider>
+                        <GameSessionProvider>{children}</GameSessionProvider>
+                      </TrendingProvider>
                     </MatchmakingProvider>
                   </ChatProvider>
                 </GameLimitProvider>

--- a/contexts/TrendingContext.js
+++ b/contexts/TrendingContext.js
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import firebase from '../firebase';
+
+const TrendingContext = createContext();
+
+export const TrendingProvider = ({ children }) => {
+  const [trendingMap, setTrendingMap] = useState({});
+
+  useEffect(() => {
+    const unsub = firebase
+      .firestore()
+      .collection('games')
+      .onSnapshot(
+        (snap) => {
+          const map = {};
+          snap.docs.forEach((d) => {
+            const data = d.data() || {};
+            if (data.trending) {
+              const id = data.id || d.id;
+              map[id] = true;
+            }
+          });
+          setTrendingMap(map);
+        },
+        (e) => console.warn('Failed to load trending games', e)
+      );
+    return unsub;
+  }, []);
+
+  return (
+    <TrendingContext.Provider value={{ trendingMap }}>
+      {children}
+    </TrendingContext.Provider>
+  );
+};
+
+export const useTrending = () => useContext(TrendingContext);

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -20,6 +20,7 @@ import GameFilters from '../components/GameFilters';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
+import { useTrending } from '../contexts/TrendingContext';
 
 
 const getAllCategories = () => {
@@ -35,6 +36,7 @@ const PlayScreen = ({ navigation }) => {
   const { gamesLeft } = useGameLimit();
   const isPremiumUser = !!user?.isPremium;
   const requireCredits = useRequireGameCredits();
+  const { trendingMap } = useTrending();
   const [filter, setFilter] = useState('All');
   const [category, setCategory] = useState('All');
   const [search, setSearch] = useState('');
@@ -92,6 +94,7 @@ const PlayScreen = ({ navigation }) => {
       <GameCard
         item={item}
         isFavorite={favorites.includes(item.id)}
+        trending={!!trendingMap[item.id]}
         toggleFavorite={() => toggleFavorite(item.id)}
         onPress={() => {
           Keyboard.dismiss();


### PR DESCRIPTION
## Summary
- create a `TrendingContext` that subscribes to Firestore game documents
- show a `TrendingBadge` on game cards when marked trending
- hook the new provider into the context stack
- pass trending state to `GameCard` from `PlayScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863470940d4832d9bc7a5ab3f7017d4