### PR TITLE
Add reusable GameContainer wrapper for board games

### DIFF
--- a/components/GameContainer.js
+++ b/components/GameContainer.js
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef } from 'react';
+import { View, TouchableOpacity, StyleSheet, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import GradientBackground from './GradientBackground';
+import PlayerInfoBar from './PlayerInfoBar';
+import { useTheme } from '../contexts/ThemeContext';
+
+const AnimatedView = Animated.createAnimatedComponent(View);
+
+export default function GameContainer({
+  children,
+  player = {},
+  opponent = {},
+  onToggleChat,
+  visible = true,
+}) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  const anim = useRef(new Animated.Value(visible ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: visible ? 1 : 0,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [visible, anim]);
+
+  return (
+    <GradientBackground style={styles.container}>
+      <View style={styles.header}>
+        <PlayerInfoBar
+          name={player.name || 'You'}
+          xp={player.xp}
+          badges={player.badges}
+        />
+        {onToggleChat && (
+          <TouchableOpacity style={styles.chatToggle} onPress={onToggleChat}>
+            <Ionicons
+              name="chatbubble-ellipses-outline"
+              size={24}
+              color={theme.text}
+            />
+          </TouchableOpacity>
+        )}
+        <PlayerInfoBar
+          name={opponent.name || 'Opponent'}
+          xp={opponent.xp}
+          badges={opponent.badges}
+        />
+      </View>
+      <AnimatedView
+        style={[styles.boardSlot, { opacity: anim, transform: [{ scale: anim }] }]}
+      >
+        {children}
+      </AnimatedView>
+    </GradientBackground>
+  );
+}
+
+GameContainer.propTypes = {
+  children: PropTypes.node,
+  player: PropTypes.object,
+  opponent: PropTypes.object,
+  onToggleChat: PropTypes.func,
+  visible: PropTypes.bool,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { flex: 1 },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      marginTop: 10,
+    },
+    chatToggle: { paddingHorizontal: 8 },
+    boardSlot: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 16,
+    },
+  });

--- a/components/SyncedGame.js
+++ b/components/SyncedGame.js
@@ -4,7 +4,7 @@ import Loader from './Loader';
 import useGameSession from '../hooks/useGameSession';
 import { games } from '../games';
 import PropTypes from 'prop-types';
-import ArcadeGameWrapper from './ArcadeGameWrapper';
+import GameContainer from './GameContainer';
 import { useUser } from '../contexts/UserContext';
 
 export default function SyncedGame({ sessionId, gameId, opponent, onGameEnd }) {
@@ -22,17 +22,17 @@ export default function SyncedGame({ sessionId, gameId, opponent, onGameEnd }) {
   }
 
   return (
-    <ArcadeGameWrapper
-      title={meta?.title}
-      icon={meta?.icon}
-      player={{ photo: user?.photoURL, online: true }}
-      opponent={{ photo: opponent?.photo, online: opponent?.online }}
-      playerName={user?.displayName || 'You'}
-      opponentName={opponent?.displayName || 'Opponent'}
-      turn={ctx.currentPlayer}
+    <GameContainer
+      player={{
+        name: user?.displayName || 'You',
+        xp: user?.xp,
+      }}
+      opponent={{
+        name: opponent?.displayName || 'Opponent',
+      }}
     >
       <Board G={G} ctx={ctx} moves={moves} onGameEnd={onGameEnd} />
-    </ArcadeGameWrapper>
+    </GameContainer>
   );
 }
 

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -23,6 +23,7 @@ import Header from '../components/Header';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
 import ScreenContainer from '../components/ScreenContainer';
+import GameContainer from '../components/GameContainer';
 import { games, gameList } from '../games';
 import { icebreakers } from '../data/prompts';
 import firebase from '../firebase';
@@ -390,22 +391,11 @@ function PrivateChat({ user }) {
   const gameSection = SelectedGameClient
     ? showGame
       ? (
-          <View
-            style={{
-              flex: 1,
-              padding: 10,
-              borderBottomWidth: 1,
-              borderColor: darkMode ? '#444' : '#ccc',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
+          <GameContainer
+            onToggleChat={() => setShowGame(false)}
+            player={{ name: 'You' }}
+            opponent={{ name: user.displayName }}
           >
-            <TouchableOpacity
-              style={privateStyles.closeBtn}
-              onPress={() => setShowGame(false)}
-            >
-              <Text style={privateStyles.closeBtnText}>X</Text>
-            </TouchableOpacity>
             {devMode && (
               <View style={{ flexDirection: 'row', marginBottom: 8 }}>
                 <TouchableOpacity
@@ -438,7 +428,7 @@ function PrivateChat({ user }) {
               playerID={devMode ? devPlayer : '0'}
               onGameEnd={handleGameEnd}
             />
-          </View>
+          </GameContainer>
         )
       : (
           <TouchableOpacity

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -27,6 +27,7 @@ import getGlobalStyles from '../styles';
 import { games } from '../games';
 import SyncedGame from '../components/SyncedGame';
 import GameOverModal from '../components/GameOverModal';
+import GameContainer from '../components/GameContainer';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import { snapshotExists } from '../utils/firestore';
 import { createMatchIfMissing } from '../utils/matches';
@@ -260,7 +261,12 @@ const LiveSessionScreen = ({ route, navigation }) => {
                     <Text style={{ color: '#fff' }}>Player 2</Text>
                   </TouchableOpacity>
                 </View>
-                <GameComponent playerID={devPlayer} matchID="dev" />
+                <GameContainer
+                  player={{ name: 'You', xp: user?.xp }}
+                  opponent={{ name: 'Opponent' }}
+                >
+                  <GameComponent playerID={devPlayer} matchID="dev" />
+                </GameContainer>
               </>
             ) : (
               <SyncedGame
@@ -500,13 +506,11 @@ function BotSessionScreen({ route }) {
         <View style={{ flex: 1 }}>
           <View style={{ flex: 1 }}>
             {showBoard && !gameOver ? (
-              <>
-                <TouchableOpacity
-                  style={botStyles.closeBtn}
-                  onPress={() => setShowBoard(false)}
-                >
-                  <Text style={botStyles.closeBtnText}>X</Text>
-                </TouchableOpacity>
+              <GameContainer
+                onToggleChat={() => setShowBoard(false)}
+                player={{ name: 'You', xp: user?.xp }}
+                opponent={{ name: bot.name }}
+              >
                 <View style={botStyles.boardWrapper}>
                   <BoardComponent
                     G={G}
@@ -518,7 +522,7 @@ function BotSessionScreen({ route }) {
                 <TouchableOpacity style={botStyles.resetBtn} onPress={reset}>
                   <Text style={{ color: '#fff', fontWeight: 'bold' }}>Reset</Text>
                 </TouchableOpacity>
-              </>
+              </GameContainer>
             ) : !gameOver ? (
               <TouchableOpacity
                 style={botStyles.showBtn}


### PR DESCRIPTION
## Summary
- create `GameContainer` with gradient background, player headers and chat toggle
- wrap live sync game client with new component
- use the wrapper in dev mode and bot sessions
- integrate wrapper in chat game view

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68636dd38a18832d98c319179b10f48c