### PR TITLE
Add premium priority sorting

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -17,6 +17,8 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `createdAt` (timestamp)
 - `isPremium` (boolean)
 - `premiumUpdatedAt` (timestamp)
+- `priorityScore` (number) – higher values surface the user more often
+- `boostUntil` (timestamp|null) – temporary boost end time
 - `xp` (number)
 - `streak` (number)
 - `lastActiveAt` (timestamp) – last login or game completion

--- a/docs/premium-priority.md
+++ b/docs/premium-priority.md
@@ -1,0 +1,9 @@
+# Premium User Priority
+
+Swipe matching uses a priority system to surface premium and boosted users more frequently.
+Each `users` document may include:
+
+- `priorityScore` – numeric value that determines a user's default ranking.
+- `boostUntil` – optional timestamp. When set to a future time the user is given a large bonus so they appear first in swipe results.
+
+When retrieving profiles, the app sorts first by the computed priority and then by compatibility. Boosted users get an additional 1000 points during the boost period.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "deploy": "bash scripts/deploy.sh"
+    "deploy": "bash scripts/deploy.sh",
+    "test": "node tests/runTests.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -33,6 +33,7 @@ import LottieView from 'lottie-react-native';
 import { BlurView } from 'expo-blur';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { imageSource } from '../utils/avatar';
+import { computePriority } from '../utils/priority';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PropTypes from 'prop-types';
 import * as Haptics from 'expo-haptics';
@@ -193,6 +194,8 @@ const SwipeScreen = () => {
             gender: u.gender || '',
             genderPref: u.genderPref || '',
             location: u.location || '',
+            priorityScore: u.priorityScore || 0,
+            boostUntil: u.boostUntil || null,
             images,
           };
         });
@@ -213,12 +216,15 @@ const SwipeScreen = () => {
           );
         }
 
-        // Sort by compatibility score so higher matches appear first
-        formatted.sort(
-          (aUser, bUser) =>
+        // Sort by priority then compatibility so premium/boosted users surface first
+        formatted.sort((aUser, bUser) => {
+          const prioDiff = computePriority(bUser) - computePriority(aUser);
+          if (prioDiff !== 0) return prioDiff;
+          return (
             computeMatchPercent(currentUser, bUser) -
             computeMatchPercent(currentUser, aUser)
-        );
+          );
+        });
 
         setUsers(formatted);
       } catch (e) {

--- a/tests/priority.test.js
+++ b/tests/priority.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const { computePriority } = require('../utils/priority');
+
+describe('computePriority', () => {
+  it('uses priorityScore value', () => {
+    assert(computePriority({ priorityScore: 5 }) > computePriority({ priorityScore: 1 }));
+  });
+
+  it('boosted users rank highest', () => {
+    const now = Date.now();
+    const boosted = computePriority({ boostUntil: new Date(now + 1000) });
+    const regular = computePriority({ priorityScore: 100 });
+    assert(boosted > regular);
+  });
+});

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function runFile(file) {
+  const code = fs.readFileSync(file, 'utf-8');
+  const script = new vm.Script(code, { filename: file });
+  const context = {
+    require,
+    console,
+    __dirname: path.dirname(file),
+    __filename: file,
+    module,
+    exports,
+    describe: (name, fn) => { fn(); },
+    it: (msg, fn) => { fn(); },
+  };
+  script.runInNewContext(context);
+}
+
+const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.test.js'));
+files.forEach(f => runFile(path.join(__dirname, f)));
+console.log('All tests passed');

--- a/utils/priority.js
+++ b/utils/priority.js
@@ -1,0 +1,8 @@
+export function computePriority(user = {}) {
+  let score = user.priorityScore || 0;
+  if (user.boostUntil) {
+    const boostUntil = user.boostUntil.toDate?.() || new Date(user.boostUntil);
+    if (boostUntil > new Date()) score += 1000;
+  }
+  return score;
+}


### PR DESCRIPTION
## Summary
- rank swipe results using new priority values
- expose `priorityScore` and `boostUntil` on user docs
- document premium ranking
- add simple tests for the computePriority helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686404d3fedc832db159dd05cac71939