### PR TITLE
Add admin review flow for celebrity avatars

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -18,6 +18,7 @@ const SwipeScreen = lazy(() => import("../screens/SwipeScreen"));
 const LikedYouScreen = lazy(() => import("../screens/LikedYouScreen"));
 const VerifyHumanScreen = lazy(() => import("../screens/VerifyHumanScreen"));
 const PhoneVerificationScreen = lazy(() => import("../screens/PhoneVerificationScreen"));
+const AdminReviewScreen = lazy(() => import("../screens/AdminReviewScreen"));
 
 const Stack = createNativeStackNavigator();
 
@@ -63,6 +64,7 @@ export default function AppStack() {
         name="PhoneVerification"
         component={PhoneVerificationScreen}
       />
+      <Stack.Screen name="AdminReview" component={AdminReviewScreen} />
     </Stack.Navigator>
     </Suspense>
   );

--- a/screens/AdminReviewScreen.js
+++ b/screens/AdminReviewScreen.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+import PropTypes from 'prop-types';
+import firebase from '../firebase';
+import GradientBackground from '../components/GradientBackground';
+import ScreenContainer from '../components/ScreenContainer';
+import Header from '../components/Header';
+import GradientButton from '../components/GradientButton';
+import AvatarRing from '../components/AvatarRing';
+import Loader from '../components/Loader';
+import getStyles from '../styles';
+import { useTheme } from '../contexts/ThemeContext';
+import { HEADER_SPACING } from '../layout';
+
+export default function AdminReviewScreen() {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = firebase
+      .firestore()
+      .collection('users')
+      .where('flaggedForReview', '==', true)
+      .onSnapshot((snap) => {
+        setUsers(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+        setLoading(false);
+      });
+    return () => unsub();
+  }, []);
+
+  const approve = async (uid) => {
+    await firebase.firestore().collection('users').doc(uid).update({
+      flaggedForReview: false,
+    });
+  };
+
+  const reject = async (uid) => {
+    await firebase.firestore().collection('users').doc(uid).update({
+      flaggedForReview: false,
+    });
+  };
+
+  const renderItem = ({ item }) => (
+    <View style={{ marginBottom: 16 }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
+        <AvatarRing source={item.photoURL} size={60} />
+        <Text style={{ marginLeft: 10, color: theme.text, fontWeight: '600' }}>
+          {item.displayName || item.email}
+        </Text>
+      </View>
+      <GradientButton text="Approve" onPress={() => approve(item.id)} />
+      <GradientButton text="Reject" onPress={() => reject(item.id)} style={{ marginTop: 6 }} />
+    </View>
+  );
+
+  return (
+    <GradientBackground style={{ flex: 1 }}>
+      <ScreenContainer style={[styles.container, { paddingTop: HEADER_SPACING }] }>
+        <Header />
+        <Text style={[styles.logoText, { color: theme.text, marginBottom: 20 }]}>Flagged Users</Text>
+        {loading ? (
+          <Loader />
+        ) : (
+          <FlatList
+            data={users}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            ListEmptyComponent={<Text style={{ color: theme.textSecondary }}>No flagged users.</Text>}
+          />
+        )}
+      </ScreenContainer>
+    </GradientBackground>
+  );
+}
+
+AdminReviewScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func,
+  }),
+};

--- a/screens/EditProfileScreen.js
+++ b/screens/EditProfileScreen.js
@@ -123,10 +123,6 @@ const EditProfileScreen = ({ navigation, route }) => {
     try {
       photoURL = await uploadAvatarAsync(avatar, user.uid);
     } catch (e) {
-      if (e.message === 'celebrity-face') {
-        Toast.show({ type: 'error', text1: 'Invalid profile photo' });
-        return;
-      }
       console.warn('Avatar upload failed', e);
       Toast.show({ type: 'error', text1: 'Failed to upload photo' });
     }

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -168,10 +168,6 @@ export default function OnboardingScreen() {
             firebase.auth().currentUser.uid
           );
         } catch (e) {
-          if (e.message === 'celebrity-face') {
-            Toast.show({ type: 'error', text1: 'Invalid profile photo' });
-            return;
-          }
           throw e;
         }
       }
@@ -221,10 +217,6 @@ export default function OnboardingScreen() {
           );
           setAnswers((prev) => ({ ...prev, avatar: url }));
         } catch (e) {
-          if (e.message === 'celebrity-face') {
-            Toast.show({ type: 'error', text1: 'Invalid profile photo' });
-            return;
-          }
           console.error('Photo upload failed:', e);
           Toast.show({ type: 'error', text1: 'Failed to upload photo' });
           return;

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -126,10 +126,6 @@ const ProfileScreen = ({ navigation, route }) => {
     try {
       photoURL = await uploadAvatarAsync(avatar, user.uid);
     } catch (e) {
-      if (e.message === 'celebrity-face') {
-        Toast.show({ type: 'error', text1: 'Invalid profile photo' });
-        return;
-      }
       console.warn('Avatar upload failed', e);
       Toast.show({ type: 'error', text1: 'Failed to upload photo' });
     }

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -322,6 +322,13 @@ const SettingsScreen = ({ navigation }) => {
             onPress={toggleDevMode}
           />
 
+          {user?.isAdmin && (
+            <GradientButton
+              text="Review Flagged Users"
+              onPress={() => navigation.navigate('AdminReview')}
+            />
+          )}
+
           <GradientButton text="Log Out" onPress={handleLogout} />
         </>
       )}

--- a/utils/upload.js
+++ b/utils/upload.js
@@ -19,8 +19,17 @@ export async function uploadAvatarAsync(uri, uid) {
     const response = await fetch(uri);
     const blob = await response.blob();
 
-    if (await detectCelebrityFace(uri)) {
-      throw new Error('celebrity-face');
+    const isCelebrity = await detectCelebrityFace(uri);
+    if (isCelebrity) {
+      try {
+        await firebase
+          .firestore()
+          .collection('users')
+          .doc(uid)
+          .set({ flaggedForReview: true }, { merge: true });
+      } catch (err) {
+        console.warn('Failed to flag user for review', err);
+      }
     }
 
     // Store avatar inside a user specific folder so it matches storage.rules


### PR DESCRIPTION
## Summary
- flag celebrity-face uploads instead of rejecting them
- add AdminReviewScreen for moderating flagged users
- show admin review button in Settings
- include AdminReview in navigation
- stop blocking uploads in profile & onboarding screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686788616be0832d88fb647acd52dfd6