### PR TITLE
Style HomeScreen community board

### DIFF
--- a/components/EventFlyer.js
+++ b/components/EventFlyer.js
@@ -6,12 +6,18 @@ import { eventImageSource } from '../utils/avatar';
 import GradientButton from './GradientButton';
 import { CARD_STYLE } from './Card';
 
-const EventFlyer = ({ event, onJoin, joined }) => {
+const EventFlyer = ({ event, onJoin, joined, style }) => {
   const { darkMode, theme } = useTheme();
   const styles = getStyles(theme, darkMode);
 
   return (
-    <View style={[styles.container, { backgroundColor: darkMode ? '#333' : '#fff' }]}>
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: darkMode ? '#333' : '#fff' },
+        style,
+      ]}
+    >
       <Image source={eventImageSource(event.image)} style={styles.image} />
       <View style={styles.details}>
         <View style={styles.headerRow}>
@@ -36,6 +42,7 @@ EventFlyer.propTypes = {
   event: PropTypes.object.isRequired,
   onJoin: PropTypes.func,
   joined: PropTypes.bool,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 
 const getStyles = (theme, darkMode) =>

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -157,13 +157,21 @@ const HomeScreen = ({ navigation }) => {
 
           <View style={local.communityBoard}>
             <Text style={local.sectionTitle}>Community Board</Text>
-            {SAMPLE_EVENTS.slice(0, 3).map((ev) => (
-              <EventFlyer
-                key={ev.id}
-                event={ev}
-                onJoin={() => navigation.navigate('Community')}
-              />
-            ))}
+            <View style={local.boardBackground}>
+              {SAMPLE_EVENTS.slice(0, 3).map((ev, idx) => (
+                <View key={ev.id} style={local.noteWrapper}>
+                  <View style={local.pin} />
+                  <EventFlyer
+                    event={ev}
+                    onJoin={() => navigation.navigate('Community')}
+                    style={[
+                      local.noteCard,
+                      idx % 2 === 0 ? local.rotateLeft : local.rotateRight,
+                    ]}
+                  />
+                </View>
+              ))}
+            </View>
           </View>
         </ScrollView>
         <View style={local.swipeButtonContainer}>
@@ -371,6 +379,40 @@ const getStyles = (theme) =>
     communityBoard: {
       width: '100%',
       marginBottom: 24,
+    },
+    boardBackground: {
+      backgroundColor: '#f5deb3',
+      padding: 12,
+      borderRadius: 12,
+    },
+    noteWrapper: {
+      marginBottom: 24,
+      alignItems: 'center',
+    },
+    noteCard: {
+      backgroundColor: '#fffef8',
+      borderWidth: 1,
+      borderColor: '#e0d4b9',
+      shadowColor: '#000',
+      shadowOpacity: 0.2,
+      shadowOffset: { width: 0, height: 2 },
+      shadowRadius: 3,
+      elevation: 2,
+    },
+    rotateLeft: {
+      transform: [{ rotate: '-2deg' }],
+    },
+    rotateRight: {
+      transform: [{ rotate: '2deg' }],
+    },
+    pin: {
+      position: 'absolute',
+      top: -6,
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      backgroundColor: '#c0392b',
+      zIndex: 1,
     },
   });
 


### PR DESCRIPTION
## Summary
- add style prop support to `EventFlyer`
- redesign `HomeScreen` community board as a corkboard with pinned notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864683eae78832d8d7ee07a2cda22af