### PR TITLE
Add match notification in SwipeScreen

### DIFF
--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -314,6 +314,7 @@ const handleSwipe = async (direction) => {
             ).catch(() => {});
             play('match');
             Toast.show({ type: 'success', text1: "It's a match!" });
+            showNotification("It's a match!");
             setShowFireworks(true);
             setTimeout(() => setShowFireworks(false), 2000);
           }


### PR DESCRIPTION
## Summary
- ensure `useNotification` is imported in SwipeScreen
- fire a notification when a reciprocal like creates a match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865bb0bb7ac832da75dfa4c4e5270cf