### PR TITLE
Fix chat layout, add dev profiles and corkboard style

### DIFF
--- a/components/GameContainer.js
+++ b/components/GameContainer.js
@@ -13,6 +13,7 @@ export default function GameContainer({
   player = {},
   opponent = {},
   onToggleChat,
+  onClose,
   visible = true,
 }) {
   const { theme } = useTheme();
@@ -44,6 +45,11 @@ export default function GameContainer({
             />
           </TouchableOpacity>
         )}
+        {onClose && (
+          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+            <Ionicons name="close" size={24} color={theme.text} />
+          </TouchableOpacity>
+        )}
         <PlayerInfoBar
           name={opponent.name || 'Opponent'}
           xp={opponent.xp}
@@ -64,6 +70,7 @@ GameContainer.propTypes = {
   player: PropTypes.object,
   opponent: PropTypes.object,
   onToggleChat: PropTypes.func,
+  onClose: PropTypes.func,
   visible: PropTypes.bool,
 };
 
@@ -78,6 +85,7 @@ const getStyles = (theme) =>
       marginTop: 10,
     },
     chatToggle: { paddingHorizontal: 8 },
+    closeBtn: { position: 'absolute', top: 4, right: 4, padding: 4 },
     boardSlot: {
       flex: 1,
       justifyContent: 'center',

--- a/components/SafeKeyboardView.js
+++ b/components/SafeKeyboardView.js
@@ -1,13 +1,14 @@
 import { KeyboardAvoidingView, Platform } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { HEADER_SPACING } from '../layout';
 
 export default function SafeKeyboardView({ children, style }) {
   return (
     <KeyboardAvoidingView
       style={style}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 60 : 0}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? HEADER_SPACING : 0}
     >
       {children}
     </KeyboardAvoidingView>

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -111,7 +111,7 @@ function PrivateChat({ user }) {
     const handleShow = (e) => {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
       setKeyboardOpen(true);
-      setKeyboardHeight(e.endCoordinates?.height || 0);
+      setKeyboardHeight((e.endCoordinates?.height || 0) - insets.bottom);
     };
 
     const handleHide = () => {
@@ -414,6 +414,7 @@ function PrivateChat({ user }) {
         <GameContainer
           visible={gameVisible}
           onToggleChat={() => setShowGame(false)}
+          onClose={() => setShowGame(false)}
           player={{ name: 'You' }}
           opponent={{ name: user.displayName }}
         >
@@ -513,12 +514,12 @@ function PrivateChat({ user }) {
     }
   };
 
-  const inputBarOffset = keyboardOpen ? keyboardHeight : 0;
+  const inputBarOffset = keyboardOpen ? keyboardHeight - insets.bottom : 0;
   const inputBar = (
       <View
         style={[
           privateStyles.inputBar,
-          { marginBottom: inputBarOffset, paddingBottom: insets.bottom },
+          { bottom: inputBarOffset, paddingBottom: insets.bottom },
         ]}
       >
         <TouchableOpacity
@@ -647,6 +648,10 @@ const getPrivateStyles = (theme) =>
     marginTop: 2,
   },
   inputBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 8,

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -157,12 +157,14 @@ const HomeScreen = ({ navigation }) => {
 
           <View style={local.communityBoard}>
             <Text style={local.sectionTitle}>Community Board</Text>
-            {SAMPLE_EVENTS.slice(0, 3).map((ev) => (
-              <EventFlyer
-                key={ev.id}
-                event={ev}
-                onJoin={() => navigation.navigate('Community')}
-              />
+            {SAMPLE_EVENTS.slice(0, 3).map((ev, i) => (
+              <View key={ev.id} style={local.note}>
+                <Text style={local.pin}>📌</Text>
+                <EventFlyer
+                  event={ev}
+                  onJoin={() => navigation.navigate('Community')}
+                />
+              </View>
             ))}
           </View>
         </ScrollView>
@@ -371,6 +373,27 @@ const getStyles = (theme) =>
     communityBoard: {
       width: '100%',
       marginBottom: 24,
+      backgroundColor: '#DEB887',
+      padding: 12,
+      borderRadius: 12,
+    },
+    note: {
+      backgroundColor: '#fff8dc',
+      borderRadius: 8,
+      padding: 8,
+      marginBottom: 12,
+      position: 'relative',
+      shadowColor: '#000',
+      shadowOpacity: 0.1,
+      shadowOffset: { width: 0, height: 2 },
+      shadowRadius: 4,
+      elevation: 3,
+    },
+    pin: {
+      position: 'absolute',
+      top: -10,
+      right: 16,
+      fontSize: 18,
     },
   });
 

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -175,9 +175,6 @@ const SwipeScreen = () => {
         }
         const snap = await userQuery.limit(50).get();
         let data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-        if (devMode) {
-          data = [...devUsers, ...data];
-        }
         let formatted = data.map((u) => {
           const imgs = Array.isArray(u.photos) && u.photos.length
             ? u.photos
@@ -225,6 +222,25 @@ const SwipeScreen = () => {
             computeMatchPercent(currentUser, aUser)
           );
         });
+
+        if (devMode) {
+          const extras = devUsers.map((u) => ({
+            id: u.id,
+            displayName: u.displayName,
+            age: u.age,
+            bio: u.bio,
+            favoriteGames: Array.isArray(u.favoriteGames) ? u.favoriteGames : [],
+            gender: u.gender || '',
+            genderPref: u.genderPref || '',
+            location: u.location || '',
+            priorityScore: 0,
+            boostUntil: null,
+            images: u.photos.map((img) =>
+              imageSource(img, require('../assets/user1.jpg'))
+            ),
+          }));
+          formatted = [...extras, ...formatted];
+        }
 
         setUsers(formatted);
       } catch (e) {


### PR DESCRIPTION
## Summary
- keep chat input pinned when keyboard toggles
- add close button to in-game view
- load dummy profiles in dev mode on Swipe screen
- restyle Home screen community board like a corkboard
- use consistent keyboard offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686468a4e5cc832d9e08b1b7729e52a1