### PR TITLE
Implement animated transitions

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -13,27 +13,45 @@ import PremiumScreen from '../screens/PremiumScreen';
 import StatsScreen from '../screens/StatsScreen';
 import PlayScreen from '../screens/PlayScreen';
 import ActiveGamesScreen from '../screens/ActiveGamesScreen';
+import SwipeScreen from '../screens/SwipeScreen';
 
 const Stack = createNativeStackNavigator();
 
 export default function AppStack() {
   return (
     <Stack.Navigator
-      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+        animationDuration: 200,
+      }}
     >
       <Stack.Screen name="Main" component={MainTabs} />
       <Stack.Screen name="Profile" component={ProfileScreen} />
       <Stack.Screen name="Chat" component={ChatScreen} />
       <Stack.Screen name="Notifications" component={NotificationsScreen} />
       <Stack.Screen name="GameInvite" component={GameInviteScreen} />
-      <Stack.Screen name="GameSession" component={GameSessionScreen} />
+      <Stack.Screen
+        name="GameSession"
+        component={GameSessionScreen}
+        options={{ animation: 'fade_from_bottom' }}
+      />
       <Stack.Screen name="Community" component={CommunityScreen} />
       <Stack.Screen name="EventChat" component={ChatScreen} />
       <Stack.Screen name="ActiveGames" component={ActiveGamesScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
       <Stack.Screen name="Stats" component={StatsScreen} />
-      <Stack.Screen name="GameWithBot" component={GameWithBotScreen} />
+      <Stack.Screen
+        name="GameWithBot"
+        component={GameWithBotScreen}
+        options={{ animation: 'fade_from_bottom' }}
+      />
       <Stack.Screen name="Play" component={PlayScreen} />
+      <Stack.Screen
+        name="Swipe"
+        component={SwipeScreen}
+        options={{ animation: 'slide_from_bottom' }}
+      />
       </Stack.Navigator>
   );
 }

--- a/navigation/AuthStack.js
+++ b/navigation/AuthStack.js
@@ -9,7 +9,11 @@ const Stack = createNativeStackNavigator();
 export default function AuthStack() {
   return (
     <Stack.Navigator
-      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+        animationDuration: 200,
+      }}
     >
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen

--- a/navigation/OnboardingStack.js
+++ b/navigation/OnboardingStack.js
@@ -8,7 +8,11 @@ const Stack = createNativeStackNavigator();
 export default function OnboardingStack() {
   return (
     <Stack.Navigator
-      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+        animationDuration: 200,
+      }}
     >
       <Stack.Screen name="Onboarding" component={OnboardingScreen} />
     </Stack.Navigator>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "expo-device": "~7.1.4",
     "expo-haptics": "~14.1.4",
     "expo-updates": "~0.28.15",
-    "expo-blur": "~12.5.0"
+    "expo-blur": "~12.5.0",
+    "@react-navigation/stack": "^7.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -169,7 +169,7 @@ const HomeScreen = ({ navigation }) => {
         <View style={local.swipeButtonContainer}>
           <GradientButton
             text="Swipe Now"
-            onPress={() => navigation.navigate('Explore')}
+            onPress={() => navigation.navigate('Swipe')}
           />
         </View>
 

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -30,6 +30,7 @@ import { useChats } from '../contexts/ChatContext';
 import firebase from '../firebase';
 import { useNavigation } from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
+import { BlurView } from 'expo-blur';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { imageSource } from '../utils/avatar';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
@@ -562,7 +563,7 @@ const handleSwipe = async (direction) => {
 
         {matchedUser && (
           <Modal visible={showFireworks} transparent animationType="fade">
-            <View style={styles.fireworksOverlay}>
+            <BlurView intensity={50} tint="dark" style={styles.fireworksOverlay}>
               <LottieView
                 source={require('../assets/confetti.json')}
                 autoPlay
@@ -576,7 +577,7 @@ const handleSwipe = async (direction) => {
               {matchGame ? (
                 <Text style={styles.suggestText}>{`Or invite them to play ${matchGame.title}`}</Text>
               ) : null}
-            </View>
+            </BlurView>
           </Modal>
         )}
       </ScreenContainer>


### PR DESCRIPTION
## Summary
- add React Navigation stack dependency
- slide up to Swipe screen and fade/zoom game screens
- tweak auth and onboarding transitions
- blur match fireworks overlay
- open Swipe screen via dedicated transition button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68636e065be4832dab11b6994cccb760