### PR TITLE
Use OnboardingStack in root navigator

### DIFF
--- a/navigation/OnboardingStack.js
+++ b/navigation/OnboardingStack.js
@@ -1,0 +1,20 @@
+// navigation/OnboardingStack.js
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import OnboardingScreen from '../screens/OnboardingScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function OnboardingStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+        animationDuration: 200,
+      }}
+    >
+      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -8,7 +8,7 @@ import { useOnboarding } from '../contexts/OnboardingContext';
 import SplashScreen from '../screens/SplashScreen';
 import AuthStack from './AuthStack';
 import AppStack from './AppStack';
-import OnboardingScreen from '../screens/OnboardingScreen';
+import OnboardingStack from './OnboardingStack';
 
 
 const splashDuration = 2000;
@@ -50,7 +50,7 @@ export default function RootNavigator() {
   }
 
   if (!onboarded) {
-    return <OnboardingScreen />;
+    return <OnboardingStack />;
   }
 
   return <AppStack />;


### PR DESCRIPTION
## Summary
- add `OnboardingStack` navigator wrapping `OnboardingScreen`
- return `OnboardingStack` in `RootNavigator` when user isn't onboarded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865c0e5d6b4832dbc6d0e15604e533a