### PR TITLE
Add discovery and messaging settings

### DIFF
--- a/contexts/FilterContext.js
+++ b/contexts/FilterContext.js
@@ -6,6 +6,8 @@ export const FilterProvider = ({ children }) => {
   const [location, setLocation] = useState('');
   const [ageRange, setAgeRange] = useState([18, 99]);
   const [interests, setInterests] = useState([]);
+  const [gender, setGender] = useState('');
+  const [verifiedOnly, setVerifiedOnly] = useState(false);
 
   return (
     <FilterContext.Provider
@@ -13,9 +15,13 @@ export const FilterProvider = ({ children }) => {
         location,
         ageRange,
         interests,
+        gender,
+        verifiedOnly,
         setLocationFilter: setLocation,
         setAgeRangeFilter: setAgeRange,
         setInterestsFilter: setInterests,
+        setGenderFilter: setGender,
+        setVerifiedFilter: setVerifiedOnly,
       }}
     >
       {children}

--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -30,6 +30,13 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `online` (boolean)
 - `lastOnline` (timestamp) – last presence update time
 - `badges` (array of string) – earned badge IDs
+- `visibility` (string) – `standard` or `incognito`
+- `discoveryEnabled` (boolean) – hide from swipe if false
+- `messagePermission` (string) – `everyone`, `verified`, or `profile100`
+- `seeAgeRange` (array) – preferred age range for matches
+- `seeGender` (string) – preferred gender of matches
+- `seeLocation` (string) – preferred location for matches
+- `seeVerifiedOnly` (boolean) – show only verified profiles
 
 ### Subcollections
 - **gameInvites** – invitations sent or received by the user. Each invite document mirrors the root `gameInvites` collection.

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -95,7 +95,13 @@ const SwipeScreen = () => {
   const { sendGameInvite } = useMatchmaking();
   const isPremiumUser = !!currentUser?.isPremium;
   const requireCredits = useRequireGameCredits();
-  const { location: filterLocation, ageRange, interests } = useFilters();
+  const {
+    location: filterLocation,
+    ageRange,
+    interests,
+    gender: filterGender,
+    verifiedOnly,
+  } = useFilters();
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [likesUsed, setLikesUsed] = useState(0);
@@ -166,6 +172,14 @@ const SwipeScreen = () => {
             .where('age', '<=', ageRange[1]);
         }
 
+        if (filterGender) {
+          userQuery = userQuery.where('gender', '==', filterGender);
+        }
+
+        if (verifiedOnly) {
+          userQuery = userQuery.where('isVerified', '==', true);
+        }
+
         if (Array.isArray(interests) && interests.length) {
           userQuery = userQuery.where(
             'favoriteGames',
@@ -196,12 +210,21 @@ const SwipeScreen = () => {
             location: u.location || '',
             priorityScore: u.priorityScore || 0,
             boostUntil: u.boostUntil || null,
+            isVerified: !!u.isVerified,
             images,
           };
         });
 
         if (filterLocation) {
           formatted = formatted.filter((u) => u.location === filterLocation);
+        }
+
+        if (filterGender) {
+          formatted = formatted.filter((u) => u.gender === filterGender);
+        }
+
+        if (verifiedOnly) {
+          formatted = formatted.filter((u) => u.isVerified);
         }
 
         if (Array.isArray(ageRange) && ageRange.length === 2) {
@@ -233,7 +256,15 @@ const SwipeScreen = () => {
       setLoadingUsers(false);
     };
     fetchUsers();
-  }, [currentUser?.uid, devMode, filterLocation, ageRange, interests]);
+  }, [
+    currentUser?.uid,
+    devMode,
+    filterLocation,
+    ageRange,
+    interests,
+    filterGender,
+    verifiedOnly,
+  ]);
 
   // Reset card position whenever the index changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- expand `FilterContext` to track gender and verified filters
- support gender/verification filters in swipe list
- document new preference fields in Firestore schema
- extend Settings screen with discovery and privacy controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686705deae58832d9eb9be254236c474