### PR TITLE
Use theme colors for various components

### DIFF
--- a/components/GameOverModal.js
+++ b/components/GameOverModal.js
@@ -6,6 +6,7 @@ import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 import { avatarSource } from '../utils/avatar';
 import useWinLossStats from '../hooks/useWinLossStats';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function GameOverModal({
   visible,
@@ -16,6 +17,8 @@ export default function GameOverModal({
   rematchDisabled,
   onExit,
 }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
   const stats = useWinLossStats(winnerId);
   useEffect(() => {
     if (visible && winnerName) {
@@ -49,7 +52,7 @@ export default function GameOverModal({
           )}
           <Pressable
             onPress={onRematch}
-            android_ripple={{ color: '#fff' }}
+            android_ripple={{ color: theme.text }}
             style={[styles.rematchBtn, rematchDisabled && { opacity: 0.6 }]}
             disabled={rematchDisabled}
           >
@@ -57,7 +60,7 @@ export default function GameOverModal({
           </Pressable>
           <Pressable
             onPress={onExit}
-            android_ripple={{ color: '#fff' }}
+            android_ripple={{ color: theme.text }}
             style={styles.exitBtn}
           >
             <Text style={styles.btnText}>Exit</Text>
@@ -78,69 +81,71 @@ GameOverModal.propTypes = {
   onExit: PropTypes.func.isRequired,
 };
 
-const styles = StyleSheet.create({
-  backdrop: {
-    flex: 1,
-    backgroundColor: '#0009',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  animationContainer: {
-    ...StyleSheet.absoluteFillObject,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  animation: {
-    width: '100%',
-    height: '100%',
-  },
-  card: {
-    padding: 24,
-    borderRadius: 20,
-    width: 280,
-    alignItems: 'center',
-    overflow: 'hidden',
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    marginBottom: 10,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: '#fff',
-    marginBottom: 6,
-    textAlign: 'center',
-  },
-  stats: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#fff',
-    marginBottom: 16,
-  },
-  rematchBtn: {
-    backgroundColor: '#28c76f',
-    paddingVertical: 12,
-    paddingHorizontal: 40,
-    borderRadius: 16,
-    width: '100%',
-    marginBottom: 12,
-    overflow: 'hidden',
-  },
-  exitBtn: {
-    backgroundColor: '#e74c3c',
-    paddingVertical: 12,
-    paddingHorizontal: 40,
-    borderRadius: 16,
-    width: '100%',
-    overflow: 'hidden',
-  },
-  btnText: {
-    color: '#fff',
-    fontWeight: 'bold',
-    fontSize: 16,
-    textAlign: 'center',
-  },
-});
+const getStyles = (theme) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: '#0009',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    animationContainer: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    animation: {
+      width: '100%',
+      height: '100%',
+    },
+    card: {
+      padding: 24,
+      borderRadius: 20,
+      width: 280,
+      alignItems: 'center',
+      overflow: 'hidden',
+      backgroundColor: theme.card,
+    },
+    avatar: {
+      width: 80,
+      height: 80,
+      borderRadius: 40,
+      marginBottom: 10,
+    },
+    title: {
+      fontSize: 22,
+      fontWeight: 'bold',
+      color: theme.text,
+      marginBottom: 6,
+      textAlign: 'center',
+    },
+    stats: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.text,
+      marginBottom: 16,
+    },
+    rematchBtn: {
+      backgroundColor: theme.accent,
+      paddingVertical: 12,
+      paddingHorizontal: 40,
+      borderRadius: 16,
+      width: '100%',
+      marginBottom: 12,
+      overflow: 'hidden',
+    },
+    exitBtn: {
+      backgroundColor: theme.accent,
+      paddingVertical: 12,
+      paddingHorizontal: 40,
+      borderRadius: 16,
+      width: '100%',
+      overflow: 'hidden',
+    },
+    btnText: {
+      color: '#fff',
+      fontWeight: 'bold',
+      fontSize: 16,
+      textAlign: 'center',
+    },
+  });

--- a/components/PremiumBadge.js
+++ b/components/PremiumBadge.js
@@ -1,16 +1,21 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
 
 const PremiumBadge = ({ premium, route, accent }) => {
+  const { theme } = useTheme();
   if (route) return null;
+  const backgroundColor = premium
+    ? accent || theme.accent
+    : theme.textSecondary;
   return (
     <View
       style={{
         position: 'absolute',
         top: 8,
         right: 8,
-        backgroundColor: premium ? accent : '#aaa',
+        backgroundColor,
         paddingHorizontal: 6,
         paddingVertical: 2,
         borderRadius: 8,

--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import { View, TextInput } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
 
 export default function SearchInput({ search, setSearch }) {
+  const { theme } = useTheme();
   return (
     <View
       style={{
         marginHorizontal: 16,
         marginBottom: 6,
-        backgroundColor: '#fff',
+        backgroundColor: theme.card,
         borderRadius: 12,
         paddingHorizontal: 12,
         paddingVertical: 4,
@@ -17,10 +19,10 @@ export default function SearchInput({ search, setSearch }) {
     >
       <TextInput
         placeholder="Search games..."
-        placeholderTextColor="#999"
+        placeholderTextColor={theme.textSecondary}
         value={search}
         onChangeText={setSearch}
-        style={{ fontSize: 14, color: '#000', paddingVertical: 3 }}
+        style={{ fontSize: 14, color: theme.text, paddingVertical: 3 }}
       />
     </View>
   );

--- a/components/SkeletonUserCard.js
+++ b/components/SkeletonUserCard.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const CARD_HEIGHT = SCREEN_HEIGHT * 0.75;
 
 function SkeletonUserCard() {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
   return (
     <View style={styles.card}>
       <View style={styles.image} />
@@ -23,39 +26,43 @@ SkeletonUserCard.propTypes = {};
 
 export default SkeletonUserCard;
 
-const styles = StyleSheet.create({
-  card: {
-    width: SCREEN_WIDTH * 0.9,
-    height: CARD_HEIGHT,
-    borderRadius: 20,
-    overflow: 'hidden',
-    backgroundColor: '#fff',
-    elevation: 8,
-    shadowColor: '#000',
-    shadowOpacity: 0.2,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 4 },
-  },
-  image: {
-    width: '100%',
-    height: '75%',
-    backgroundColor: '#eee',
-  },
-  info: {
-    padding: 15,
-  },
-  name: {
-    width: '50%',
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: '#ddd',
-    marginBottom: 8,
-  },
-  bio: {
-    width: '80%',
-    height: 16,
-    borderRadius: 8,
-    backgroundColor: '#eee',
-    marginTop: 4,
-  },
-});
+const getStyles = (theme) =>
+  StyleSheet.create({
+    card: {
+      width: SCREEN_WIDTH * 0.9,
+      height: CARD_HEIGHT,
+      borderRadius: 20,
+      overflow: 'hidden',
+      backgroundColor: theme.card,
+      elevation: 8,
+      shadowColor: '#000',
+      shadowOpacity: 0.2,
+      shadowRadius: 8,
+      shadowOffset: { width: 0, height: 4 },
+    },
+    image: {
+      width: '100%',
+      height: '75%',
+      backgroundColor: theme.textSecondary,
+      opacity: 0.3,
+    },
+    info: {
+      padding: 15,
+    },
+    name: {
+      width: '50%',
+      height: 24,
+      borderRadius: 12,
+      backgroundColor: theme.textSecondary,
+      opacity: 0.3,
+      marginBottom: 8,
+    },
+    bio: {
+      width: '80%',
+      height: 16,
+      borderRadius: 8,
+      backgroundColor: theme.textSecondary,
+      opacity: 0.3,
+      marginTop: 4,
+    },
+  });


### PR DESCRIPTION
## Summary
- hook up SearchInput to use theme colors
- update GameOverModal styles based on active theme
- apply theme to PremiumBadge
- use themed skeleton styles for user card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865f3144268832d9e385435de7b1bb4