### PR TITLE
Fix onboarding context initialization

### DIFF
--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -4,7 +4,7 @@ import * as Google from "expo-auth-session/providers/google";
 import * as AuthSession from "expo-auth-session";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import firebase from "../firebase";
-import { clearStoredOnboarding } from "./OnboardingContext";
+import { clearStoredOnboarding } from "../utils/onboarding";
 import { snapshotExists } from "../utils/firestore";
 import { isAllowedDomain } from "../utils/email";
 

--- a/contexts/OnboardingContext.js
+++ b/contexts/OnboardingContext.js
@@ -3,17 +3,10 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { View } from "react-native";
 import Loader from "../components/Loader";
 import { useAuth } from "./AuthContext";
+import { clearStoredOnboarding } from "../utils/onboarding";
 
 const OnboardingContext = createContext();
 
-export const clearStoredOnboarding = async (uid) => {
-  if (!uid) return;
-  try {
-    await AsyncStorage.removeItem(`hasOnboarded_${uid}`);
-  } catch (e) {
-    console.warn("Failed to clear onboarding flag", e);
-  }
-};
 
 export const OnboardingProvider = ({ children }) => {
   const { user } = useAuth();

--- a/contexts/Providers.js
+++ b/contexts/Providers.js
@@ -16,11 +16,11 @@ import { FilterProvider } from './FilterContext';
 
 const Providers = ({ children }) => (
   <DevProvider>
-    <OnboardingProvider>
-      <UserProvider>
-        <ThemeProvider>
-          <SoundProvider>
-            <AuthProvider>
+    <AuthProvider>
+      <OnboardingProvider>
+        <UserProvider>
+          <ThemeProvider>
+            <SoundProvider>
               <NotificationProvider>
                 <ListenerProvider>
                   <GameLimitProvider>
@@ -38,11 +38,11 @@ const Providers = ({ children }) => (
                   </GameLimitProvider>
                 </ListenerProvider>
               </NotificationProvider>
-            </AuthProvider>
-          </SoundProvider>
-        </ThemeProvider>
-      </UserProvider>
-    </OnboardingProvider>
+            </SoundProvider>
+          </ThemeProvider>
+        </UserProvider>
+      </OnboardingProvider>
+    </AuthProvider>
   </DevProvider>
 );
 

--- a/contexts/UserContext.js
+++ b/contexts/UserContext.js
@@ -4,7 +4,8 @@ import Toast from "react-native-toast-message";
 import Loader from "../components/Loader";
 import firebase from "../firebase";
 import { useDev } from "./DevContext";
-import { useOnboarding, clearStoredOnboarding } from "./OnboardingContext";
+import { useOnboarding } from "./OnboardingContext";
+import { clearStoredOnboarding } from "../utils/onboarding";
 import { snapshotExists } from "../utils/firestore";
 import { computeBadges } from "../utils/badges";
 

--- a/utils/onboarding.js
+++ b/utils/onboarding.js
@@ -1,0 +1,10 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const clearStoredOnboarding = async (uid) => {
+  if (!uid) return;
+  try {
+    await AsyncStorage.removeItem(`hasOnboarded_${uid}`);
+  } catch (e) {
+    console.warn('Failed to clear onboarding flag', e);
+  }
+};


### PR DESCRIPTION
## Summary
- prevent Auth/onboarding circular dependency by extracting clearStoredOnboarding to utils
- nest `OnboardingProvider` inside `AuthProvider`
- update imports for new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866c7d61630832d855a0defffaf6ebb