### PR TITLE
Persist local game state

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -11,8 +11,10 @@ import { useSound } from './SoundContext';
 const ChatContext = createContext();
 
 const STORAGE_PREFIX = 'chatMatches_';
+const GAME_STATE_PREFIX = 'gameState_';
 
 const getStorageKey = (uid) => `${STORAGE_PREFIX}${uid}`;
+const getGameStateKey = (matchId) => `${GAME_STATE_PREFIX}${matchId}`;
 
 export const ChatProvider = ({ children }) => {
   const { devMode } = useDev();
@@ -270,6 +272,35 @@ export const ChatProvider = ({ children }) => {
   const getActiveGame = (matchId) =>
     matches.find((m) => m.id === matchId)?.activeGameId || null;
 
+  const getSavedGameState = async (matchId) => {
+    try {
+      const val = await AsyncStorage.getItem(getGameStateKey(matchId));
+      return val ? JSON.parse(val) : null;
+    } catch (e) {
+      console.warn('Failed to load game state', e);
+      return null;
+    }
+  };
+
+  const saveGameState = async (matchId, state) => {
+    try {
+      await AsyncStorage.setItem(
+        getGameStateKey(matchId),
+        JSON.stringify(state)
+      );
+    } catch (e) {
+      console.warn('Failed to save game state', e);
+    }
+  };
+
+  const clearGameState = async (matchId) => {
+    try {
+      await AsyncStorage.removeItem(getGameStateKey(matchId));
+    } catch (e) {
+      console.warn('Failed to clear game state', e);
+    }
+  };
+
 
   const addMatch = (match) =>
     setMatches((prev) => {
@@ -331,6 +362,9 @@ export const ChatProvider = ({ children }) => {
         removeMatch,
         setActiveGame,
         getActiveGame,
+        getSavedGameState,
+        saveGameState,
+        clearGameState,
         startLocalGame,
         clearGameInvite,
         acceptGameInvite,

--- a/games/battleship.js
+++ b/games/battleship.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -157,7 +157,7 @@ const BattleshipBoard = ({ G, ctx, moves, playerID, onGameEnd }) => {
   );
 };
 
-const BattleshipClient = Client({ game: BattleshipGame, board: BattleshipBoard });
+const BattleshipClient = createGameClient({ game: BattleshipGame, board: BattleshipBoard });
 
 export const Game = BattleshipGame;
 export const Board = BattleshipBoard;

--- a/games/blackjack.js
+++ b/games/blackjack.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -117,7 +117,7 @@ const BlackjackBoard = ({ G, ctx, moves, playerID, onGameEnd }) => {
   );
 };
 
-const BlackjackClient = Client({ game: BlackjackGame, board: BlackjackBoard });
+const BlackjackClient = createGameClient({ game: BlackjackGame, board: BlackjackBoard });
 
 export const Game = BlackjackGame;
 export const Board = BlackjackBoard;

--- a/games/checkers.js
+++ b/games/checkers.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -179,7 +179,7 @@ const CheckersBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const CheckersClient = Client({ game: CheckersGame, board: CheckersBoard });
+const CheckersClient = createGameClient({ game: CheckersGame, board: CheckersBoard });
 
 export const Game = CheckersGame;
 export const Board = CheckersBoard;

--- a/games/coin-toss.js
+++ b/games/coin-toss.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -67,7 +67,7 @@ const CoinTossBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const CoinTossClient = Client({ game: CoinTossGame, board: CoinTossBoard });
+const CoinTossClient = createGameClient({ game: CoinTossGame, board: CoinTossBoard });
 
 export const Game = CoinTossGame;
 export const Board = CoinTossBoard;

--- a/games/connect-four.js
+++ b/games/connect-four.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -124,7 +124,7 @@ const ConnectFourBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const ConnectFourClient = Client({ game: ConnectFourGame, board: ConnectFourBoard });
+const ConnectFourClient = createGameClient({ game: ConnectFourGame, board: ConnectFourBoard });
 
 export const Game = ConnectFourGame;
 export const Board = ConnectFourBoard;

--- a/games/createGameClient.js
+++ b/games/createGameClient.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef, forwardRef } from 'react';
+import { Client } from 'boardgame.io/react-native';
+
+export default function createGameClient(opts) {
+  const BaseClient = Client(opts);
+
+  const Wrapped = forwardRef(function Wrapped(props, ref) {
+    const { initialState, onStateChange, ...rest } = props;
+    const clientRef = useRef(null);
+
+    useEffect(() => {
+      const client = clientRef.current?.client;
+      if (!client) return;
+      if (initialState) {
+        try {
+          if (client.restore) client.restore(initialState);
+          else if (client.updateState) client.updateState(initialState);
+          else if (client.reset) client.reset(initialState);
+          else if (client.overrideGameState) client.overrideGameState(initialState);
+        } catch (e) {
+          console.warn('Failed to apply initial state', e);
+        }
+      }
+      if (onStateChange && client.subscribe) {
+        const unsub = client.subscribe(() => {
+          try {
+            onStateChange(client.getState ? client.getState() : client.store.getState());
+          } catch (err) {
+            console.warn('Failed to report state', err);
+          }
+        });
+        return () => unsub && unsub();
+      }
+    }, [initialState, onStateChange]);
+
+    return <BaseClient ref={(c) => {
+      clientRef.current = c;
+      if (typeof ref === 'function') ref(c);
+      else if (ref) ref.current = c;
+    }} {...rest} />;
+  });
+
+  return Wrapped;
+}

--- a/games/dominoes.js
+++ b/games/dominoes.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -180,7 +180,7 @@ const DominoesBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const DominoesClient = Client({ game: DominoesGame, board: DominoesBoard });
+const DominoesClient = createGameClient({ game: DominoesGame, board: DominoesBoard });
 
 export const Game = DominoesGame;
 export const Board = DominoesBoard;

--- a/games/dots-and-boxes.js
+++ b/games/dots-and-boxes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 
@@ -151,7 +151,7 @@ const DotsBoxesBoard = ({ G, ctx, moves }) => {
   );
 };
 
-const DotsBoxesClient = Client({ game: DotsBoxesGame, board: DotsBoxesBoard });
+const DotsBoxesClient = createGameClient({ game: DotsBoxesGame, board: DotsBoxesBoard });
 
 export const Game = DotsBoxesGame;
 export const Board = DotsBoxesBoard;

--- a/games/flirty-questions.js
+++ b/games/flirty-questions.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
 
@@ -60,7 +60,7 @@ const FlirtyBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const FlirtyClient = Client({ game: FlirtyGame, board: FlirtyBoard });
+const FlirtyClient = createGameClient({ game: FlirtyGame, board: FlirtyBoard });
 
 export const Game = FlirtyGame;
 export const Board = FlirtyBoard;

--- a/games/gomoku.js
+++ b/games/gomoku.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -103,7 +103,7 @@ const GomokuBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const GomokuClient = Client({ game: GomokuGame, board: GomokuBoard });
+const GomokuClient = createGameClient({ game: GomokuGame, board: GomokuBoard });
 
 export const Game = GomokuGame;
 export const Board = GomokuBoard;

--- a/games/guess-number.js
+++ b/games/guess-number.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity, TextInput } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -72,7 +72,7 @@ const GuessNumberBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const GuessNumberClient = Client({ game: GuessNumberGame, board: GuessNumberBoard });
+const GuessNumberClient = createGameClient({ game: GuessNumberGame, board: GuessNumberBoard });
 
 export const Game = GuessNumberGame;
 export const Board = GuessNumberBoard;

