### PR TITLE
Add debug menu and improve logging

### DIFF
--- a/contexts/ChatContext.js
+++ b/contexts/ChatContext.js
@@ -170,7 +170,7 @@ export const ChatProvider = ({ children }) => {
     setMatches((prev) => {
       if (devMode) {
         if (!prev.find((m) => m.id === devMatch.id)) {
-          logDev('Adding dev match');
+          logDev('Chat', 'Adding dev match');
           return [...prev, devMatch];
         }
         return prev;
@@ -235,7 +235,7 @@ export const ChatProvider = ({ children }) => {
       )
     );
     if (devMode) {
-      logDev('Auto-accepting game invite');
+      logDev('Chat', 'Auto-accepting game invite');
       acceptGameInvite(matchId);
     }
   };

--- a/contexts/DevContext.js
+++ b/contexts/DevContext.js
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { logDev } from '../utils/logger';
+import { logDev, setLoggerDevMode } from '../utils/logger';
 
 const DevContext = createContext();
 
@@ -12,7 +12,7 @@ export const DevProvider = ({ children }) => {
   const toggleDevMode = () => {
     setDevMode((prev) => {
       const next = !prev;
-      logDev(`Dev mode ${next ? 'enabled' : 'disabled'}`);
+      logDev('Dev', `Dev mode ${next ? 'enabled' : 'disabled'}`);
       return next;
     });
   };
@@ -33,6 +33,10 @@ export const DevProvider = ({ children }) => {
       console.warn = origWarn;
       console.error = origError;
     };
+  }, [devMode]);
+
+  useEffect(() => {
+    setLoggerDevMode(devMode);
   }, [devMode]);
 
   const clearLogs = () => setLogs([]);

--- a/contexts/GameLimitContext.js
+++ b/contexts/GameLimitContext.js
@@ -49,7 +49,7 @@ export const GameLimitProvider = ({ children }) => {
           lastGamePlayedAt: firebase.firestore.FieldValue.serverTimestamp(),
         });
     } catch (e) {
-      logDev('Failed to update play count', e);
+      logDev('GameLimit', 'Failed to update play count', e);
     }
   };
 

--- a/firebase.js
+++ b/firebase.js
@@ -46,7 +46,7 @@ const firebaseConfig = {
 
 if (!firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);
-  logDev('Firebase config loaded', firebaseConfig);
+  logDev('Firebase', 'Firebase config loaded', firebaseConfig);
 }
 
 const auth = firebase.auth();
@@ -54,7 +54,7 @@ let firestore;
 try {
   firestore = firebase.firestore();
 } catch (e) {
-  logDev('Firestore init error', e);
+  logDev('Firebase', 'Firestore init error', e);
 }
 const storage = firebase.storage();
 const functions = firebase.functions();

--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -18,6 +18,7 @@ const SwipeScreen = lazy(() => import("../screens/SwipeScreen"));
 const LikedYouScreen = lazy(() => import("../screens/LikedYouScreen"));
 const VerifyHumanScreen = lazy(() => import("../screens/VerifyHumanScreen"));
 const PhoneVerificationScreen = lazy(() => import("../screens/PhoneVerificationScreen"));
+const DebugMenuScreen = lazy(() => import("../screens/DebugMenuScreen"));
 
 const Stack = createNativeStackNavigator();
 
