### PR TITLE
Add home screen sections

### DIFF
--- a/components/ActiveGamesPreview.js
+++ b/components/ActiveGamesPreview.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+import { useGameSessions } from '../contexts/GameSessionContext';
+import { useChats } from '../contexts/ChatContext';
+import { useUser } from '../contexts/UserContext';
+import { games } from '../games';
+import Card from './Card';
+import GradientButton from './GradientButton';
+
+export default function ActiveGamesPreview({ navigation }) {
+  const { theme } = useTheme();
+  const { sessions } = useGameSessions();
+  const { matches } = useChats();
+  const { user } = useUser();
+  const styles = getStyles(theme);
+
+  const list = sessions.slice(0, 3);
+  if (list.length === 0) return null;
+
+  const renderItem = (item) => {
+    const otherId = item.players.find((p) => p !== user.uid);
+    const match = matches.find((m) => m.otherUserId === otherId);
+    const name = match?.displayName || 'Opponent';
+    const title = games[item.gameId]?.meta?.title || 'Game';
+    return (
+      <Card
+        key={item.id}
+        onPress={() =>
+          navigation.navigate('GameSession', {
+            sessionId: item.id,
+            game: { id: item.gameId, title },
+            opponent: { id: otherId, displayName: name, photo: match?.image },
+          })
+        }
+        style={[styles.card, { backgroundColor: theme.card }]}
+      >
+        <Text style={[styles.cardTitle, { color: theme.text }]}>{title}</Text>
+        <Text style={{ color: theme.textSecondary }}>{name}</Text>
+      </Card>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Active Games</Text>
+      {list.map(renderItem)}
+      <GradientButton
+        text="View All"
+        onPress={() => navigation.navigate('ActiveGames')}
+        style={{ alignSelf: 'center', width: 160, marginTop: 4 }}
+      />
+    </View>
+  );
+}
+
+ActiveGamesPreview.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { marginBottom: 24, width: '100%' },
+    title: {
+      fontSize: 16,
+      fontWeight: '700',
+      alignSelf: 'center',
+      marginBottom: 8,
+      color: theme.accent,
+    },
+    card: { marginBottom: 12 },
+    cardTitle: { fontSize: 15, fontWeight: '600', marginBottom: 2 },
+  });

--- a/components/MatchesPreview.js
+++ b/components/MatchesPreview.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+import { useChats } from '../contexts/ChatContext';
+import AvatarRing from './AvatarRing';
+import GradientButton from './GradientButton';
+
+export default function MatchesPreview({ navigation }) {
+  const { theme } = useTheme();
+  const { matches } = useChats();
+  const styles = getStyles(theme);
+
+  const list = matches.slice(0, 5);
+  if (list.length === 0) return null;
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity
+      style={styles.match}
+      onPress={() => navigation.navigate('Chat', { user: item })}
+    >
+      <AvatarRing source={item.image} size={56} isMatch isOnline={item.online} />
+      <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>
+        {item.displayName}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Matches</Text>
+      <FlatList
+        data={list}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.list}
+      />
+      <GradientButton
+        text="View All"
+        onPress={() => navigation.navigate('Matches')}
+        style={{ alignSelf: 'center', width: 160, marginTop: 4 }}
+      />
+    </View>
+  );
+}
+
+MatchesPreview.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { marginBottom: 24, width: '100%' },
+    title: {
+      fontSize: 16,
+      fontWeight: '700',
+      alignSelf: 'center',
+      marginBottom: 8,
+      color: theme.accent,
+    },
+    list: { paddingHorizontal: 8, marginBottom: 8 },
+    match: { alignItems: 'center', marginRight: 12 },
+    name: { fontSize: 13, fontWeight: '600', maxWidth: 72, marginTop: 4 },
+  });

