### PR TITLE
Add margin to game wrapper

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -612,6 +612,7 @@ const getPrivateStyles = (theme) =>
   gameWrapper: {
     flex: 1,
     overflow: 'hidden',
+    marginBottom: 20,
   },
   chatWrapper: {
     flex: 1,


### PR DESCRIPTION
## Summary
- add marginBottom in PrivateChat gameWrapper to prevent game board being hidden

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa4f53fc832dad4e589b6d531639