@@ -46,6 +47,7 @@ export default function AppStack() {
       <Stack.Screen name="EventChat" component={ChatScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
       <Stack.Screen name="Stats" component={StatsScreen} />
+      <Stack.Screen name="DebugMenu" component={DebugMenuScreen} />
       <Stack.Screen
         name="GameWithBot"
         component={GameWithBotScreen}

--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -28,7 +28,7 @@ export default function RootNavigator() {
     const handleDeepLink = ({ url }) => {
       const parsed = Linking.parse(url);
       if (parsed.path === 'chat') {
-        logDev('Deep linking to Chat');
+        logDev('Nav', 'Deep linking to Chat');
       }
     };
     const sub = Linking.addEventListener('url', handleDeepLink);

--- a/screens/DebugMenuScreen.js
+++ b/screens/DebugMenuScreen.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import GradientBackground from '../components/GradientBackground';
+import GradientButton from '../components/GradientButton';
+import ScreenContainer from '../components/ScreenContainer';
+import Header from '../components/Header';
+import { useTheme } from '../contexts/ThemeContext';
+import { useDev } from '../contexts/DevContext';
+import { useOnboarding } from '../contexts/OnboardingContext';
+import { useUser } from '../contexts/UserContext';
+
+export default function DebugMenuScreen() {
+  const { darkMode, toggleTheme, theme } = useTheme();
+  const { devMode, toggleDevMode } = useDev();
+  const { clearOnboarding } = useOnboarding();
+  const { user } = useUser();
+
+  const clearStorage = async () => {
+    try {
+      await AsyncStorage.clear();
+    } catch (e) {
+      console.warn('Failed to clear storage', e);
+    }
+  };
+
+  const styles = {
+    content: { flexGrow: 1, justifyContent: 'center', width: '100%' },
+    label: { color: theme.textSecondary, textAlign: 'center', marginBottom: 10 },
+  };
+
+  return (
+    <GradientBackground style={{ flex: 1 }}>
+      <ScreenContainer style={{ flex: 1 }}>
+        <Header />
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text style={[styles.label]}>UID: {user?.uid || 'None'}</Text>
+          <GradientButton
+            text={`Toggle ${darkMode ? 'Light' : 'Dark'} Mode`}
+            onPress={toggleTheme}
+          />
+          <GradientButton
+            text={devMode ? 'Disable Dev Mode' : 'Enable Dev Mode'}
+            onPress={toggleDevMode}
+          />
+          <GradientButton text="Skip Onboarding" onPress={clearOnboarding} />
+          <GradientButton text="Clear AsyncStorage" onPress={clearStorage} />
+        </ScrollView>
+      </ScreenContainer>
+    </GradientBackground>
+  );
+}

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -100,7 +100,7 @@ const GameInviteScreen = ({ route, navigation }) => {
       });
 
     if (devMode) {
-      logDev('Auto-accepting invite');
+      logDev('Invite', 'Auto-accepting invite');
       toLobby();
     } else {
       setTimeout(toLobby, 2000);

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -268,7 +268,7 @@ export default function OnboardingScreen() {
       const { city, region } = geo[0];
       setAnswers((prev) => ({ ...prev, location: `${city}, ${region}` }));
     } catch (e) {
-      logDev('Geo error:', e);
+      logDev('Onboarding', 'Geo error:', e);
     }
   };
 

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -322,6 +322,13 @@ const SettingsScreen = ({ navigation }) => {
             onPress={toggleDevMode}
           />
 
+          {devMode && (
+            <GradientButton
+              text="Debug Menu"
+              onPress={() => navigation.navigate('DebugMenu')}
+            />
+          )}
+
           <GradientButton text="Log Out" onPress={handleLogout} />
         </>
       )}

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -45,7 +45,7 @@ export default function LoginScreen() {
         .auth()
         .signInWithCredential(credential)
         .then(async (res) => {
-          logDev('✅ Google login success:', res.user.uid);
+          logDev('Login', '✅ Google login success:', res.user.uid);
           const snap = await firebase
             .firestore()
             .collection('users')

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,6 +1,12 @@
-export function logDev(...args) {
-  if (__DEV__) {
+let devMode = false;
+
+export const setLoggerDevMode = (val) => {
+  devMode = val;
+};
+
+export function logDev(tag, ...args) {
+  if (__DEV__ && devMode) {
     // eslint-disable-next-line no-console
-    console.log(...args);
+    console.log(`[${tag}]`, ...args);
   }
 }

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -7,12 +7,13 @@ import { logDev } from './logger';
 export async function registerForPushNotificationsAsync() {
   try {
     if (!Constants.isDevice) {
-      logDev('Must use physical device for Push Notifications');
+      logDev('Notifications', 'Must use physical device for Push Notifications');
       return null;
     }
 
     if (Constants.appOwnership === 'expo' && Platform.OS === 'android') {
       logDev(
+        'Notifications',
         'Remote push notifications are not supported in Expo Go on Android. Use a development build.'
       );
       return null;
@@ -26,7 +27,7 @@ export async function registerForPushNotificationsAsync() {
     }
 
     if (finalStatus !== 'granted') {
-      logDev('Failed to get push token for push notification!');
+      logDev('Notifications', 'Failed to get push token for push notification!');
       return null;
     }
 


### PR DESCRIPTION
## Summary
- add `DebugMenuScreen` accessible via Settings when dev mode is enabled
- show user's UID and buttons to toggle dark mode, toggle dev mode, skip onboarding, and clear storage
- update navigation to include DebugMenu screen
- enhance `logDev` helper with devMode check and tag prefix
- wire logging helper into DevContext and update all log calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867890399a0832dbe3726f94c30e7d6