### PR TITLE
Add SoundContext placeholders

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -6,6 +6,7 @@ import firebase from '../firebase';
 import { useListeners } from './ListenerContext';
 import Toast from 'react-native-toast-message';
 import * as Haptics from 'expo-haptics';
+import { useSound } from './SoundContext';
 
 const ChatContext = createContext();
 
@@ -17,6 +18,7 @@ export const ChatProvider = ({ children }) => {
   const { devMode } = useDev();
   const { user } = useUser();
   const { getMessages } = useListeners();
+  const { play } = useSound();
   const devMatch = {
     id: '__testMatch',
     displayName: 'Dev Tester',
@@ -198,6 +200,7 @@ export const ChatProvider = ({ children }) => {
         });
       if (sender === 'you') {
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+        play('message');
         Toast.show({ type: 'success', text1: 'Message sent' });
       }
     } catch (e) {

--- a/contexts/Providers.js
+++ b/contexts/Providers.js
@@ -12,31 +12,34 @@ import { ChatProvider } from './ChatContext';
 import { MatchmakingProvider } from './MatchmakingContext';
 import { GameSessionProvider } from './GameSessionContext';
 import { TrendingProvider } from './TrendingContext';
+import { SoundProvider } from './SoundContext';
 
 const Providers = ({ children }) => (
   <DevProvider>
     <ThemeProvider>
-      <AuthProvider>
-        <PresenceProvider>
-          <NotificationProvider>
-            <OnboardingProvider>
-            <UserProvider>
-              <ListenerProvider>
-                <GameLimitProvider>
-                  <ChatProvider>
-                    <MatchmakingProvider>
-                      <TrendingProvider>
-                        <GameSessionProvider>{children}</GameSessionProvider>
-                      </TrendingProvider>
-                    </MatchmakingProvider>
-                  </ChatProvider>
-                </GameLimitProvider>
-              </ListenerProvider>
-            </UserProvider>
-          </OnboardingProvider>
-        </NotificationProvider>
-        </PresenceProvider>
-      </AuthProvider>
+      <SoundProvider>
+        <AuthProvider>
+          <PresenceProvider>
+            <NotificationProvider>
+              <OnboardingProvider>
+                <UserProvider>
+                  <ListenerProvider>
+                    <GameLimitProvider>
+                      <ChatProvider>
+                        <MatchmakingProvider>
+                          <TrendingProvider>
+                            <GameSessionProvider>{children}</GameSessionProvider>
+                          </TrendingProvider>
+                        </MatchmakingProvider>
+                      </ChatProvider>
+                    </GameLimitProvider>
+                  </ListenerProvider>
+                </UserProvider>
+              </OnboardingProvider>
+            </NotificationProvider>
+          </PresenceProvider>
+        </AuthProvider>
+      </SoundProvider>
     </ThemeProvider>
   </DevProvider>
 );

--- a/contexts/SoundContext.js
+++ b/contexts/SoundContext.js
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useRef, useEffect } from 'react';
+import { Audio } from 'expo-av';
+
+const SoundContext = createContext();
+
+export const SoundProvider = ({ children }) => {
+  const soundsRef = useRef({});
+
+  const loadSound = async (key) => {
+    // TODO: load actual audio file for the given key, e.g.
+    // const { sound } = await Audio.Sound.createAsync(require(`../assets/${key}.mp3`));
+    // return sound;
+    return null;
+  };
+
+  const play = async (key) => {
+    if (!key) return;
+    try {
+      let sound = soundsRef.current[key];
+      if (!sound) {
+        sound = await loadSound(key);
+        if (sound) soundsRef.current[key] = sound;
+      }
+      await sound?.replayAsync();
+    } catch (e) {
+      console.warn('Failed to play sound', key, e);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      Object.values(soundsRef.current).forEach((s) => s?.unloadAsync());
+    };
+  }, []);
+
+  return (
+    <SoundContext.Provider value={{ play }}>
+      {children}
+    </SoundContext.Provider>
+  );
+};
+
+export const useSound = () => useContext(SoundContext);
+
+export default SoundContext;

--- a/hooks/useBotGame.js
+++ b/hooks/useBotGame.js
@@ -1,9 +1,11 @@
 import { useMemo, useEffect, useState, useRef } from 'react';
 import { Client } from 'boardgame.io/client';