--- a/components/PremiumBanner.js
+++ b/components/PremiumBanner.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+import GradientButton from './GradientButton';
+
+export default function PremiumBanner({ onClose, onPress }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  return (
+    <LinearGradient
+      colors={[theme.gradientStart, theme.gradientEnd]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 0 }}
+      style={styles.container}
+    >
+      <View style={{ flex: 1 }}>
+        <Text style={styles.title}>Upgrade to Premium</Text>
+        <Text style={styles.subtitle}>Unlimited games & all features</Text>
+        <GradientButton
+          text="Go Premium"
+          onPress={onPress}
+          style={{ width: 140, marginVertical: 0, marginTop: 8 }}
+        />
+      </View>
+      <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+        <Ionicons name="close" size={20} color="#fff" />
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+PremiumBanner.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 16,
+      borderRadius: 16,
+      marginBottom: 16,
+    },
+    title: { color: '#fff', fontSize: 16, fontWeight: 'bold' },
+    subtitle: { color: '#fff', fontSize: 13, marginTop: 2 },
+    closeButton: { marginLeft: 12 },
+  });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -26,6 +26,9 @@ import EventFlyer from "../components/EventFlyer";
 import GradientButton from '../components/GradientButton';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { eventImageSource } from '../utils/avatar';
+import PremiumBanner from '../components/PremiumBanner';
+import ActiveGamesPreview from '../components/ActiveGamesPreview';
+import MatchesPreview from '../components/MatchesPreview';
 
 // Map app game IDs to boardgame registry keys for AI play
 const aiGameMap = allGames.reduce((acc, g) => {
@@ -45,6 +48,7 @@ const HomeScreen = ({ navigation }) => {
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
   const [playTarget, setPlayTarget] = useState('match');
   const [showBonus, setShowBonus] = useState(false);
+  const [showPremiumBanner, setShowPremiumBanner] = useState(!isPremiumUser);
   const local = getStyles(theme);
 
 
@@ -61,6 +65,10 @@ const HomeScreen = ({ navigation }) => {
       return () => clearTimeout(t);
     }
   }, [loginBonus]);
+
+  useEffect(() => {
+    setShowPremiumBanner(!isPremiumUser);
+  }, [isPremiumUser]);
 
   const openGamePicker = (target) => {
     if (target === 'browse') {
@@ -125,9 +133,16 @@ const HomeScreen = ({ navigation }) => {
               <Text style={[local.levelText, { color: theme.text }]}>{`Level ${level}`}</Text>
               <ProgressBar value={xpProgress} max={100} color={theme.accent} />
               <Text style={[local.streakLabel, { color: theme.textSecondary }]}>{`${user?.streak || 0} day streak`}</Text>
-              <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
-            </Card>
-          </View>
+          <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
+        </Card>
+      </View>
+
+      {!isPremiumUser && showPremiumBanner && (
+        <PremiumBanner
+          onClose={() => setShowPremiumBanner(false)}
+          onPress={() => navigation.navigate('Premium', { context: 'paywall' })}
+        />
+      )}
 
           <View style={local.group}>
             <Text style={local.sectionTitle}>Quick Play</Text>
@@ -140,16 +155,16 @@ const HomeScreen = ({ navigation }) => {
                 <Text style={[local.tileEmoji, { marginBottom: 0 }]}>{item.emoji}</Text>
                 <Text style={[local.fullTileText, { color: theme.text }]}>{item.title}</Text>
               </Card>
-            ))}
-          </View>
+          ))}
+        </View>
+        <ActiveGamesPreview navigation={navigation} />
+        <MatchesPreview navigation={navigation} />
 
-
-
-          <View style={local.group}>
-            <Card
-              onPress={() => navigation.navigate('Play')}
-              style={[local.fullTile, { backgroundColor: theme.card }]}
-            >
+        <View style={local.group}>
+          <Card
+            onPress={() => navigation.navigate('Play')}
+            style={[local.fullTile, { backgroundColor: theme.card }]}
+          >
               <Text style={[local.tileEmoji, { marginBottom: 0 }]}>🎮</Text>
               <Text style={[local.fullTileText, { color: theme.text }]}>Games</Text>
             </Card>


### PR DESCRIPTION
## Summary
- create `PremiumBanner`, `ActiveGamesPreview`, and `MatchesPreview` components
- show dismissible Premium banner when user isn't premium
- display previews for active games and matches on HomeScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865bbd23bc0832d8c3882564375e13a