### PR TITLE
Improve startup performance

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaView, KeyboardAvoidingView, Platform } from 'react-native';
+import * as SplashScreen from 'expo-splash-screen';
+import { useFonts } from 'expo-font';
+import { useUser } from './contexts/UserContext';
 import Providers from './contexts/Providers';
 import NotificationCenter from './components/NotificationCenter';
 import DevBanner from './components/DevBanner';
@@ -16,6 +19,20 @@ const ThemedNotificationCenter = () => {
 
 export default function App() {
   usePushNotifications();
+  const [fontsLoaded] = useFonts({});
+  const { loaded: themeLoaded } = useTheme();
+  const { loading: userLoading } = useUser();
+
+  useEffect(() => {
+    if (fontsLoaded && themeLoaded && !userLoading) {
+      SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded, themeLoaded, userLoading]);
+
+  if (!fontsLoaded || !themeLoaded || userLoading) {
+    return null;
+  }
+
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <KeyboardAvoidingView

--- a/app.json
+++ b/app.json
@@ -25,6 +25,7 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
+    "jsEngine": "hermes",
     "plugins": [
       "expo-web-browser",
       "expo-secure-store"

--- a/contexts/ThemeContext.js
+++ b/contexts/ThemeContext.js
@@ -30,7 +30,7 @@ export const ThemeProvider = ({ children }) => {
   const theme = darkMode ? darkTheme : lightTheme;
 
   return (
-    <ThemeContext.Provider value={{ darkMode, toggleTheme, theme }}>
+    <ThemeContext.Provider value={{ darkMode, toggleTheme, theme, loaded }}>
       {loaded ? (
         children
       ) : (

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 import { registerRootComponent } from 'expo';
+import * as SplashScreen from 'expo-splash-screen';
 
 import App from './App';
+
+SplashScreen.preventAutoHideAsync();
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/metro.config.js
+++ b/metro.config.js
@@ -3,5 +3,6 @@ const { getDefaultConfig } = require('expo/metro-config');
 const config = getDefaultConfig(__dirname);
 config.resolver.sourceExts.push('cjs');
 config.resolver.unstable_enablePackageExports = false;
+config.transformer = { ...config.transformer, inlineRequires: true };
 
 module.exports = config;

--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -1,27 +1,29 @@
 // navigation/AppStack.js
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import MainTabs from "./MainTabs";
-import ProfileScreen from "../screens/ProfileScreen";
-import EditProfileScreen from "../screens/EditProfileScreen";
-import ChatScreen from "../screens/ChatScreen";
-import NotificationsScreen from "../screens/NotificationsScreen";
-import GameInviteScreen from "../screens/GameInviteScreen";
-import GameSessionScreen from "../screens/GameSessionScreen";
-import GameWithBotScreen from "../screens/GameWithBotScreen";
-import CommunityScreen from "../screens/CommunityScreen";
-import PremiumScreen from "../screens/PremiumScreen";
-import StatsScreen from "../screens/StatsScreen";
-import PlayScreen from "../screens/PlayScreen";
-import SwipeScreen from "../screens/SwipeScreen";
-import LikedYouScreen from "../screens/LikedYouScreen";
-import VerifyHumanScreen from "../screens/VerifyHumanScreen";
-import PhoneVerificationScreen from "../screens/PhoneVerificationScreen";
+import Loader from "../components/Loader";
+const MainTabs = lazy(() => import("./MainTabs"));
+const ProfileScreen = lazy(() => import("../screens/ProfileScreen"));
+const EditProfileScreen = lazy(() => import("../screens/EditProfileScreen"));
+const ChatScreen = lazy(() => import("../screens/ChatScreen"));
+const NotificationsScreen = lazy(() => import("../screens/NotificationsScreen"));
+const GameInviteScreen = lazy(() => import("../screens/GameInviteScreen"));
+const GameSessionScreen = lazy(() => import("../screens/GameSessionScreen"));
+const GameWithBotScreen = lazy(() => import("../screens/GameWithBotScreen"));
+const CommunityScreen = lazy(() => import("../screens/CommunityScreen"));
+const PremiumScreen = lazy(() => import("../screens/PremiumScreen"));
+const StatsScreen = lazy(() => import("../screens/StatsScreen"));
+const PlayScreen = lazy(() => import("../screens/PlayScreen"));
+const SwipeScreen = lazy(() => import("../screens/SwipeScreen"));
+const LikedYouScreen = lazy(() => import("../screens/LikedYouScreen"));
+const VerifyHumanScreen = lazy(() => import("../screens/VerifyHumanScreen"));
+const PhoneVerificationScreen = lazy(() => import("../screens/PhoneVerificationScreen"));
 
 const Stack = createNativeStackNavigator();
 
 export default function AppStack() {
   return (
+    <Suspense fallback={<Loader /> }>
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
@@ -62,5 +64,6 @@ export default function AppStack() {
         component={PhoneVerificationScreen}
       />
     </Stack.Navigator>
+    </Suspense>
   );
 }

--- a/navigation/AuthStack.js
+++ b/navigation/AuthStack.js
@@ -1,13 +1,15 @@
 // navigation/AuthStack.js
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import LoginScreen from '../screens/auth/LoginScreen';
-import EmailAuthScreen from '../screens/EmailAuthScreen';
+import Loader from '../components/Loader';
+const LoginScreen = lazy(() => import('../screens/auth/LoginScreen'));
+const EmailAuthScreen = lazy(() => import('../screens/EmailAuthScreen'));
 
 const Stack = createNativeStackNavigator();
 
 export default function AuthStack() {
   return (
+    <Suspense fallback={<Loader /> }>
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
@@ -27,5 +29,6 @@ export default function AuthStack() {
         initialParams={{ mode: 'signup' }}
       />
     </Stack.Navigator>
+    </Suspense>
   );
 }

--- a/navigation/MainTabs.js
+++ b/navigation/MainTabs.js
@@ -1,5 +1,5 @@
 // navigation/MainTabs.js
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import {
   Ionicons,
@@ -8,10 +8,11 @@ import {
 } from '@expo/vector-icons';
 
 import { useTheme } from '../contexts/ThemeContext';
-import HomeScreen from '../screens/HomeScreen';
-import SwipeScreen from '../screens/SwipeScreen';
-import MatchesScreen from '../screens/MatchesScreen';
-import SettingsScreen from '../screens/SettingsScreen';
+import Loader from '../components/Loader';
+const HomeScreen = lazy(() => import('../screens/HomeScreen'));
+const SwipeScreen = lazy(() => import('../screens/SwipeScreen'));
+const MatchesScreen = lazy(() => import('../screens/MatchesScreen'));
+const SettingsScreen = lazy(() => import('../screens/SettingsScreen'));
 
 const Tab = createBottomTabNavigator();
 
@@ -19,6 +20,7 @@ export default function MainTabs() {
   const { darkMode, theme } = useTheme();
 
   return (
+    <Suspense fallback={<Loader /> }>
     <Tab.Navigator
         screenOptions={({ route }) => ({
           headerShown: false,
@@ -49,5 +51,6 @@ export default function MainTabs() {
       <Tab.Screen name="Matches" component={MatchesScreen} />
       <Tab.Screen name="Settings" component={SettingsScreen} />
     </Tab.Navigator>
+    </Suspense>
   );
 }

--- a/navigation/OnboardingStack.js
+++ b/navigation/OnboardingStack.js
@@ -1,12 +1,14 @@
 // navigation/OnboardingStack.js
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import OnboardingScreen from '../screens/OnboardingScreen';
+import Loader from '../components/Loader';
+const OnboardingScreen = lazy(() => import('../screens/OnboardingScreen'));
 
 const Stack = createNativeStackNavigator();
 
 export default function OnboardingStack() {
   return (
+    <Suspense fallback={<Loader /> }>
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
@@ -16,5 +18,6 @@ export default function OnboardingStack() {
     >
       <Stack.Screen name="Onboarding" component={OnboardingScreen} />
     </Stack.Navigator>
+    </Suspense>
   );
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "expo-linear-gradient": "~14.1.4",
     "expo-location": "~18.1.6",
     "expo-web-browser": "~14.2.0",
+    "expo-font": "~12.1.4",
+    "expo-splash-screen": "~0.23.4",
     "firebase": "^9.6.11",
     "lottie-ios": "^4.5.1",
     "lottie-react-native": "7.2.2",


### PR DESCRIPTION
## Summary
- lazy-load navigation screens using `React.lazy` and `Suspense`
- delay splash screen hiding until fonts, user and theme load
- enable Hermes engine in `app.json`
- enable inline requires via `metro.config.js`
- expose `loaded` in `ThemeContext`
- add `expo-font` and `expo-splash-screen` dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686758a15b14832dab7e5fe3826e5db7