### PR TITLE
Improve safe areas and fonts

### DIFF
--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import { eventImageSource } from '../utils/avatar';
 import GradientButton from './GradientButton';
+import { textStyles } from '../textStyles';
 
 const NEXT_EVENT = {
   title: 'Checkers Blitz Tournament',
@@ -62,11 +63,11 @@ const getStyles = (theme) =>
     marginRight: 12,
   },
   title: {
-    fontSize: 15,
+    ...textStyles.subtitle,
     fontWeight: 'bold',
   },
   time: {
-    fontSize: 13,
+    ...textStyles.label,
     color: theme.accent,
     marginTop: 2,
   },

--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { textStyles } from '../textStyles';
 import PropTypes from 'prop-types';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
@@ -41,10 +42,10 @@ export default function GameCard({ item, onPress, toggleFavorite, isFavorite, tr
       <View style={{ marginBottom: 10, alignItems: 'center', justifyContent: 'center' }}>
         {item.icon}
       </View>
-      <Text style={{ fontSize: 15, fontWeight: '600', textAlign: 'center' }}>
+      <Text style={[textStyles.subtitle, { textAlign: 'center' }]}>
         {item.title}
       </Text>
-      <Text style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
+      <Text style={[textStyles.label, { color: '#666', marginTop: 4 }]}>
         {item.category}
       </Text>
     </GameCardBase>

--- a/components/SafeKeyboardView.js
+++ b/components/SafeKeyboardView.js
@@ -1,8 +1,10 @@
 import { KeyboardAvoidingView, Platform } from 'react-native';
 import React from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import PropTypes from 'prop-types';
 
 export default function SafeKeyboardView({ children, style, offset }) {
+  const insets = useSafeAreaInsets();
   const verticalOffset =
     offset !== undefined
       ? offset
@@ -12,7 +14,10 @@ export default function SafeKeyboardView({ children, style, offset }) {
 
   return (
     <KeyboardAvoidingView
-      style={style}
+      style={[
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+        style,
+      ]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       keyboardVerticalOffset={verticalOffset}
     >

--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TextInput } from 'react-native';
+import { textStyles } from '../textStyles';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';
 
@@ -22,7 +23,7 @@ export default function SearchInput({ search, setSearch }) {
         placeholderTextColor={theme.textSecondary}
         value={search}
         onChangeText={setSearch}
-        style={{ fontSize: 14, color: theme.text, paddingVertical: 3 }}
+        style={[textStyles.body, { color: theme.text, paddingVertical: 3 }]}
       />
     </View>
   );

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -336,7 +336,7 @@ export default function OnboardingScreen() {
           style={{
             inputIOS: styles.input,
             inputAndroid: styles.input,
-            placeholder: { color: darkMode ? '#999' : '#aaa' },
+            placeholder: { color: theme.textSecondary },
           }}
           items={ageItems}
         />

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -230,7 +230,7 @@ const ProfileScreen = ({ navigation, route }) => {
         style={{
           inputIOS: styles.input,
           inputAndroid: styles.input,
-          placeholder: { color: '#999' },
+          placeholder: { color: theme.textSecondary },
         }}
         items={[
           { label: 'Male', value: 'Male' },

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -1,10 +1,12 @@
 // screens/SplashScreen.js
 import React, { useEffect, useRef } from 'react';
 import { Animated, Image, StatusBar, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import LottieView from 'lottie-react-native';
 import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import getStyles from '../styles';
+import { textStyles } from '../textStyles';
 import PropTypes from 'prop-types';
 
 const splashDuration = 2000;
@@ -35,27 +37,29 @@ export default function SplashScreen({ onFinish }) {
 
   return (
     <GradientBackground colors={colors} style={styles.container}>
-      <StatusBar barStyle="light-content" />
-      <Animated.View style={{ opacity: fadeAnim, alignItems: 'center' }}>
-        <Image source={require('../assets/logo.png')} style={styles.logoImage} />
-        <Text style={[styles.logoText, { color: '#fff' }]}>Pinged</Text>
-        <Text style={{ color: '#fff', fontSize: 16 }}>Find your next ping...</Text>
-        {showEgg && (
-          <Text style={{ color: '#fff', fontSize: 14, marginTop: 4 }}>
-            Lucky day! Try the secret mini-game: Strip RPS 😉
-          </Text>
-        )}
-        <LottieView
-          source={
-            showEgg
-              ? require('../assets/confetti.json')
-              : require('../assets/hearts.json')
-          }
-          autoPlay
-          loop
-          style={{ width: 200, height: 200, position: 'absolute', bottom: -20 }}
-        />
-      </Animated.View>
+      <SafeAreaView style={{ flex: 1 }}>
+        <StatusBar barStyle="light-content" />
+        <Animated.View style={{ opacity: fadeAnim, alignItems: 'center' }}>
+          <Image source={require('../assets/logo.png')} style={styles.logoImage} />
+          <Text style={[styles.logoText, { color: '#fff' }]}>Pinged</Text>
+          <Text style={[textStyles.subtitle, { color: '#fff' }]}>Find your next ping...</Text>
+          {showEgg && (
+            <Text style={[textStyles.label, { color: '#fff', marginTop: 4 }]}>
+              Lucky day! Try the secret mini-game: Strip RPS 😉
+            </Text>
+          )}
+          <LottieView
+            source={
+              showEgg
+                ? require('../assets/confetti.json')
+                : require('../assets/hearts.json')
+            }
+            autoPlay
+            loop
+            style={{ width: 200, height: 200, position: 'absolute', bottom: -20 }}
+          />
+        </Animated.View>
+      </SafeAreaView>
     </GradientBackground>
   );
 }

--- a/textStyles.js
+++ b/textStyles.js
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+import { FONT_SIZES } from './layout';
+
+export const textStyles = StyleSheet.create({
+  title: {
+    fontSize: FONT_SIZES.XL,
+    fontWeight: 'bold',
+  },
+  subtitle: {
+    fontSize: FONT_SIZES.LG,
+    fontWeight: '600',
+  },
+  label: {
+    fontSize: FONT_SIZES.SM,
+  },
+  body: {
+    fontSize: FONT_SIZES.MD,
+  },
+});


### PR DESCRIPTION
## Summary
- add shared textStyles for consistent fonts
- enforce safe area padding in SafeKeyboardView
- style GameCard, EventBanner and SearchInput using textStyles
- tweak placeholder color in Onboarding and Profile screens
- wrap SplashScreen in SafeAreaView for padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686758d74fb8832db0c812f84566facb