### PR TITLE
Implement debounce for key actions

### DIFF
--- a/components/GameOverModal.js
+++ b/components/GameOverModal.js
@@ -13,6 +13,7 @@ export default function GameOverModal({
   winnerAvatar,
   winnerId,
   onRematch,
+  rematchDisabled,
   onExit,
 }) {
   const stats = useWinLossStats(winnerId);
@@ -49,7 +50,8 @@ export default function GameOverModal({
           <Pressable
             onPress={onRematch}
             android_ripple={{ color: '#fff' }}
-            style={styles.rematchBtn}
+            style={[styles.rematchBtn, rematchDisabled && { opacity: 0.6 }]}
+            disabled={rematchDisabled}
           >
             <Text style={styles.btnText}>Rematch</Text>
           </Pressable>
@@ -72,6 +74,7 @@ GameOverModal.propTypes = {
   winnerAvatar: PropTypes.any,
   winnerId: PropTypes.string,
   onRematch: PropTypes.func.isRequired,
+  rematchDisabled: PropTypes.bool,
   onExit: PropTypes.func.isRequired,
 };
 

--- a/components/InviteUserCard.js
+++ b/components/InviteUserCard.js
@@ -7,7 +7,16 @@ import Loader from './Loader';
 import useCardPressAnimation from '../hooks/useCardPressAnimation';
 import AvatarRing from './AvatarRing';
 
-const InviteUserCard = ({ item, onInvite, isInvited, isLoading, theme, darkMode, width }) => {
+const InviteUserCard = ({
+  item,
+  onInvite,
+  isInvited,
+  isLoading,
+  disabled,
+  theme,
+  darkMode,
+  width,
+}) => {
   const { scale, handlePressIn, handlePressOut, playSuccess } = useCardPressAnimation();
 
   const handlePress = () => onInvite(item, playSuccess);
@@ -53,6 +62,7 @@ const InviteUserCard = ({ item, onInvite, isInvited, isLoading, theme, darkMode,
               onPressIn={handlePressIn}
               onPressOut={handlePressOut}
               width={120}
+              disabled={disabled}
               style={{ marginTop: 6 }}
             />
           </Animated.View>
@@ -67,6 +77,7 @@ InviteUserCard.propTypes = {
   onInvite: PropTypes.func.isRequired,
   isInvited: PropTypes.bool,
   isLoading: PropTypes.bool,
+  disabled: PropTypes.bool,
   theme: PropTypes.object.isRequired,
   darkMode: PropTypes.bool,
   width: PropTypes.number.isRequired,

--- a/hooks/useDebouncedCallback.js
+++ b/hooks/useDebouncedCallback.js
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useDebouncedCallback(fn, delay = 500) {
+  const [waiting, setWaiting] = useState(false);
+  const timeoutRef = useRef(null);
+
+  const callback = useCallback(
+    async (...args) => {
+      if (waiting) return;
+      setWaiting(true);
+      try {
+        await fn(...args);
+      } finally {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => {
+          setWaiting(false);
+          timeoutRef.current = null;
+        }, delay);
+      }
+    },
+    [fn, delay, waiting]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return [callback, waiting];
+}

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -43,6 +43,7 @@ import useVoiceRecorder from '../hooks/useVoiceRecorder';
 // TODO: add support for sending short voice or video intro clips in chat
 import Toast from 'react-native-toast-message';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import useDebouncedCallback from '../hooks/useDebouncedCallback';
 import EmptyState from '../components/EmptyState';
 
 // Available emoji reactions for group chats
@@ -246,6 +247,8 @@ function PrivateChat({ user }) {
       updateTyping(false);
     }
   };
+
+  const [debouncedSend, sending] = useDebouncedCallback(handleSend, 800);
 
 
   const handleVoiceFinish = async () => {
@@ -540,7 +543,11 @@ function PrivateChat({ user }) {
           onChangeText={handleTextChange}
           placeholderTextColor="#888"
         />
-        <TouchableOpacity style={privateStyles.sendBtn} onPress={handleSend}>
+        <TouchableOpacity
+          style={[privateStyles.sendBtn, sending && { opacity: 0.6 }]}
+          onPress={debouncedSend}
+          disabled={sending}
+        >
           <Text style={{ color: '#fff', fontWeight: 'bold' }}>Send</Text>
         </TouchableOpacity>
         <TouchableOpacity
@@ -787,6 +794,8 @@ function GroupChat({ event }) {
     }
   };
 
+  const [debouncedSend, sending] = useDebouncedCallback(sendMessage, 800);
+
   const addReaction = async (msgId, emoji) => {
     try {
       await firebase
@@ -941,7 +950,11 @@ function GroupChat({ event }) {
             placeholderTextColor="#999"
             style={groupStyles.input}
           />
-          <TouchableOpacity onPress={sendMessage} style={groupStyles.sendBtn}>
+          <TouchableOpacity
+            onPress={debouncedSend}
+            disabled={sending}
+            style={[groupStyles.sendBtn, sending && { opacity: 0.6 }]}
+          >
             <Text style={{ color: '#fff', fontWeight: 'bold' }}>Send</Text>
           </TouchableOpacity>
         </View>

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -26,6 +26,7 @@ import Toast from 'react-native-toast-message';
 import { HEADER_SPACING } from '../layout';
 import EmptyState from '../components/EmptyState';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import useDebouncedCallback from '../hooks/useDebouncedCallback';
 import InviteUserCard from '../components/InviteUserCard';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -105,6 +106,8 @@ const GameInviteScreen = ({ route, navigation }) => {
     }
   };
 
+  const [debouncedInvite, inviting] = useDebouncedCallback(handleInvite, 800);
+
   const filtered = matches.filter((u) =>
     u.displayName.toLowerCase().includes(search.toLowerCase())
   );
@@ -121,9 +124,10 @@ const GameInviteScreen = ({ route, navigation }) => {
     return (
       <InviteUserCard
         item={item}
-        onInvite={handleInvite}
+        onInvite={debouncedInvite}
         isInvited={isInvited}
         isLoading={isLoading}
+        disabled={inviting}
         theme={theme}
         darkMode={darkMode}
         width={CARD_WIDTH}

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -43,6 +43,7 @@ import EmptyState from '../components/EmptyState';
 import useGameSession from '../hooks/useGameSession';
 import { logGameStats } from '../utils/gameStats';
 import useRequireGameCredits from '../hooks/useRequireGameCredits';
+import useDebouncedCallback from '../hooks/useDebouncedCallback';
 import PlayerInfoBar from '../components/PlayerInfoBar';
 import useUserProfile from '../hooks/useUserProfile';
 import PropTypes from 'prop-types';
@@ -211,6 +212,8 @@ const LiveSessionScreen = ({ route, navigation }) => {
     });
   };
 
+  const [debouncedRematch, rematchWaiting] = useDebouncedCallback(handleRematch, 800);
+
   if (!game || !opponent) {
     return (
       <GradientBackground style={globalStyles.swipeScreen}>
@@ -327,7 +330,8 @@ const LiveSessionScreen = ({ route, navigation }) => {
             ? opponent.id
             : null
         }
-        onRematch={handleRematch}
+        onRematch={debouncedRematch}
+        rematchDisabled={rematchWaiting}
         onExit={() => navigation.goBack()}
       />
     </GradientBackground>
@@ -413,6 +417,8 @@ function BotSessionScreen({ route }) {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
     play('message');
   };
+
+  const [debouncedSend, sending] = useDebouncedCallback(handleSend, 800);
 
   const playAgain = () => {
     reset();
@@ -580,7 +586,11 @@ function BotSessionScreen({ route }) {
                   value={text}
                   onChangeText={setText}
                 />
-                <TouchableOpacity style={botStyles.sendBtn} onPress={handleSend}>
+                <TouchableOpacity
+                  style={[botStyles.sendBtn, sending && { opacity: 0.6 }]}
+                  onPress={debouncedSend}
+                  disabled={sending}
+                >
                   <Text style={{ color: '#fff', fontWeight: 'bold' }}>Send</Text>
                 </TouchableOpacity>
               </View>


### PR DESCRIPTION
## Summary
- add new `useDebouncedCallback` hook
- debounce message send buttons
- debounce game invite actions
- disable rematch button while waiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864783ecdac832d8fa05c2a23209ba2