### PR TITLE
Add spectator mode placeholder UI

### DIFF
--- a/hooks/useGameSession.js
+++ b/hooks/useGameSession.js
@@ -89,6 +89,7 @@ export default function useGameSession(sessionId, gameId, opponentId) {
     G: session?.state,
     ctx: { currentPlayer: session?.currentPlayer, gameover: session?.gameover },
     moves,
+    moveHistory: session?.moves || [],
     loading: !session,
   };
 }

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -38,16 +38,21 @@ import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 import Loader from "../components/Loader";
 import EmptyState from '../components/EmptyState';
+import useGameSession from '../hooks/useGameSession';
 import { logGameStats } from '../utils/gameStats';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PropTypes from 'prop-types';
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
-  const type = sessionType || route.params?.sessionType || (route.params?.botId ? "bot" : "live");
-  return type === "bot" ? (
-    <BotSessionScreen route={route} navigation={navigation} />
-  ) : (
-    <LiveSessionScreen route={route} navigation={navigation} />
-  );
+  const type =
+    sessionType || route.params?.sessionType ||
+    (route.params?.botId ? 'bot' : 'live');
+  if (type === 'bot') {
+    return <BotSessionScreen route={route} navigation={navigation} />;
+  }
+  if (type === 'spectator') {
+    return <SpectatorSessionScreen route={route} navigation={navigation} />;
+  }
+  return <LiveSessionScreen route={route} navigation={navigation} />;
 };
 
 
@@ -532,6 +537,94 @@ function BotSessionScreen({ route }) {
   );
 }
 
+function SpectatorSessionScreen({ route }) {
+  const { theme } = useTheme();
+  const styles = getSpectatorStyles(theme);
+  const anim = useRef(new Animated.Value(0)).current;
+  const scrollRef = useRef();
+  const { sessionId, game, players = [] } = route.params || {};
+  const { moveHistory, ctx, loading } = useGameSession(sessionId, game?.id, '');
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(anim, { toValue: 1, duration: 800, useNativeDriver: true }),
+        Animated.timing(anim, { toValue: 0.3, duration: 800, useNativeDriver: true }),
+      ])
+    ).start();
+  }, [anim]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollToEnd({ animated: true });
+  }, [moveHistory]);
+
+  return (
+    <GradientBackground style={{ flex: 1 }}>
+      <Header showLogoOnly />
+      <ScreenContainer style={{ paddingTop: HEADER_SPACING }}>
+        {loading && (
+          <Animated.Text style={[styles.waiting, { opacity: anim }]}>Waiting for Players...</Animated.Text>
+        )}
+        <View style={styles.playerRow}>
+          {players.map((p) => (
+            <View key={p.id} style={styles.player}>
+              <Image
+                source={p.photo ? { uri: p.photo } : require('../assets/logo.png')}
+                style={styles.avatar}
+              />
+              <Text style={styles.playerName}>{p.displayName}</Text>
+            </View>
+          ))}
+        </View>
+        <View style={styles.logBox}>
+          <ScrollView ref={scrollRef}>
+            {moveHistory.map((m, idx) => (
+              <Text key={idx} style={styles.logText}>
+                Player {Number(m.player) + 1}: {m.action}
+              </Text>
+            ))}
+          </ScrollView>
+        </View>
+      </ScreenContainer>
+    </GradientBackground>
+  );
+}
+
+const getSpectatorStyles = (theme) =>
+  StyleSheet.create({
+    waiting: {
+      textAlign: 'center',
+      color: '#fff',
+      fontWeight: 'bold',
+      fontSize: 18,
+      marginBottom: 12,
+    },
+    playerRow: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      marginBottom: 12,
+    },
+    player: { alignItems: 'center', marginHorizontal: 8 },
+    avatar: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      marginBottom: 4,
+      borderWidth: 2,
+      borderColor: '#9146FF',
+    },
+    playerName: { color: theme.text, fontSize: 12 },
+    logBox: {
+      flex: 1,
+      borderWidth: 1,
+      borderColor: '#9146FF',
+      borderRadius: 8,
+      padding: 8,
+      backgroundColor: '#0007',
+    },
+    logText: { color: '#fff', fontSize: 14, marginBottom: 2 },
+  });
+
 const getBotStyles = (theme) =>
   StyleSheet.create({
   messageRow: {
@@ -693,6 +786,7 @@ GameSessionScreen.propTypes = {
       opponent: PropTypes.object,
       status: PropTypes.string,
       inviteId: PropTypes.string,
+      players: PropTypes.array,
     }),
   }).isRequired,
   sessionType: PropTypes.string,


### PR DESCRIPTION
## Summary
- enable `useGameSession` to expose `moveHistory`
- add `SpectatorSessionScreen` for spectator sessions
- support new `spectator` session type in `GameSessionScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863690cf2a4832d968047b42fb40728