### PR TITLE
Add GameContainer wrapper for boardgame.io games

### DIFF
--- a/components/GameContainer.js
+++ b/components/GameContainer.js
@@ -1,0 +1,117 @@
+import React, { useRef, useEffect } from 'react';
+import { View, Text, StyleSheet, Image, TouchableOpacity, Animated } from 'react-native';
+import PropTypes from 'prop-types';
+import GradientBackground from './GradientBackground';
+import { useTheme } from '../contexts/ThemeContext';
+import { HEADER_SPACING } from '../layout';
+
+export default function GameContainer({
+  children,
+  player1,
+  player2,
+  visible = true,
+  onToggleChat,
+}) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  const fade = useRef(new Animated.Value(visible ? 1 : 0)).current;
+  const scale = useRef(new Animated.Value(visible ? 1 : 0.95)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fade, {
+        toValue: visible ? 1 : 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.timing(scale, {
+        toValue: visible ? 1 : 0.95,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [visible, fade, scale]);
+
+  return (
+    <GradientBackground style={styles.container}>
+      <View style={styles.header}>
+        <View style={styles.playerInfo}>
+          {player1?.avatar && (
+            <Image source={{ uri: player1.avatar }} style={styles.avatar} />
+          )}
+          <Text style={styles.name}>{player1?.name || 'You'}</Text>
+        </View>
+        <View style={styles.playerInfo}>
+          {player2?.avatar && (
+            <Image source={{ uri: player2.avatar }} style={styles.avatar} />
+          )}
+          <Text style={styles.name}>{player2?.name || 'Opponent'}</Text>
+        </View>
+      </View>
+      <Animated.View style={[styles.boardWrapper, { opacity: fade, transform: [{ scale }] }]}>
+        {children}
+      </Animated.View>
+      {onToggleChat && (
+        <TouchableOpacity style={styles.chatBtn} onPress={onToggleChat}>
+          <Text style={styles.chatText}>Chat</Text>
+        </TouchableOpacity>
+      )}
+    </GradientBackground>
+  );
+}
+
+GameContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  player1: PropTypes.shape({ name: PropTypes.string, avatar: PropTypes.string }),
+  player2: PropTypes.shape({ name: PropTypes.string, avatar: PropTypes.string }),
+  visible: PropTypes.bool,
+  onToggleChat: PropTypes.func,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingTop: HEADER_SPACING,
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+    },
+    header: {
+      width: '90%',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: 20,
+    },
+    playerInfo: {
+      alignItems: 'center',
+    },
+    avatar: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      marginBottom: 4,
+    },
+    name: {
+      color: theme.text,
+      fontWeight: 'bold',
+    },
+    boardWrapper: {
+      width: '90%',
+      aspectRatio: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    chatBtn: {
+      position: 'absolute',
+      right: 20,
+      bottom: 30,
+      backgroundColor: theme.accent,
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      borderRadius: 20,
+    },
+    chatText: {
+      color: '#fff',
+      fontWeight: 'bold',
+    },
+  });

--- a/components/SyncedGame.js
+++ b/components/SyncedGame.js
@@ -5,7 +5,16 @@ import useGameSession from '../hooks/useGameSession';
 import { games } from '../games';
 import PropTypes from 'prop-types';
 
-export default function SyncedGame({ sessionId, gameId, opponentId, onGameEnd }) {
+export default function SyncedGame({
+  sessionId,
+  gameId,
+  opponentId,
+  onGameEnd,
+  player1,
+  player2,
+  visible = true,
+  onToggleChat,
+}) {
   const { Board } = games[gameId] || {};
   const { G, ctx, moves, loading } = useGameSession(sessionId, gameId, opponentId);
 
@@ -18,7 +27,18 @@ export default function SyncedGame({ sessionId, gameId, opponentId, onGameEnd })
     );
   }
 