--- a/games/hangman.js
+++ b/games/hangman.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -72,7 +72,7 @@ const HangmanBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const HangmanClient = Client({ game: HangmanGame, board: HangmanBoard });
+const HangmanClient = createGameClient({ game: HangmanGame, board: HangmanBoard });
 
 export const Game = HangmanGame;
 export const Board = HangmanBoard;

--- a/games/mancala.js
+++ b/games/mancala.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -149,7 +149,7 @@ const MancalaBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const MancalaClient = Client({ game: MancalaGame, board: MancalaBoard });
+const MancalaClient = createGameClient({ game: MancalaGame, board: MancalaBoard });
 
 export const Game = MancalaGame;
 export const Board = MancalaBoard;

--- a/games/memory-match.js
+++ b/games/memory-match.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -79,7 +79,7 @@ const MemoryMatchBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const MemoryMatchClient = Client({ game: MemoryMatchGame, board: MemoryMatchBoard });
+const MemoryMatchClient = createGameClient({ game: MemoryMatchGame, board: MemoryMatchBoard });
 
 export const Game = MemoryMatchGame;
 export const Board = MemoryMatchBoard;

--- a/games/minesweeper.js
+++ b/games/minesweeper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -147,7 +147,7 @@ const MinesweeperBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const MinesweeperClient = Client({ game: MinesweeperGame, board: MinesweeperBoard });
+const MinesweeperClient = createGameClient({ game: MinesweeperGame, board: MinesweeperBoard });
 
 export const Game = MinesweeperGame;
 export const Board = MinesweeperBoard;

