### PR TITLE
Add menu for active games

### DIFF
--- a/components/GameMenu.js
+++ b/components/GameMenu.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function GameMenu({
+  visible,
+  bottom = 0,
+  onCancel,
+  onChange,
+}) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  if (!visible) return null;
+  return (
+    <View style={[styles.menu, { bottom }]}>
+      <TouchableOpacity onPress={onCancel}>
+        <Text style={styles.item}>Cancel Game</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onChange}>
+        <Text style={styles.item}>Change Game</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+GameMenu.propTypes = {
+  visible: PropTypes.bool,
+  bottom: PropTypes.number,
+  onCancel: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    menu: {
+      position: 'absolute',
+      right: 20,
+      backgroundColor: '#009688',
+      borderRadius: 8,
+      padding: 8,
+    },
+    item: {
+      color: '#fff',
+      paddingVertical: 6,
+    },
+  });

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -25,6 +25,7 @@ import SafeKeyboardView from '../components/SafeKeyboardView';
 import Loader from '../components/Loader';
 import ScreenContainer from '../components/ScreenContainer';
 import GameContainer from '../components/GameContainer';
+import GameMenu from '../components/GameMenu';
 import ChatContainer from '../components/ChatContainer';
 import LottieView from 'lottie-react-native';
 import { BlurView } from 'expo-blur';
@@ -651,16 +652,12 @@ function PrivateChat({ user }) {
             )}
             {inputBar}
           </ChatContainer>
-          {showGameMenu && (
-            <View style={[privateStyles.gameMenu, { bottom: menuBottom }]}>
-              <TouchableOpacity onPress={handleCancelGame}>
-                <Text style={privateStyles.gameMenuItem}>Cancel Game</Text>
-              </TouchableOpacity>
-              <TouchableOpacity onPress={handleChangeGame}>
-                <Text style={privateStyles.gameMenuItem}>Change Game</Text>
-              </TouchableOpacity>
-            </View>
-          )}
+          <GameMenu
+            visible={showGameMenu}
+            bottom={menuBottom}
+            onCancel={handleCancelGame}
+            onChange={handleChangeGame}
+          />
         </SafeKeyboardView>
       </ScreenContainer>
     </GradientBackground>
@@ -725,6 +722,8 @@ const getPrivateStyles = (theme) =>
     left: 0,
     right: 0,
     backgroundColor: theme.background,
+    height: INPUT_BAR_HEIGHT,
+    justifyContent: 'center',
   },
   input: {
     flex: 1,


### PR DESCRIPTION
## Summary
- add `GameMenu` component with cancel and change options
- show menu in ChatScreen when there is an active game
- make input bar height explicit so menu placement avoids overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864e85159a0832dad4ca17f1a44d2fe