### PR TITLE
Fix header layout consistency

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,12 @@ import { useTheme } from '../contexts/ThemeContext';
 import useUnreadNotifications from '../hooks/useUnreadNotifications';
 import { HEADER_HEIGHT } from '../layout';
 
-export interface HeaderProps {}
-const Header: React.FC<HeaderProps> = () => {
+export interface HeaderProps {
+  /** Only show the center logo */
+  showLogoOnly?: boolean;
+}
+
+const Header: React.FC<HeaderProps> = ({ showLogoOnly = false }) => {
   const navigation = useNavigation();
   const { darkMode, theme } = useTheme();
   const notificationCount = useUnreadNotifications();
@@ -14,34 +18,39 @@ const Header: React.FC<HeaderProps> = () => {
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.headerBackground }]}>
       <View style={styles.container}>
-        {/* Left icon - Gear */}
-        <TouchableOpacity onPress={() => navigation.navigate('Settings')} style={styles.iconWrapper}>
-          <Image
-            source={require('../assets/gear.png')}
-            style={[styles.icon, { tintColor: theme.text }]}
-          />
-        </TouchableOpacity>
-
-        {/* Center logo */}
-        <Image
-          source={require('../assets/logo.png')}
-          style={styles.logo}
-        />
-
-        {/* Right icon - Bell with badge */}
-        <TouchableOpacity onPress={() => navigation.navigate('Notifications')} style={styles.iconWrapper}>
-          <View style={styles.bellWrapper}>
+        {!showLogoOnly && (
+          <TouchableOpacity
+            onPress={() => navigation.navigate('Settings')}
+            style={styles.iconWrapper}
+          >
             <Image
-              source={require('../assets/bell.png')}
+              source={require('../assets/gear.png')}
               style={[styles.icon, { tintColor: theme.text }]}
             />
-            {notificationCount > 0 && (
-              <View style={styles.badge}>
-                <Text style={styles.badgeText}>{notificationCount}</Text>
-              </View>
-            )}
-          </View>
-        </TouchableOpacity>
+          </TouchableOpacity>
+        )}
+
+        {/* Center logo */}
+        <Image source={require('../assets/logo.png')} style={styles.logo} />
+
+        {!showLogoOnly && (
+          <TouchableOpacity
+            onPress={() => navigation.navigate('Notifications')}
+            style={styles.iconWrapper}
+          >
+            <View style={styles.bellWrapper}>
+              <Image
+                source={require('../assets/bell.png')}
+                style={[styles.icon, { tintColor: theme.text }]}
+              />
+              {notificationCount > 0 && (
+                <View style={styles.badge}>
+                  <Text style={styles.badgeText}>{notificationCount}</Text>
+                </View>
+              )}
+            </View>
+          </TouchableOpacity>
+        )}
       </View>
     </SafeAreaView>
   );

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -23,6 +23,7 @@ import getGlobalStyles from '../styles';
 import { useChats } from '../contexts/ChatContext';
 import { useUser } from '../contexts/UserContext';
 import Toast from 'react-native-toast-message';
+import { HEADER_SPACING } from '../layout';
 import EmptyState from '../components/EmptyState';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import InviteUserCard from '../components/InviteUserCard';
@@ -156,7 +157,7 @@ const GameInviteScreen = ({ route, navigation }) => {
   return (
     <GradientBackground style={styles.swipeScreen}>
       <Header showLogoOnly />
-      <ScreenContainer style={{ paddingBottom: 100 }}>
+      <ScreenContainer style={{ paddingTop: HEADER_SPACING, paddingBottom: 100 }}>
         <SafeKeyboardView style={{ flex: 1 }}>
           <Text
             style={{

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -14,6 +14,7 @@ import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
+import { HEADER_SPACING } from '../layout';
 
 import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
@@ -106,7 +107,12 @@ const HomeScreen = ({ navigation }) => {
     <GradientBackground style={{ flex: 1 }}>
       <ScreenContainer>
         <Header showLogoOnly />
-        <ScrollView contentContainerStyle={[local.container, { paddingBottom: 100 }]}>
+        <ScrollView
+          contentContainerStyle={[
+            local.container,
+            { paddingTop: HEADER_SPACING, paddingBottom: 100 },
+          ]}
+        >
           <Text style={[local.welcome, { color: theme.text }]}>
             {`Welcome${user?.displayName ? `, ${user.displayName}` : ''}!`}
           </Text>

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -18,6 +18,7 @@ import GradientBackground from '../components/GradientBackground';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { useUser } from '../contexts/UserContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { HEADER_SPACING } from '../layout';
 import firebase from '../firebase';
 import { games } from '../games';
 import PropTypes from 'prop-types';
@@ -118,7 +119,13 @@ const NotificationsScreen = ({ navigation }) => {
   return (
     <GradientBackground style={styles.container}>
       <Header navigation={navigation} />
-      <ScrollView contentContainerStyle={{ padding: 20, paddingBottom: 120 }}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingTop: HEADER_SPACING,
+          padding: 20,
+          paddingBottom: 120,
+        }}
+      >
         <Text style={[local.title, { color: theme.text }]}>Game Invites</Text>
 
         {pendingInvites.length === 0 ? (

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -21,6 +21,7 @@ import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 import { useTrending } from '../contexts/TrendingContext';
+import { HEADER_SPACING } from '../layout';
 
 
 const getAllCategories = () => {
@@ -108,7 +109,7 @@ const PlayScreen = ({ navigation }) => {
   return (
     <GradientBackground style={styles.swipeScreen}>
       <Header showLogoOnly />
-      <SafeKeyboardView style={{ flex: 1 }}>
+      <SafeKeyboardView style={{ flex: 1, paddingTop: HEADER_SPACING }}>
 
       <Text
         style={{

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -6,6 +6,7 @@ import GradientBackground from '../../components/GradientBackground';
 import GradientButton from '../../components/GradientButton';
 import { Animated, Easing, Image, Text } from 'react-native';
 import ScreenContainer from '../../components/ScreenContainer';
+import Header from '../../components/Header';
 import { HEADER_SPACING } from '../../layout';
 import getStyles from '../../styles';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -92,7 +93,14 @@ export default function LoginScreen() {
 
   return (
     <GradientBackground>
-      <ScreenContainer scroll contentContainerStyle={[styles.container, { paddingTop: HEADER_SPACING, alignItems: 'center' }]}>
+      <Header showLogoOnly />
+      <ScreenContainer
+        scroll
+        contentContainerStyle={[
+          styles.container,
+          { paddingTop: HEADER_SPACING, alignItems: 'center' },
+        ]}
+      >
         <Animated.View style={{ alignItems: 'center', opacity: anim, transform: [{ scale }] }}>
           <Image source={require('../../assets/logo.png')} style={styles.logoImage} />
           <Text style={[styles.logoText, { color: theme.text }]}>Pinged</Text>


### PR DESCRIPTION
## Summary
- add `showLogoOnly` option to `Header`
- show header on login screen and pad content
- pad home and invite screens below the header
- pad notification list below the header
- pad play screen below the header

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_686365b00858832d88c2d43a559bf690