### PR TITLE
Enhance Game Over modal design

### DIFF
--- a/hooks/useWinLossStats.js
+++ b/hooks/useWinLossStats.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import firebase from '../firebase';
+
+export default function useWinLossStats(userId) {
+  const [stats, setStats] = useState({ wins: 0, losses: 0, loading: true });
+  useEffect(() => {
+    if (!userId) return;
+    const load = async () => {
+      try {
+        const snap = await firebase
+          .firestore()
+          .collection('gameSessions')
+          .where('players', 'array-contains', userId)
+          .get();
+        let wins = 0;
+        snap.forEach((doc) => {
+          const data = doc.data();
+          const idx = Array.isArray(data.players)
+            ? data.players.indexOf(userId)
+            : -1;
+          if (idx !== -1 && data.gameover && data.gameover.winner === String(idx)) {
+            wins += 1;
+          }
+        });
+        setStats({ wins, losses: snap.size - wins, loading: false });
+      } catch (e) {
+        console.warn('Failed to load win/loss stats', e);
+        setStats({ wins: 0, losses: 0, loading: false });
+      }
+    };
+    load();
+  }, [userId]);
+  return stats;
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "expo-notifications": "~0.31.3",
     "expo-device": "~7.1.4",
     "expo-haptics": "~14.1.4",
-    "expo-updates": "~0.28.15"
+    "expo-updates": "~0.28.15",
+    "expo-blur": "~12.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -275,13 +275,22 @@ const LiveSessionScreen = ({ route, navigation }) => {
             ? opponent.displayName
             : null
         }
-        onRematch={handleRematch}
-        onChat={() =>
-          navigation.navigate('Chat', {
-            user: { id: opponent.id, displayName: opponent.displayName, image: opponent.photo },
-            gameId: game.id,
-          })
+        winnerAvatar={
+          gameResult?.winner === '0'
+            ? user.photoURL
+            : gameResult?.winner === '1'
+            ? opponent.photo
+            : null
         }
+        winnerId={
+          gameResult?.winner === '0'
+            ? user.uid
+            : gameResult?.winner === '1'
+            ? opponent.id
+            : null
+        }
+        onRematch={handleRematch}
+        onExit={() => navigation.goBack()}
       />
     </GradientBackground>
   );


### PR DESCRIPTION
## Summary
- add glassy Game Over modal with confetti background
- show winner avatar and name with win/loss stats
- add rematch & exit buttons with ripple effect
- include expo-blur and helper hook for win/loss stats

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686369028c1c832d81bfa703a2d4896c