### PR TITLE
Fix phone verification flow

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -14,6 +14,8 @@ import StatsScreen from '../screens/StatsScreen';
 import PlayScreen from '../screens/PlayScreen';
 import SwipeScreen from '../screens/SwipeScreen';
 import LikedYouScreen from '../screens/LikedYouScreen';
+import VerifyHumanScreen from '../screens/VerifyHumanScreen';
+import PhoneVerificationScreen from '../screens/PhoneVerificationScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -52,6 +54,8 @@ export default function AppStack() {
         component={SwipeScreen}
         options={{ animation: 'slide_from_bottom' }}
       />
+      <Stack.Screen name="VerifyHuman" component={VerifyHumanScreen} />
+      <Stack.Screen name="PhoneVerification" component={PhoneVerificationScreen} />
       </Stack.Navigator>
   );
 }

--- a/screens/PhoneVerificationScreen.js
+++ b/screens/PhoneVerificationScreen.js
@@ -30,14 +30,21 @@ export default function PhoneVerificationScreen({ navigation }) {
   const [phone, setPhone] = useState('');
   const [otp, setOtp] = useState('');
   const [verificationId, setVerificationId] = useState(null);
+  const [lastSent, setLastSent] = useState(0);
 
   const sendCode = async () => {
+    const now = Date.now();
+    if (now - lastSent < 30000) {
+      Toast.show({ type: 'info', text1: 'Please wait before requesting another code.' });
+      return;
+    }
     try {
       const phoneNumber = `${countryCode}${phone}`;
       const res = await firebase
         .auth()
         .signInWithPhoneNumber(phoneNumber, recaptchaRef.current);
       setVerificationId(res.verificationId);
+      setLastSent(now);
       Toast.show({ type: 'success', text1: 'Code sent' });
     } catch (e) {
       console.warn('Send code failed', e);
@@ -51,12 +58,24 @@ export default function PhoneVerificationScreen({ navigation }) {
         verificationId,
         otp
       );
-      await firebase.auth().currentUser?.linkWithCredential(credential);
+      if (firebase.auth().currentUser) {
+        await firebase.auth().currentUser.linkWithCredential(credential);
+      } else {
+        await firebase.auth().signInWithCredential(credential);
+      }
       Toast.show({ type: 'success', text1: 'Phone verified' });
       navigation.goBack();
     } catch (e) {
       console.warn('Verify code failed', e);
-      Toast.show({ type: 'error', text1: 'Invalid code' });
+      let message = 'Invalid code';
+      if (e.code === 'auth/credential-already-in-use') {
+        message = 'Code already used';
+      } else if (e.code === 'auth/quota-exceeded') {
+        message = 'SMS quota exceeded. Try later.';
+      } else if (e.code === 'auth/too-many-requests') {
+        message = 'Too many attempts. Please try later.';
+      }
+      Toast.show({ type: 'error', text1: message });
     }
   };
 
@@ -65,7 +84,10 @@ export default function PhoneVerificationScreen({ navigation }) {
   return (
     <GradientBackground>
       <Header showLogoOnly />
-      <FirebaseRecaptchaVerifierModal ref={recaptchaRef} firebaseConfig={firebase.app().options} />
+      <FirebaseRecaptchaVerifierModal
+        ref={recaptchaRef}
+        firebaseConfig={firebase.app()?.options || {}}
+      />
       <ScreenContainer
         style={{ paddingTop: HEADER_SPACING, alignItems: 'center' }}
       >


### PR DESCRIPTION
## Summary
- add throttle and error handling to phone verification
- handle missing firebase options in recaptcha modal
- register VerifyHuman and PhoneVerification screens in AppStack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68673ed14624832d868d7173c718fbfa