### PR TITLE
Fix syntax error in ChatScreen

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -648,7 +648,6 @@ const getPrivateStyles = (theme) =>
     color: '#666',
     marginBottom: 4,
   },
-  },
   });
 
 /********************


### PR DESCRIPTION
## Summary
- fix unbalanced braces in `ChatScreen.js` private styles

## Testing
- `node --check screens/ChatScreen.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68634b1121e8832d829747b30f282b9f