### PR TITLE
Add location info tooltip

### DIFF
--- a/components/LocationInfoModal.js
+++ b/components/LocationInfoModal.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function LocationInfoModal({ visible, onClose }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.text}>
+            We use your location to suggest nearby players. Your exact location is
+            never shared publicly.
+          </Text>
+          <TouchableOpacity onPress={onClose} style={styles.button}>
+            <Text style={styles.buttonText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+LocationInfoModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: '#0009',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    card: {
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      padding: 20,
+      alignItems: 'center',
+    },
+    text: {
+      color: theme.text,
+      fontSize: 16,
+      textAlign: 'center',
+      marginBottom: 12,
+    },
+    button: {
+      backgroundColor: theme.accent,
+      paddingHorizontal: 20,
+      paddingVertical: 8,
+      borderRadius: 20,
+    },
+    buttonText: { color: '#fff', fontWeight: 'bold' },
+  });

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -24,7 +24,7 @@ import * as Location from 'expo-location';
 import { avatarSource } from '../utils/avatar';
 import RNPickerSelect from 'react-native-picker-select';
 import Toast from 'react-native-toast-message';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import MultiSelectList from '../components/MultiSelectList';
@@ -32,6 +32,7 @@ import { FONT_SIZES, BUTTON_STYLE, HEADER_SPACING } from '../layout';
 import Header from '../components/Header';
 import { allGames } from '../data/games';
 import { logDev } from '../utils/logger';
+import LocationInfoModal from '../components/LocationInfoModal';
 
 const questions = [
   { key: 'avatar', label: 'Upload your photo' },
@@ -88,6 +89,7 @@ export default function OnboardingScreen() {
     value: g.title,
   }));
   const [gameOptions, setGameOptions] = useState(defaultGameOptions);
+  const [showLocationInfo, setShowLocationInfo] = useState(false);
 
   useEffect(() => {
     const unsub = firebase
@@ -292,17 +294,29 @@ export default function OnboardingScreen() {
 
     if (currentField === 'location') {
       return (
-        <TouchableOpacity style={styles.locationContainer} onPress={autofillLocation}>
-          <MaterialCommunityIcons
-            name="crosshairs-gps"
-            size={28}
-            color="#fff"
-            style={styles.locationIcon}
-          />
-          <Text style={styles.locationText}>
-            {answers.location ? `📍 ${answers.location}` : 'Use My Location'}
-          </Text>
-        </TouchableOpacity>
+        <View>
+          <TouchableOpacity
+            style={styles.locationContainer}
+            onPress={autofillLocation}
+          >
+            <MaterialCommunityIcons
+              name="crosshairs-gps"
+              size={28}
+              color="#fff"
+              style={styles.locationIcon}
+            />
+            <Text style={styles.locationText}>
+              {answers.location ? `📍 ${answers.location}` : 'Use My Location'}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.infoLink}
+            onPress={() => setShowLocationInfo(true)}
+          >
+            <Text style={styles.infoLinkText}>How is my location used?</Text>
+            <Ionicons name="arrow-forward" size={16} color={theme.accent} />
+          </TouchableOpacity>
+        </View>
       );
     }
 
@@ -477,6 +491,10 @@ export default function OnboardingScreen() {
             <Text style={styles.skipButtonText}>Complete Profile Later</Text>
           </TouchableOpacity>
         )}
+        <LocationInfoModal
+          visible={showLocationInfo}
+          onClose={() => setShowLocationInfo(false)}
+        />
       </SafeKeyboardView>
     </GradientBackground>
   );
@@ -571,6 +589,18 @@ const getStyles = (theme) => {
     locationText: {
       color: '#fff',
       fontSize: FONT_SIZES.MD,
+    },
+    infoLink: {
+      marginTop: 10,
+      alignSelf: 'center',
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    infoLinkText: {
+      color: accent,
+      textDecorationLine: 'underline',
+      marginRight: 4,
+      fontSize: FONT_SIZES.SM,
     },
     buttonRow: {
       flexDirection: 'row',

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -20,6 +20,8 @@ import RNPickerSelect from 'react-native-picker-select';
 import MultiSelectList from '../components/MultiSelectList';
 import { useTheme } from '../contexts/ThemeContext';
 import { allGames } from '../data/games';
+import { Ionicons } from '@expo/vector-icons';
+import LocationInfoModal from '../components/LocationInfoModal';
 
 const ProfileScreen = ({ navigation, route }) => {
   const { user, updateUser } = useUser();
@@ -38,6 +40,7 @@ const ProfileScreen = ({ navigation, route }) => {
   const defaultGameOptions = allGames.map((g) => ({ label: g.title, value: g.title }));
   const [gameOptions, setGameOptions] = useState(defaultGameOptions);
   const [avatar, setAvatar] = useState(user?.photoURL || '');
+  const [showLocationInfo, setShowLocationInfo] = useState(false);
 
   const pickImage = async () => {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -213,6 +216,13 @@ const ProfileScreen = ({ navigation, route }) => {
         value={location}
         onChangeText={setLocation}
       />
+      <TouchableOpacity
+        style={styles.infoLink}
+        onPress={() => setShowLocationInfo(true)}
+      >
+        <Text style={styles.infoLinkText}>How is my location used?</Text>
+        <Ionicons name="arrow-forward" size={16} color={theme.accent} />
+      </TouchableOpacity>
 
       <MultiSelectList
         options={gameOptions}
@@ -221,6 +231,10 @@ const ProfileScreen = ({ navigation, route }) => {
         theme={theme}
       />
       <GradientButton text={saveLabel} onPress={handleSave} />
+      <LocationInfoModal
+        visible={showLocationInfo}
+        onClose={() => setShowLocationInfo(false)}
+      />
       </SafeKeyboardView>
     </GradientBackground>
   );

--- a/styles.js
+++ b/styles.js
@@ -232,6 +232,18 @@ const getStyles = (theme) =>
   buttonIcon: {
     fontSize: 28,
     color: '#fff'
+  },
+  infoLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'center',
+    marginBottom: 12
+  },
+  infoLinkText: {
+    color: theme.accent,
+    textDecorationLine: 'underline',
+    marginRight: 4,
+    fontSize: FONT_SIZES.SM
   }
   });
 


### PR DESCRIPTION
## Summary
- show modal with info about how location is used
- add "How is my location used?" helper link on onboarding and profile screens
- style helper link and share style in global stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867059a5724832d844c0006e11d55e2