+import { useSound } from '../contexts/SoundContext';
 
 export default function useBotGame(game, getBotMove, onGameEnd) {
   const getBotMoveRef = useRef(getBotMove);
   const onGameEndRef = useRef(onGameEnd);
+  const { play } = useSound();
 
   // Keep latest callbacks without re-creating the client
   useEffect(() => {
@@ -40,5 +42,16 @@ export default function useBotGame(game, getBotMove, onGameEnd) {
     return () => unsub();
   }, [client]);
 
-  return { G: state.G, ctx: state.ctx, moves: client.moves, reset: client.reset };
+  const moves = useMemo(() => {
+    const obj = {};
+    for (const name of Object.keys(client.moves)) {
+      obj[name] = (...args) => {
+        client.moves[name](...args);
+        play('game_move');
+      };
+    }
+    return obj;
+  }, [client, play]);
+
+  return { G: state.G, ctx: state.ctx, moves, reset: client.reset };
 }

--- a/hooks/useGameSession.js
+++ b/hooks/useGameSession.js
@@ -3,10 +3,12 @@ import { INVALID_MOVE } from 'boardgame.io/core';
 import firebase from '../firebase';
 import { games } from '../games';
 import { useUser } from '../contexts/UserContext';
+import { useSound } from '../contexts/SoundContext';
 import { snapshotExists } from '../utils/firestore';
 
 export default function useGameSession(sessionId, gameId, opponentId) {
   const { user } = useUser();
+  const { play } = useSound();
   const gameEntry = games[gameId];
   const Game = gameEntry?.Game;
 
@@ -76,6 +78,7 @@ export default function useGameSession(sessionId, gameId, opponentId) {
         updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
         moves: firebase.firestore.FieldValue.arrayUnion({ action: moveName, player: String(idx), at: firebase.firestore.FieldValue.serverTimestamp() }),
       });
+    play('game_move');
   }, [session, Game, sessionId, user?.uid]);
 
   const moves = {};

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -38,6 +38,7 @@ import useBotGame from "../hooks/useBotGame";
 import { getBotMove } from "../ai/botMoves";
 import SafeKeyboardView from "../components/SafeKeyboardView";
 import Loader from "../components/Loader";
+import { useSound } from '../contexts/SoundContext';
 import EmptyState from '../components/EmptyState';
 import useGameSession from '../hooks/useGameSession';
 import { logGameStats } from '../utils/gameStats';
@@ -340,6 +341,7 @@ function BotSessionScreen({ route }) {
   const { theme } = useTheme();
   const botStyles = getBotStyles(theme);
   const { user } = useUser();
+  const { play } = useSound();
   const [game, setGame] = useState(initialGame);
 
   const aiKeyMap = { rockPaperScissors: 'rps' };
@@ -406,6 +408,7 @@ function BotSessionScreen({ route }) {
     sendMessage(t);
     setText('');
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    play('message');
   };
 
   const playAgain = () => {

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -38,6 +38,7 @@ import PropTypes from 'prop-types';
 import * as Haptics from 'expo-haptics';
 import SkeletonUserCard from '../components/SkeletonUserCard';
 import EmptyState from '../components/EmptyState';
+import { useSound } from '../contexts/SoundContext';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -85,6 +86,7 @@ const SwipeScreen = () => {
   const navigation = useNavigation();
   const { showNotification } = useNotification();
   const { user: currentUser } = useUser();
+  const { play } = useSound();
   const { devMode } = useDev();
   const { addMatch } = useChats();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
@@ -202,6 +204,7 @@ const handleSwipe = async (direction) => {
 
   // Provide light haptic feedback on every swipe
   Haptics.selectionAsync().catch(() => {});
+  play(direction === 'left' ? 'swipe_left' : 'swipe_right');
 
     if (direction === 'right') {
       if (likesUsed >= MAX_LIKES && !isPremiumUser && !devMode) {
@@ -261,7 +264,7 @@ const handleSwipe = async (direction) => {
             Haptics.notificationAsync(
               Haptics.NotificationFeedbackType.Success
             ).catch(() => {});
-            // Placeholder: play short match sound here
+            play('match');
             Toast.show({ type: 'success', text1: "It's a match!" });
             setShowFireworks(true);
             setTimeout(() => setShowFireworks(false), 2000);
@@ -290,7 +293,7 @@ const handleSwipe = async (direction) => {
         Haptics.notificationAsync(
           Haptics.NotificationFeedbackType.Success
         ).catch(() => {});
-        // Placeholder: play short match sound here
+        play('match');
         Toast.show({ type: 'success', text1: "It's a match!" });
         setShowFireworks(true);
         setTimeout(() => setShowFireworks(false), 2000);


### PR DESCRIPTION
## Summary
- create `SoundContext` to manage sound keys
- wire `SoundProvider` into the app providers
- trigger sound playback on swipes, matches, messages and game moves
- wrap board game hooks with sound logic

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686372ea1d90832d8b183e5f2f34861b