### PR TITLE
Add empty states for games and session chats

### DIFF
--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -37,6 +37,7 @@ import useBotGame from "../hooks/useBotGame";
 import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 import Loader from "../components/Loader";
+import EmptyState from '../components/EmptyState';
 import { logGameStats } from '../utils/gameStats';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PropTypes from 'prop-types';
@@ -503,6 +504,12 @@ function BotSessionScreen({ route }) {
               renderItem={renderMessage}
               inverted
               contentContainerStyle={{ paddingBottom: 40 }}
+              ListEmptyComponent={
+                <EmptyState
+                  text="No messages yet."
+                  image={require('../assets/logo.png')}
+                />
+              }
             />
             <SafeKeyboardView>
               <View style={botStyles.inputBar}>

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -18,6 +18,7 @@ import GameCard from '../components/GameCard';
 import GamePreviewModal from '../components/GamePreviewModal';
 import GameFilters from '../components/GameFilters';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import EmptyState from '../components/EmptyState';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 import { useTrending } from '../contexts/TrendingContext';
@@ -143,6 +144,12 @@ const PlayScreen = ({ navigation }) => {
         columnWrapperStyle={{ justifyContent: 'center' }}
         renderItem={renderItem}
         onScrollBeginDrag={Keyboard.dismiss}
+        ListEmptyComponent={
+          <EmptyState
+            text="No games found."
+            image={require('../assets/logo.png')}
+          />
+        }
       />
 
       <GamePreviewModal


### PR DESCRIPTION
## Summary
- add `EmptyState` component to game session chat when there are no messages
- show placeholder if the game list search yields no games

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686366351e70832da966a3de96268f09