### PR TITLE
Add create rule for user docs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,6 +32,7 @@ service cloud.firestore {
 
     match /users/{userId} {
       allow read: if signedIn();
+      allow create: if isUser(userId);
       // Only allow users to update their own document
       allow update: if isUser(userId) &&
         canPlayDaily(resource.data, request.resource.data);


### PR DESCRIPTION
## Summary
- update Firestore security rules so user docs can be created by signed-in users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865b94b2ea4832d8ac1f0d641e52989