### PR TITLE
Add close button to ChatScreen game board

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -411,6 +411,15 @@ function PrivateChat({ user }) {
   let gameSection = null;
   if (SelectedGameClient) {
     gameSection = (
+      <View style={{ flex: 1 }}>
+        {gameVisible && (
+          <TouchableOpacity
+            style={privateStyles.closeGameButton}
+            onPress={() => setShowGame(false)}
+          >
+            <Ionicons name="close" size={20} color={theme.text} />
+          </TouchableOpacity>
+        )}
         <GameContainer
           visible={gameVisible}
           onToggleChat={() => setShowGame(false)}
@@ -450,6 +459,7 @@ function PrivateChat({ user }) {
             onGameEnd={handleGameEnd}
           />
         </GameContainer>
+      </View>
     );
   }
 
@@ -706,6 +716,13 @@ const getPrivateStyles = (theme) =>
     fontSize: 12,
     color: '#666',
     marginBottom: 4,
+  },
+  closeGameButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    padding: 4,
+    zIndex: 10,
   },
   chatSection: {
     flex: 1,


### PR DESCRIPTION
## Summary
- add overlay close button in the game board
- style the button with absolute positioning over the game container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864682faf58832dacd8994c807f7555