### PR TITLE
Add active player glow

### DIFF
--- a/components/CountdownRing.js
+++ b/components/CountdownRing.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Svg, { Circle } from 'react-native-svg';
+
+export default function CountdownRing({ size = 48, strokeWidth = 4, progress = 0, color = '#ff8ab3', style }) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - Math.min(Math.max(progress, 0), 1));
+
+  return (
+    <Svg width={size} height={size} style={style}>
+      <Circle
+        stroke={color}
+        fill="none"
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeWidth={strokeWidth}
+        strokeDasharray={`${circumference}`}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+      />
+    </Svg>
+  );
+}
+
+CountdownRing.propTypes = {
+  size: PropTypes.number,
+  strokeWidth: PropTypes.number,
+  progress: PropTypes.number,
+  color: PropTypes.string,
+  style: PropTypes.any,
+};

--- a/components/SyncedGame.js
+++ b/components/SyncedGame.js
@@ -27,6 +27,8 @@ export default function SyncedGame({ sessionId, gameId, opponent, onGameEnd }) {
       icon={meta?.icon}
       player={{ photo: user?.photoURL, online: true }}
       opponent={{ photo: opponent?.photo, online: opponent?.online }}
+      playerName={user?.displayName || 'You'}
+      opponentName={opponent?.displayName || 'Opponent'}
       turn={ctx.currentPlayer}
     >
       <Board G={G} ctx={ctx} moves={moves} onGameEnd={onGameEnd} />


### PR DESCRIPTION
## Summary
- highlight the current player with a pulsing pink glow
- show player names in the game header
- include an optional countdown ring component

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68636beea4a4832dbe671d9c871939d8