### PR TITLE
Fix container layout

### DIFF
--- a/screens/ActiveGamesScreen.js
+++ b/screens/ActiveGamesScreen.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl, SafeAreaView } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
+import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useGameSessions } from '../contexts/GameSessionContext';
 import { useChats } from '../contexts/ChatContext';
@@ -69,32 +70,30 @@ const ActiveGamesScreen = ({ navigation }) => {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <GradientBackground style={{ flex: 1 }}>
-        <Header />
-        <View style={{ flex: 1, paddingTop: HEADER_SPACING }}>
-          {loading ? (
-            <View style={styles.loader}>
-              <Loader />
-            </View>
-          ) : (
-            <FlatList
-              data={list}
-              keyExtractor={(item) => item.id}
-              renderItem={renderItem}
-              refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
-              ListEmptyComponent={
-                <EmptyState
-                  text="No active games."
-                  image={require('../assets/logo.png')}
-                />
-              }
-              contentContainerStyle={{ paddingBottom: 120 }}
-            />
-          )}
-        </View>
-      </GradientBackground>
-    </SafeAreaView>
+    <GradientBackground style={{ flex: 1 }}>
+      <Header />
+      <ScreenContainer style={{ paddingTop: HEADER_SPACING }}>
+        {loading ? (
+          <View style={styles.loader}>
+            <Loader />
+          </View>
+        ) : (
+          <FlatList
+            data={list}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+            ListEmptyComponent={
+              <EmptyState
+                text="No active games."
+                image={require('../assets/logo.png')}
+              />
+            }
+            contentContainerStyle={{ paddingBottom: 120 }}
+          />
+        )}
+      </ScreenContainer>
+    </GradientBackground>
   );
 };
 

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -9,13 +9,13 @@ import {
   FlatList,
   ScrollView,
   StyleSheet,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
   Easing,
 } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
+import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useDev } from '../contexts/DevContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
@@ -437,7 +437,7 @@ function BotSessionScreen({ route }) {
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           keyboardVerticalOffset={80}
         >
-        <SafeAreaView style={{ flex: 1, paddingTop: HEADER_SPACING, paddingHorizontal: 10, paddingBottom: 20 }}>
+        <ScreenContainer style={{ paddingTop: HEADER_SPACING, paddingBottom: 20 }}>
         <View style={botStyles.gameTabs}>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             {Object.entries(gameMap).map(([key, val]) => (
@@ -519,7 +519,7 @@ function BotSessionScreen({ route }) {
             </SafeKeyboardView>
           </View>
         </View>
-        </SafeAreaView>
+        </ScreenContainer>
         </KeyboardAvoidingView>
       </GradientBackground>
   );

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -228,8 +228,8 @@ HomeScreen.propTypes = {
 const getStyles = (theme) =>
   StyleSheet.create({
     container: {
-      alignItems: 'center',
-      paddingHorizontal: 20,
+      alignItems: 'stretch',
+      paddingHorizontal: 0,
       paddingVertical: 20,
     },
     welcome: {

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -207,9 +207,9 @@ const MatchesScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
+    alignItems: 'stretch',
     justifyContent: 'flex-start',
-    paddingHorizontal: 16,
+    paddingHorizontal: 0,
   },
   sectionTitle: {
     fontSize: 16,

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -490,7 +490,13 @@ const getStyles = (theme) => {
   const accent = theme.accent;
 
   return StyleSheet.create({
-    container: { flex: 1, paddingTop: HEADER_SPACING, paddingHorizontal: 20, paddingBottom: 20, backgroundColor: background },
+    container: {
+      flex: 1,
+      paddingTop: HEADER_SPACING,
+      paddingBottom: 20,
+      backgroundColor: background,
+      alignItems: 'stretch',
+    },
     inner: { flex: 1, justifyContent: 'center' },
     progressText: {
       color: textColor,

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -128,7 +128,8 @@ const PremiumScreen = ({ navigation, route }) => {
 
 const upgradeStyles = StyleSheet.create({
   container: {
-    paddingHorizontal: 24,
+    paddingHorizontal: 0,
+    alignItems: 'stretch',
   },
   title: {
     fontSize: 24,
@@ -171,8 +172,8 @@ const getPaywallStyles = (theme) =>
   StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    paddingHorizontal: 24,
+    alignItems: 'stretch',
+    paddingHorizontal: 0,
     paddingTop: HEADER_SPACING,
   },
   title: {

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -183,7 +183,8 @@ const getStyles = (theme) => StyleSheet.create({
   container: {
     paddingBottom: 80,
     paddingTop: HEADER_SPACING,
-    paddingHorizontal: 20
+    paddingHorizontal: 0,
+    alignItems: 'stretch',
   },
   profileCard: {
     alignItems: 'center',

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -589,8 +589,8 @@ const getStyles = (theme) =>
   container: {
     flex: 1,
     paddingTop: HEADER_SPACING,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
   },
   card: {
     position: 'absolute',

--- a/styles.js
+++ b/styles.js
@@ -4,9 +4,9 @@ import { BUTTON_STYLE, FONT_SIZES } from './layout';
 const getStyles = (theme) =>
   StyleSheet.create({
     container: {
-      flexGrow: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
+      flex: 1,
+      justifyContent: 'flex-start',
+      alignItems: 'stretch',
       paddingVertical: 20,
     },
     logoImage: {
@@ -206,8 +206,8 @@ const getStyles = (theme) =>
     },
   swipeScreen: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
     paddingTop: 40
   },
   swipeButtons: {


### PR DESCRIPTION
## Summary
- stretch layout in global styles
- remove padding from onboarding and stats screens
- uncenter home and matches styles
- adjust premium and swipe screen containers
- use ScreenContainer for ActiveGames and GameSession screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68634cd06910832da940cd09803332d5