### PR TITLE
Add animated avatar rings with status

### DIFF
--- a/components/ArcadeGameWrapper.js
+++ b/components/ArcadeGameWrapper.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
-import { View, StyleSheet, Text, Image, Animated, Easing } from 'react-native';
+import { View, StyleSheet, Text, Animated, Easing } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
-import { avatarSource } from '../utils/avatar';
+import AvatarRing from './AvatarRing';
 import CountdownRing from './CountdownRing';
 
 export default function ArcadeGameWrapper({
@@ -75,7 +75,12 @@ export default function ArcadeGameWrapper({
       <View style={styles.playersRow}>
         <View style={styles.playerBox}>
           <View style={styles.avatarWrapper}>
-            <Image source={avatarSource(player?.photo)} style={styles.avatar} />
+            <AvatarRing
+              source={player?.photo}
+              size={40}
+              isOnline={player?.online}
+              isPremium={player?.isPremium}
+            />
             {turn === '0' && (
               <Animated.View
                 pointerEvents="none"
@@ -91,9 +96,6 @@ export default function ArcadeGameWrapper({
                 style={styles.countdownRing}
               />
             )}
-            <View
-              style={[styles.dot, { backgroundColor: player?.online ? '#2ecc71' : '#999' }]}
-            />
           </View>
           <Animated.Text
             style={[
@@ -114,7 +116,12 @@ export default function ArcadeGameWrapper({
         </Animated.Text>
         <View style={styles.playerBox}>
           <View style={styles.avatarWrapper}>
-            <Image source={avatarSource(opponent?.photo)} style={styles.avatar} />
+            <AvatarRing
+              source={opponent?.photo}
+              size={40}
+              isOnline={opponent?.online}
+              isPremium={opponent?.isPremium}
+            />
             {turn === '1' && (
               <Animated.View
                 pointerEvents="none"
@@ -130,9 +137,6 @@ export default function ArcadeGameWrapper({
                 style={styles.countdownRing}
               />
             )}
-            <View
-              style={[styles.dot, { backgroundColor: opponent?.online ? '#2ecc71' : '#999' }]}
-            />
           </View>
           <Animated.Text
             style={[
@@ -191,16 +195,6 @@ const getStyles = (theme) =>
       position: 'absolute',
       top: -6,
       left: -6,
-    },
-    dot: {
-      width: 10,
-      height: 10,
-      borderRadius: 5,
-      position: 'absolute',
-      bottom: 2,
-      right: 2,
-      borderWidth: 1,
-      borderColor: '#fff',
     },
     nameText: { fontWeight: '600', marginTop: 4, fontSize: 12 },
     turnText: { fontWeight: 'bold' },

--- a/components/AvatarRing.js
+++ b/components/AvatarRing.js
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Image, StyleSheet, Animated, Easing } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import PropTypes from 'prop-types';
+import { avatarSource } from '../utils/avatar';
+
+export default function AvatarRing({
+  source,
+  size = 40,
+  isMatch = false,
+  isOnline = false,
+  isPremium = false,
+}) {
+  const shimmer = useRef(new Animated.Value(0)).current;
+  const pulse = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (isPremium) {
+      const loop = Animated.loop(
+        Animated.timing(shimmer, {
+          toValue: 1,
+          duration: 1500,
+          useNativeDriver: true,
+        })
+      );
+      loop.start();
+      return () => loop.stop();
+    }
+  }, [isPremium, shimmer]);
+
+  useEffect(() => {
+    if (isOnline) {
+      const loop = Animated.loop(
+        Animated.sequence([
+          Animated.timing(pulse, {
+            toValue: 1.4,
+            duration: 500,
+            easing: Easing.ease,
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulse, {
+            toValue: 1,
+            duration: 500,
+            easing: Easing.ease,
+            useNativeDriver: true,
+          }),
+        ])
+      );
+      loop.start();
+      return () => loop.stop();
+    }
+  }, [isOnline, pulse]);
+
+  const shimmerTranslate = shimmer.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['-100%', '100%'],
+  });
+
+  const ringSize = size + 6;
+
+  return (
+    <View style={{ width: ringSize, height: ringSize }}>
+      {isPremium ? (
+        <View style={[styles.premiumRing, { width: ringSize, height: ringSize, borderRadius: ringSize / 2 }]}> 
+          <Animated.View
+            style={[StyleSheet.absoluteFill, { transform: [{ translateX: shimmerTranslate }] }]}
+          >
+            <LinearGradient
+              colors={['#ffd700', '#fff', '#ffd700']}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={StyleSheet.absoluteFill}
+            />
+          </Animated.View>
+        </View>
+      ) : isMatch ? (
+        <LinearGradient
+          colors={[ '#ff0080', '#ff8c00' ]}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: ringSize,
+            height: ringSize,
+            borderRadius: ringSize / 2,
+          }}
+        />
+      ) : null}
+      <View style={{
+        position: 'absolute',
+        top: 3,
+        left: 3,
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        overflow: 'hidden',
+      }}>
+        <Image source={avatarSource(source)} style={{ width: size, height: size }} />
+      </View>
+      {isOnline && (
+        <Animated.View
+          style={{
+            position: 'absolute',
+            bottom: 2,
+            right: 2,
+            width: 10,
+            height: 10,
+            borderRadius: 5,
+            backgroundColor: '#2ecc71',
+            borderWidth: 1,
+            borderColor: '#fff',
+            transform: [{ scale: pulse }],
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+AvatarRing.propTypes = {
+  source: PropTypes.any,
+  size: PropTypes.number,
+  isMatch: PropTypes.bool,
+  isOnline: PropTypes.bool,
+  isPremium: PropTypes.bool,
+};
+
+const styles = StyleSheet.create({
+  premiumRing: {
+    overflow: 'hidden',
+  },
+});

--- a/components/GameOverModal.js
+++ b/components/GameOverModal.js
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
-import { Modal, View, Text, Image, Pressable, StyleSheet } from 'react-native';
+import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
 import LottieView from 'lottie-react-native';
 import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
-import { avatarSource } from '../utils/avatar';
+import AvatarRing from './AvatarRing';
 import useWinLossStats from '../hooks/useWinLossStats';
 
 export default function GameOverModal({
@@ -38,7 +38,7 @@ export default function GameOverModal({
         </View>
         <BlurView intensity={80} tint="dark" style={styles.card}>
           {winnerAvatar && (
-            <Image source={avatarSource(winnerAvatar)} style={styles.avatar} />
+            <AvatarRing source={winnerAvatar} size={80} />
           )}
           <Text style={styles.title}>
             {winnerName ? `${winnerName} wins!` : 'Draw'}
@@ -97,12 +97,6 @@ const styles = StyleSheet.create({
     width: 280,
     alignItems: 'center',
     overflow: 'hidden',
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    marginBottom: 10,
   },
   title: {
     fontSize: 22,

--- a/components/SyncedGame.js
+++ b/components/SyncedGame.js
@@ -25,8 +25,8 @@ export default function SyncedGame({ sessionId, gameId, opponent, onGameEnd }) {
     <ArcadeGameWrapper
       title={meta?.title}
       icon={meta?.icon}
-      player={{ photo: user?.photoURL, online: true }}
-      opponent={{ photo: opponent?.photo, online: opponent?.online }}
+      player={{ photo: user?.photoURL, online: true, isPremium: user?.isPremium }}
+      opponent={{ photo: opponent?.photo, online: opponent?.online, isPremium: opponent?.isPremium }}
       playerName={user?.displayName || 'You'}
       opponentName={opponent?.displayName || 'Opponent'}
       turn={ctx.currentPlayer}

--- a/components/stats/ProfileCard.js
+++ b/components/stats/ProfileCard.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { View, Text, Image } from 'react-native';
+import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
-import { avatarSource } from '../../utils/avatar';
+import AvatarRing from '../AvatarRing';
 
 const ProfileCard = ({ user, isPremium, styles, accent }) => (
   <View style={styles.profileCard}>
-    <Image source={avatarSource(user?.photoURL)} style={styles.avatar} />
+    <AvatarRing source={user?.photoURL} size={90} isPremium={isPremium} />
     <Text style={styles.name}>{user?.displayName || 'User'}</Text>
     {isPremium && (
       <Text style={[styles.premiumBadge, { backgroundColor: accent }]}>★ Premium</Text>
@@ -21,3 +21,4 @@ ProfileCard.propTypes = {
 };
 
 export default ProfileCard;
+

--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -100,6 +100,7 @@ export const ChatProvider = ({ children }) => {
             age: prevMatch.age || 0,
             image: prevMatch.image || require('../assets/user1.jpg'),
             online: prevMatch.online || false,
+            isPremium: prevMatch.isPremium || false,
             messages: prevMatch.messages || [],
             matchedAt: m.createdAt
               ? m.createdAt.toDate?.().toISOString()
@@ -140,12 +141,13 @@ export const ChatProvider = ({ children }) => {
                   m.otherUserId === uid
                     ? {
                         ...m,
-            displayName: info.displayName || 'User',
+                        displayName: info.displayName || 'User',
                         age: info.age || 0,
                         image: info.photoURL
                           ? { uri: info.photoURL }
                           : require('../assets/user1.jpg'),
                         online: !!info.online,
+                        isPremium: !!info.isPremium,
                       }
                     : m
                 )
@@ -301,6 +303,7 @@ export const ChatProvider = ({ children }) => {
             age: prevMatch.age || 0,
             image: prevMatch.image || require('../assets/user1.jpg'),
             online: prevMatch.online || false,
+            isPremium: prevMatch.isPremium || false,
             messages: prevMatch.messages || [],
             matchedAt: m.createdAt
               ? m.createdAt.toDate?.().toISOString()

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -11,7 +11,6 @@ import {
   Platform,
   KeyboardAvoidingView,
   Keyboard,
-  Image,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import GradientBackground from '../components/GradientBackground';
@@ -19,6 +18,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import PropTypes from 'prop-types';
 import { avatarSource } from '../utils/avatar';
+import AvatarRing from '../components/AvatarRing';
 import Header from '../components/Header';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
@@ -338,7 +338,12 @@ function PrivateChat({ user }) {
         style={[privateStyles.messageRow, isUser ? privateStyles.rowRight : privateStyles.rowLeft]}
       >
         {!isUser && user.image && (
-          <Image source={avatarSource(user.image)} style={privateStyles.avatar} />
+          <AvatarRing
+            source={user.image}
+            size={40}
+            isOnline={user.online}
+            isPremium={user.isPremium}
+          />
         )}
         <View
           style={[privateStyles.message, isUser ? privateStyles.right : privateStyles.left]}

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -4,7 +4,6 @@ import {
   Text,
   FlatList,
   TouchableOpacity,
-  Image,
   StyleSheet,
   RefreshControl,
 } from 'react-native';
@@ -17,6 +16,7 @@ import { useChats } from '../contexts/ChatContext';
 import PropTypes from 'prop-types';
 import { HEADER_SPACING } from '../layout';
 import EmptyState from '../components/EmptyState';
+import AvatarRing from '../components/AvatarRing';
 
 const SKELETON_NEW_COUNT = 5;
 const SKELETON_CHAT_COUNT = 5;
@@ -92,7 +92,13 @@ const MatchesScreen = ({ navigation }) => {
       style={styles.newMatch}
       onPress={() => navigation.navigate('Chat', { user: item })}
     >
-      <Image source={item.image} style={styles.newAvatar} />
+      <AvatarRing
+        source={item.image}
+        size={64}
+        isOnline={item.online}
+        isPremium={item.isPremium}
+        isMatch
+      />
       <Text style={[styles.newName, { color: theme.text }]} numberOfLines={1}>
         {item.displayName}
       </Text>
@@ -105,7 +111,12 @@ const MatchesScreen = ({ navigation }) => {
       style={[styles.chatItem, { backgroundColor: theme.card }]}
     >
       <View style={styles.avatarColumn}>
-        <Image source={item.image} style={styles.chatAvatar} />
+        <AvatarRing
+          source={item.image}
+          size={48}
+          isOnline={item.online}
+          isPremium={item.isPremium}
+        />
         <Text
           style={[styles.avatarName, { color: theme.text }]}
           numberOfLines={1}


### PR DESCRIPTION
## Summary
- add AvatarRing component supporting match gradient, online pulse, and premium shimmer
- track premium status in `ChatContext`
- update `ProfileCard`, `ArcadeGameWrapper`, match lists, chat bubbles, and winner modal to use new AvatarRing
- pass premium flags through game components

## Testing
- `node --check components/AvatarRing.js`
- `node --check components/ArcadeGameWrapper.js`
- `node --check components/GameOverModal.js`
- `node --check components/SyncedGame.js`
- `node --check screens/MatchesScreen.js`
- `node --check screens/ChatScreen.js`
- `node --check components/stats/ProfileCard.js`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68636e24ea6c832db473b0dcfbc9d055