### PR TITLE
Add user badges system

### DIFF
--- a/components/PlayerInfoBar.js
+++ b/components/PlayerInfoBar.js
@@ -4,12 +4,8 @@ import { Ionicons } from '@expo/vector-icons';
 import ProgressBar from './ProgressBar';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
+import { BADGE_LIST, getBadgeMeta } from '../utils/badges';
 
-const BADGES = [
-  { id: 'firstWin', icon: 'trophy-outline', title: 'First Win', desc: 'Win your first game.' },
-  { id: 'perfectGame', icon: 'star-outline', title: 'Perfect Game', desc: 'Win without mistakes.' },
-  { id: 'dailyStreak', icon: 'flame-outline', title: 'Daily Streak', desc: 'Play 7 days in a row.' },
-];
 
 export default function PlayerInfoBar({ name, xp = 0, badges = [] }) {
   const { theme } = useTheme();
@@ -26,16 +22,17 @@ export default function PlayerInfoBar({ name, xp = 0, badges = [] }) {
       <Text style={{ fontSize: 12, color: theme.textSecondary }}>Level {level}</Text>
       <ProgressBar value={progress} max={100} color={theme.accent} />
       <View style={{ flexDirection: 'row', marginTop: 4 }}>
-        {BADGES.map((badge) => {
+        {BADGE_LIST.map((badge) => {
           const earned = badges.includes(badge.id);
+          const meta = getBadgeMeta(badge.id) || badge;
           return (
             <TouchableOpacity
               key={badge.id}
-              onPress={() => showInfo(badge)}
+              onPress={() => showInfo(meta)}
               style={{ marginHorizontal: 4, opacity: earned ? 1 : 0.3 }}
             >
               <Ionicons
-                name={badge.icon}
+                name={meta.icon}
                 size={20}
                 color={earned ? theme.accent : theme.textSecondary}
               />

--- a/components/stats/ProfileCard.js
+++ b/components/stats/ProfileCard.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import AvatarRing from '../AvatarRing';
+import { Ionicons } from '@expo/vector-icons';
+import { getBadgeMeta } from '../../utils/badges';
 import PropTypes from 'prop-types';
 
-const ProfileCard = ({ user, isPremium, styles, accent }) => (
+const ProfileCard = ({ user, isPremium, badges = [], styles, accent }) => (
   <View style={styles.profileCard}>
     <AvatarRing
       source={user?.photoURL}
@@ -15,6 +17,23 @@ const ProfileCard = ({ user, isPremium, styles, accent }) => (
     {isPremium && (
       <Text style={[styles.premiumBadge, { backgroundColor: accent }]}>★ Premium</Text>
     )}
+    {badges.length > 0 && (
+      <View style={{ flexDirection: 'row', marginTop: 6 }}>
+        {badges.map((b) => {
+          const meta = getBadgeMeta(b);
+          if (!meta) return null;
+          return (
+            <Ionicons
+              key={b}
+              name={meta.icon}
+              size={18}
+              color={accent}
+              style={{ marginHorizontal: 2 }}
+            />
+          );
+        })}
+      </View>
+    )}
   </View>
 );
 
@@ -23,6 +42,7 @@ ProfileCard.propTypes = {
   isPremium: PropTypes.bool,
   styles: PropTypes.object.isRequired,
   accent: PropTypes.string.isRequired,
+  badges: PropTypes.array,
 };
 
 export default ProfileCard;

--- a/data/badges.js
+++ b/data/badges.js
@@ -1,0 +1,33 @@
+export const BADGE_LIST = [
+  {
+    id: 'premiumMember',
+    icon: 'diamond-outline',
+    title: 'Premium Member',
+    desc: 'Subscribed to Pinged Premium.',
+    premium: true,
+  },
+  {
+    id: 'firstWin',
+    icon: 'trophy-outline',
+    title: 'First Win',
+    desc: 'Win your first game.',
+  },
+  {
+    id: 'perfectGame',
+    icon: 'star-outline',
+    title: 'Perfect Game',
+    desc: 'Win a match without mistakes.',
+  },
+  {
+    id: 'dailyStreak',
+    icon: 'flame-outline',
+    title: 'Daily Streak',
+    desc: 'Play 7 days in a row.',
+  },
+  {
+    id: 'socialButterfly',
+    icon: 'people-outline',
+    title: 'Social Butterfly',
+    desc: 'Join your first community event.',
+  },
+];

--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -27,6 +27,7 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `expoPushToken` (string)
 - `online` (boolean)
 - `lastOnline` (timestamp) – last presence update time
+- `badges` (array of string) – earned badge IDs
 
 ### Subcollections
 - **gameInvites** – invitations sent or received by the user. Each invite document mirrors the root `gameInvites` collection.
@@ -83,6 +84,12 @@ A copy of each invite is also stored under `users/{uid}/gameInvites/{inviteId}` 
 - `winner` (string|null) – uid of the winner or `null`
 - `moves` (array of map) – `{ action, player, at }`
 - `loggedAt` (timestamp)
+
+## Badges (`badges/{badgeId}`)
+- `name` (string)
+- `description` (string)
+- `icon` (string) – Ionicons icon name
+- `premium` (boolean) – if true, badge is exclusive to Premium members
 
 ## Chats
 Chat conversations occur inside match documents under the `messages` subcollection (see **Matches** above). Each event also has a chat stored at `events/{eventId}/messages` following the same message shape.

--- a/functions/index.js
+++ b/functions/index.js
@@ -74,6 +74,7 @@ exports.stripeWebhook = functions.https.onRequest(async (req, res) => {
         await admin.firestore().collection('users').doc(uid).update({
           isPremium: true,
           premiumUpdatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          badges: admin.firestore.FieldValue.arrayUnion('premiumMember'),
         });
       } catch (e) {
         console.error('Failed to update premium status', e);

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -97,10 +97,27 @@ const CommunityScreen = () => {
     : events.filter((e) => e.category === activeFilter);
   const displayEvents = filteredEvents.slice(0, 4);
 
-  const toggleJoin = (id) => {
+  const toggleJoin = async (id) => {
     const isJoined = joinedEvents.includes(id);
-    if (!isJoined && joinedEvents.length === 0) setFirstJoin(true);
-    setJoinedEvents(isJoined ? joinedEvents.filter(e => e !== id) : [...joinedEvents, id]);
+    if (!isJoined && joinedEvents.length === 0) {
+      setFirstJoin(true);
+      if (user?.uid && !(user.badges || []).includes('socialButterfly')) {
+        try {
+          await firebase
+            .firestore()
+            .collection('users')
+            .doc(user.uid)
+            .update({
+              badges: firebase.firestore.FieldValue.arrayUnion('socialButterfly'),
+            });
+        } catch (e) {
+          console.warn('Failed to award badge', e);
+        }
+      }
+    }
+    setJoinedEvents(
+      isJoined ? joinedEvents.filter((e) => e !== id) : [...joinedEvents, id]
+    );
     Alert.alert(
       isJoined ? 'RSVP Cancelled' : 'Event Joined',
       isJoined ? 'You left the event.' : 'You’re in! XP applied.'

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -46,14 +46,7 @@ import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import PlayerInfoBar from '../components/PlayerInfoBar';
 import useUserProfile from '../hooks/useUserProfile';
 import PropTypes from 'prop-types';
-
-const computeBadges = (xp = 0, streak = 0) => {
-  const res = [];
-  if (xp >= 10) res.push('firstWin');
-  if (xp >= 50) res.push('perfectGame');
-  if (streak >= 7) res.push('dailyStreak');
-  return res;
-};
+import { computeBadges } from '../utils/badges';
 const GameSessionScreen = ({ route, navigation, sessionType }) => {
   const type =
     sessionType || route.params?.sessionType ||
@@ -94,8 +87,18 @@ const LiveSessionScreen = ({ route, navigation }) => {
   const overlayOpacity = useRef(new Animated.Value(1)).current;
   const opponentProfile = useUserProfile(opponent?.id);
 
-  const userBadges = computeBadges(user?.xp, user?.streak);
-  const oppBadges = computeBadges(opponentProfile?.xp, opponentProfile?.streak);
+  const userBadges = computeBadges({
+    xp: user?.xp,
+    streak: user?.streak,
+    badges: user?.badges || [],
+    isPremium: user?.isPremium,
+  });
+  const oppBadges = computeBadges({
+    xp: opponentProfile?.xp,
+    streak: opponentProfile?.streak,
+    badges: opponentProfile?.badges || [],
+    isPremium: opponentProfile?.isPremium,
+  });
 
   // Listen for Firestore invite status
   useEffect(() => {
@@ -481,7 +484,16 @@ function BotSessionScreen({ route }) {
       <GradientBackground style={{ flex: 1 }}>
         <Header />
         <View style={{ flexDirection: 'row', paddingHorizontal: 16, marginTop: 10 }}>
-          <PlayerInfoBar name="You" xp={user?.xp || 0} badges={computeBadges(user?.xp, user?.streak)} />
+          <PlayerInfoBar
+            name="You"
+            xp={user?.xp || 0}
+            badges={computeBadges({
+              xp: user?.xp,
+              streak: user?.streak,
+              badges: user?.badges || [],
+              isPremium: user?.isPremium,
+            })}
+          />
           <PlayerInfoBar name={bot.name} xp={0} badges={[]} />
         </View>
         <KeyboardAvoidingView

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import GradientButton from '../components/GradientButton';
@@ -15,6 +16,7 @@ import ProfileCard from '../components/stats/ProfileCard';
 import StatBox from '../components/stats/StatBox';
 import ScreenContainer from '../components/ScreenContainer';
 import { CARD_STYLE } from '../components/Card';
+import { getBadgeMeta } from '../utils/badges';
 
 const StatsScreen = ({ navigation }) => {
   const { theme } = useTheme();
@@ -32,7 +34,7 @@ const StatsScreen = ({ navigation }) => {
     messagesSent: 0,
     xp: 0,
     streak: 0,
-    badge: '',
+    badges: [],
   });
 
   const [loading, setLoading] = useState(true);
@@ -90,7 +92,7 @@ const StatsScreen = ({ navigation }) => {
           messagesSent,
           xp: data.xp || 0,
           streak: data.streak || 0,
-          badge: '',
+          badges: data.badges || [],
         });
         setLoading(false);
       } catch (e) {
@@ -114,6 +116,7 @@ const StatsScreen = ({ navigation }) => {
         <ProfileCard
           user={user}
           isPremium={isPremium}
+          badges={stats.badges}
           styles={styles}
           accent={theme.accent}
         />
@@ -163,8 +166,22 @@ const StatsScreen = ({ navigation }) => {
           <Text style={styles.statSub}>{stats.streak} days</Text>
         </StatBox>
         <StatBox loading={loading} styles={styles}>
-          <Text style={styles.statLabel}>Badge</Text>
-          <Text style={styles.statValue}>{stats.badge}</Text>
+          <Text style={styles.statLabel}>Badges</Text>
+          <View style={{ flexDirection: 'row', marginTop: 4 }}>
+            {stats.badges.map((b) => {
+              const meta = getBadgeMeta(b);
+              if (!meta) return null;
+              return (
+                <Ionicons
+                  key={b}
+                  name={meta.icon}
+                  size={20}
+                  color={theme.accent}
+                  style={{ marginHorizontal: 4 }}
+                />
+              );
+            })}
+          </View>
         </StatBox>
 
         {!isPremium && (

--- a/utils/badges.js
+++ b/utils/badges.js
@@ -1,0 +1,23 @@
+import { BADGE_LIST } from '../data/badges';
+export { BADGE_LIST };
+
+export const BADGE_THRESHOLDS = {
+  firstWin: { xp: 10 },
+  perfectGame: { xp: 50 },
+  dailyStreak: { streak: 7 },
+};
+
+export function computeBadges({ xp = 0, streak = 0, badges = [], isPremium }) {
+  const unlocked = new Set(badges);
+  if (isPremium) unlocked.add('premiumMember');
+  Object.entries(BADGE_THRESHOLDS).forEach(([id, req]) => {
+    if ((req.xp && xp >= req.xp) || (req.streak && streak >= req.streak)) {
+      unlocked.add(id);
+    }
+  });
+  return Array.from(unlocked);
+}
+
+export function getBadgeMeta(id) {
+  return BADGE_LIST.find((b) => b.id === id);
+}


### PR DESCRIPTION
## Summary
- create badge metadata and utility helpers
- award premium badge on subscription and store badge IDs on users
- track unlocked badges when XP increases
- grant a community badge when joining the first event
- display badge icons on profile and stats screens
- document new `badges` collection in firestore schema

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864051e18b8832d8dfe685bcbd636a9