-  return <Board G={G} ctx={ctx} moves={moves} onGameEnd={onGameEnd} />;
+  return (
+    <Board
+      G={G}
+      ctx={ctx}
+      moves={moves}
+      onGameEnd={onGameEnd}
+      player1={player1}
+      player2={player2}
+      visible={visible}
+      onToggleChat={onToggleChat}
+    />
+  );
 }
 
 SyncedGame.propTypes = {
@@ -26,4 +46,8 @@ SyncedGame.propTypes = {
   gameId: PropTypes.string.isRequired,
   opponentId: PropTypes.string.isRequired,
   onGameEnd: PropTypes.func.isRequired,
+  player1: PropTypes.object,
+  player2: PropTypes.object,
+  visible: PropTypes.bool,
+  onToggleChat: PropTypes.func,
 };

--- a/games/index.js
+++ b/games/index.js
@@ -1,8 +1,10 @@
+import React from 'react';
 import TicTacToeClient, { Game as ticTacToeGame, Board as TicTacToeBoard, meta as ticTacToeMeta } from './tic-tac-toe';
 import RPSClient, { Game as rpsGame, Board as RPSBoard, meta as rpsMeta } from './rock-paper-scissors';
 import ConnectFourClient, { Game as connectFourGame, Board as ConnectFourBoard, meta as connectFourMeta } from './connect-four';
 import GomokuClient, { Game as gomokuGame, Board as GomokuBoard, meta as gomokuMeta } from './gomoku';
 import MemoryMatchClient, { Game as memoryMatchGame, Board as MemoryMatchBoard, meta as memoryMatchMeta } from './memory-match';
+import GameContainer from '../components/GameContainer';
 import HangmanClient, { Game as hangmanGame, Board as HangmanBoard, meta as hangmanMeta } from './hangman';
 import MinesweeperClient, { Game as minesweeperGame, Board as MinesweeperBoard, meta as minesweeperMeta } from './minesweeper';
 import SudokuClient, { Game as sudokuGame, Board as SudokuBoard, meta as sudokuMeta } from './sudoku';
@@ -19,105 +21,136 @@ import PigClient, { Game as pigGame, Board as PigBoard, meta as pigMeta } from '
 import CoinTossClient, { Game as coinTossGame, Board as CoinTossBoard, meta as coinTossMeta } from './coin-toss';
 import FlirtyQuestionsClient, { Game as flirtyQuestionsGame, Board as FlirtyQuestionsBoard, meta as flirtyQuestionsMeta } from './flirty-questions';
 
+const withContainer = (Board) => (props) => (
+  <GameContainer
+    player1={props.player1}
+    player2={props.player2}
+    onToggleChat={props.onToggleChat}
+    visible={props.visible}
+  >
+    <Board {...props} />
+  </GameContainer>
+);
+
 export const games = {
   [ticTacToeMeta.id]: {
     Client: TicTacToeClient,
     Game: ticTacToeGame,
-    Board: TicTacToeBoard,
+    Board: withContainer(TicTacToeBoard),
     meta: ticTacToeMeta,
   },
-  [rpsMeta.id]: { Client: RPSClient, Game: rpsGame, Board: RPSBoard, meta: rpsMeta },
+  [rpsMeta.id]: {
+    Client: RPSClient,
+    Game: rpsGame,
+    Board: withContainer(RPSBoard),
+    meta: rpsMeta,
+  },
   [connectFourMeta.id]: {
     Client: ConnectFourClient,
     Game: connectFourGame,
-    Board: ConnectFourBoard,
+    Board: withContainer(ConnectFourBoard),
     meta: connectFourMeta,
   },
-  [gomokuMeta.id]: { Client: GomokuClient, Game: gomokuGame, Board: GomokuBoard, meta: gomokuMeta },
+  [gomokuMeta.id]: {
+    Client: GomokuClient,
+    Game: gomokuGame,
+    Board: withContainer(GomokuBoard),
+    meta: gomokuMeta,
+  },
   [memoryMatchMeta.id]: {
     Client: MemoryMatchClient,
     Game: memoryMatchGame,
-    Board: MemoryMatchBoard,
+    Board: withContainer(MemoryMatchBoard),
     meta: memoryMatchMeta,
   },
-  [hangmanMeta.id]: { Client: HangmanClient, Game: hangmanGame, Board: HangmanBoard, meta: hangmanMeta },
+  [hangmanMeta.id]: {
+    Client: HangmanClient,
+    Game: hangmanGame,
+    Board: withContainer(HangmanBoard),
+    meta: hangmanMeta,
+  },
   [minesweeperMeta.id]: {
     Client: MinesweeperClient,
     Game: minesweeperGame,
-    Board: MinesweeperBoard,
+    Board: withContainer(MinesweeperBoard),
     meta: minesweeperMeta,
   },
-  [sudokuMeta.id]: { Client: SudokuClient, Game: sudokuGame, Board: SudokuBoard, meta: sudokuMeta },
+  [sudokuMeta.id]: {
+    Client: SudokuClient,
+    Game: sudokuGame,
+    Board: withContainer(SudokuBoard),
+    meta: sudokuMeta,
+  },
   [guessNumberMeta.id]: {
     Client: GuessNumberClient,
     Game: guessNumberGame,
-    Board: GuessNumberBoard,
+    Board: withContainer(GuessNumberBoard),
     meta: guessNumberMeta,
   },
   [checkersMeta.id]: {
     Client: CheckersClient,
     Game: checkersGame,
-    Board: CheckersBoard,
+    Board: withContainer(CheckersBoard),
     meta: checkersMeta,
   },
   [dominoesMeta.id]: {
     Client: DominoesClient,
     Game: dominoesGame,
-    Board: DominoesBoard,
+    Board: withContainer(DominoesBoard),
     meta: dominoesMeta,
   },
   [battleshipMeta.id]: {
     Client: BattleshipClient,
     Game: battleshipGame,
-    Board: BattleshipBoard,
+    Board: withContainer(BattleshipBoard),
     meta: battleshipMeta,
   },
   [dotsBoxesMeta.id]: {
     Client: DotsBoxesClient,
     Game: dotsBoxesGame,
-    Board: DotsBoxesBoard,
+    Board: withContainer(DotsBoxesBoard),
     meta: dotsBoxesMeta,
   },
   [mancalaMeta.id]: {
     Client: MancalaClient,
     Game: mancalaGame,
-    Board: MancalaBoard,
+    Board: withContainer(MancalaBoard),
     meta: mancalaMeta,
   },
   [snakesLaddersMeta.id]: {
     Client: SnakesLaddersClient,
     Game: snakesLaddersGame,
-    Board: SnakesLaddersBoard,
+    Board: withContainer(SnakesLaddersBoard),
     meta: snakesLaddersMeta,
   },
   [blackjackMeta.id]: {
     Client: BlackjackClient,
     Game: blackjackGame,
-    Board: BlackjackBoard,
+    Board: withContainer(BlackjackBoard),
     meta: blackjackMeta,
   },
   [nimMeta.id]: {
     Client: NimClient,
     Game: nimGame,
-    Board: NimBoard,
+    Board: withContainer(NimBoard),
     meta: nimMeta,
   },
   [pigMeta.id]: {
     Client: PigClient,
     Game: pigGame,
-    Board: PigBoard,
+    Board: withContainer(PigBoard),
     meta: pigMeta,
   },
   [flirtyQuestionsMeta.id]: {
     Client: FlirtyQuestionsClient,
     Game: flirtyQuestionsGame,
-    Board: FlirtyQuestionsBoard,
+    Board: withContainer(FlirtyQuestionsBoard),
     meta: flirtyQuestionsMeta,
   },
   [coinTossMeta.id]: {
     Client: CoinTossClient,
     Game: coinTossGame,
-    Board: CoinTossBoard,
+    Board: withContainer(CoinTossBoard),
     meta: coinTossMeta,
   },
 };

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -232,7 +232,15 @@ const LiveSessionScreen = ({ route, navigation }) => {
                     <Text style={{ color: '#fff' }}>Player 2</Text>
                   </TouchableOpacity>
                 </View>
-                <GameComponent playerID={devPlayer} matchID="dev" />
+                <GameComponent
+                  playerID={devPlayer}
+                  matchID="dev"
+                  boardProps={{
+                    player1: { name: 'Player 1' },
+                    player2: { name: 'Player 2' },
+                    visible: true,
+                  }}
+                />
               </>
             ) : (
               <SyncedGame
@@ -240,6 +248,15 @@ const LiveSessionScreen = ({ route, navigation }) => {
                 gameId={game.id}
                 opponentId={opponent.id}
                 onGameEnd={handleGameEnd}
+                player1={{ name: user.displayName, avatar: user.photo }}
+                player2={{ name: opponent.displayName, avatar: opponent.photo }}
+                visible={showGame}
+                onToggleChat={() =>
+                  navigation.navigate('Chat', {
+                    user: { id: opponent.id, displayName: opponent.displayName, image: opponent.photo },
+                    gameId: game.id,
+                  })
+                }
               />
             )}
           </View>
@@ -471,6 +488,10 @@ function BotSessionScreen({ route }) {
                     ctx={ctx}
                     moves={moves}
                     onGameEnd={(res) => handleGameEnd(res, game)}
+                    player1={{ name: 'You' }}
+                    player2={{ name: bot.name }}
+                    visible={showBoard}
+                    onToggleChat={() => setShowBoard(false)}
                   />
                 </View>
                 <TouchableOpacity style={botStyles.resetBtn} onPress={reset}>


### PR DESCRIPTION
## Summary
- create reusable `GameContainer` component
- add wrapper in `games/index.js` to apply `GameContainer` to all boards
- extend `SyncedGame` and `GameSessionScreen` to pass player info and chat callbacks

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686369080c68832d8c8923b0ff6aa608