### PR TITLE
Implement remote config hook

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import NotificationCenter from './components/NotificationCenter';
 import DevBanner from './components/DevBanner';
 import Toast from 'react-native-toast-message';
 import usePushNotifications from './hooks/usePushNotifications';
+import useRemoteConfig from './hooks/useRemoteConfig';
 import RootNavigator from './navigation/RootNavigator';
 import { useTheme } from './contexts/ThemeContext';
 
@@ -23,14 +24,15 @@ export default function App() {
   const [fontsLoaded] = useFonts({});
   const { loaded: themeLoaded } = useTheme();
   const { loading: userLoading } = useUser();
+  const { loading: configLoading } = useRemoteConfig();
 
   useEffect(() => {
-    if (fontsLoaded && themeLoaded && !userLoading) {
+    if (fontsLoaded && themeLoaded && !userLoading && !configLoading) {
       SplashScreen.hideAsync();
     }
-  }, [fontsLoaded, themeLoaded, userLoading]);
+  }, [fontsLoaded, themeLoaded, userLoading, configLoading]);
 
-  if (!fontsLoaded || !themeLoaded || userLoading) {
+  if (!fontsLoaded || !themeLoaded || userLoading || configLoading) {
     return null;
   }
 

--- a/hooks/useRemoteConfig.js
+++ b/hooks/useRemoteConfig.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import firebase from '../firebase';
+import { snapshotExists } from '../utils/firestore';
+
+export default function useRemoteConfig() {
+  const [config, setConfig] = useState({
+    minVersion: null,
+    maxFreeGames: null,
+    alertMessage: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    const ref = firebase.firestore().collection('config').doc('app');
+    const unsub = ref.onSnapshot(
+      (doc) => {
+        const data = snapshotExists(doc) ? doc.data() : {};
+        setConfig({
+          minVersion: data?.minVersion ?? null,
+          maxFreeGames: data?.maxFreeGames ?? null,
+          alertMessage: data?.alertMessage ?? null,
+          loading: false,
+          error: null,
+        });
+      },
+      (err) => {
+        console.warn('Failed to load remote config', err);
+        setConfig((prev) => ({ ...prev, loading: false, error: err }));
+      }
+    );
+    return unsub;
+  }, []);
+
+  return config;
+}


### PR DESCRIPTION
## Summary
- add `useRemoteConfig` hook for fetching app config from Firestore
- load remote config in `App.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867959e2490832db61494ebe585c4ad