--- a/games/nim.js
+++ b/games/nim.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -57,7 +57,7 @@ const NimBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const NimClient = Client({ game: NimGame, board: NimBoard });
+const NimClient = createGameClient({ game: NimGame, board: NimBoard });
 
 export const Game = NimGame;
 export const Board = NimBoard;

--- a/games/pig.js
+++ b/games/pig.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -87,7 +87,7 @@ const PigBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const PigClient = Client({ game: PigGame, board: PigBoard });
+const PigClient = createGameClient({ game: PigGame, board: PigBoard });
 
 export const Game = PigGame;
 export const Board = PigBoard;

--- a/games/rock-paper-scissors.js
+++ b/games/rock-paper-scissors.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -78,7 +78,7 @@ const RPSBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const RPSClient = Client({ game: RPSGame, board: RPSBoard });
+const RPSClient = createGameClient({ game: RPSGame, board: RPSBoard });
 
 export const Game = RPSGame;
 export const Board = RPSBoard;

--- a/games/snakes-and-ladders.js
+++ b/games/snakes-and-ladders.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { View, Text, TouchableOpacity } from 'react-native';
 
 const snakes = { 16: 6, 47: 26, 49: 11, 56: 53, 62: 19, 64: 60, 87: 24, 93: 73, 95: 75, 98: 78 };
@@ -77,7 +77,7 @@ const SnakesLaddersBoard = ({ G, ctx, moves }) => {
   );
 };
 
-const SnakesLaddersClient = Client({ game: SnakesLaddersGame, board: SnakesLaddersBoard });
+const SnakesLaddersClient = createGameClient({ game: SnakesLaddersGame, board: SnakesLaddersBoard });
 
 export const Game = SnakesLaddersGame;
 export const Board = SnakesLaddersBoard;

--- a/games/sudoku.js
+++ b/games/sudoku.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity } from 'react-native';
 import useOnGameOver from '../hooks/useOnGameOver';
@@ -98,7 +98,7 @@ const SudokuBoard = ({ G, ctx, moves, onGameEnd }) => {
   );
 };
 
-const SudokuClient = Client({ game: SudokuGame, board: SudokuBoard });
+const SudokuClient = createGameClient({ game: SudokuGame, board: SudokuBoard });
 
 export const Game = SudokuGame;
 export const Board = SudokuBoard;

--- a/games/tic-tac-toe.js
+++ b/games/tic-tac-toe.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import { Client } from 'boardgame.io/react-native';
+import createGameClient from './createGameClient';
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { View, Text, TouchableOpacity, Dimensions, StyleSheet, Animated } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -154,7 +154,7 @@ const getStyles = (theme) =>
   resultText: { marginTop: 12, fontWeight: 'bold', fontSize: 18, color: theme.text },
 });
 
-const TicTacToeClient = Client({
+const TicTacToeClient = createGameClient({
   game: TicTacToeGame,
   board: TicTacToeBoard,
 });


### PR DESCRIPTION
## Summary
- create helper `createGameClient` that handles initial state and state change callbacks
- persist each game's state through `ChatContext` helpers
- load, save, and clear game state in `ChatScreen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865b7055d68832db393648cba99ccef