### PR TITLE
Enable remote config integration

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { SafeAreaView, KeyboardAvoidingView, Platform } from 'react-native';
+import { SafeAreaView, KeyboardAvoidingView, Platform, Text } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
 import { useUser } from './contexts/UserContext';
@@ -25,7 +25,17 @@ export default function App() {
   const [fontsLoaded] = useFonts({});
   const { loaded: themeLoaded } = useTheme();
   const { loading: userLoading } = useUser();
-  const { loading: configLoading } = useRemoteConfig();
+  const {
+    loading: configLoading,
+    error: configError,
+    alertMessage,
+  } = useRemoteConfig();
+
+  useEffect(() => {
+    if (alertMessage) {
+      Toast.show({ type: 'info', text1: alertMessage });
+    }
+  }, [alertMessage]);
 
   useEffect(() => {
     if (fontsLoaded && themeLoaded && !userLoading && !configLoading) {
@@ -35,6 +45,14 @@ export default function App() {
 
   if (!fontsLoaded || !themeLoaded || userLoading || configLoading) {
     return null;
+  }
+
+  if (configError) {
+    return (
+      <SafeAreaView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Failed to load configuration.</Text>
+      </SafeAreaView>
+    );
   }
 
   return (

--- a/contexts/GameLimitContext.js
+++ b/contexts/GameLimitContext.js
@@ -1,19 +1,23 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useUser } from './UserContext';
 import { useDev } from './DevContext';
+import useRemoteConfig from '../hooks/useRemoteConfig';
 import firebase from '../firebase';
 import { logDev } from '../utils/logger';
 
 const GameLimitContext = createContext();
-const DAILY_LIMIT = 1;
+const DEFAULT_LIMIT = 1;
 
 export const GameLimitProvider = ({ children }) => {
   const { user } = useUser();
   const { devMode } = useDev();
+  const { maxFreeGames } = useRemoteConfig();
   const isPremium = !!user?.isPremium;
-  const [gamesLeft, setGamesLeft] = useState(isPremium ? Infinity : DAILY_LIMIT);
+  const limit = maxFreeGames ?? DEFAULT_LIMIT;
+  const [gamesLeft, setGamesLeft] = useState(isPremium ? Infinity : limit);
 
   useEffect(() => {
+    const dailyLimit = maxFreeGames ?? DEFAULT_LIMIT;
     if (isPremium || devMode) {
       setGamesLeft(Infinity);
       return;
@@ -22,11 +26,11 @@ export const GameLimitProvider = ({ children }) => {
       (user?.lastGamePlayedAt ? new Date(user.lastGamePlayedAt) : null);
     const today = new Date().toDateString();
     if (last && last.toDateString() === today) {
-      setGamesLeft(Math.max(DAILY_LIMIT - (user.dailyPlayCount || 0), 0));
+      setGamesLeft(Math.max(dailyLimit - (user.dailyPlayCount || 0), 0));
     } else {
-      setGamesLeft(DAILY_LIMIT);
+      setGamesLeft(dailyLimit);
     }
-  }, [isPremium, devMode, user?.dailyPlayCount, user?.lastGamePlayedAt]);
+  }, [isPremium, devMode, user?.dailyPlayCount, user?.lastGamePlayedAt, maxFreeGames]);
 
   const recordGamePlayed = async () => {
     if (isPremium || devMode || !user?.uid) return;
@@ -38,7 +42,8 @@ export const GameLimitProvider = ({ children }) => {
     if (last && last.toDateString() === today.toDateString()) {
       count = (user.dailyPlayCount || 0) + 1;
     }
-    setGamesLeft(Math.max(DAILY_LIMIT - count, 0));
+    const dailyLimit = maxFreeGames ?? DEFAULT_LIMIT;
+    setGamesLeft(Math.max(dailyLimit - count, 0));
     try {
       await firebase
         .firestore()


### PR DESCRIPTION
## Summary
- display remote alert messages via toast
- fail gracefully if remote config cannot load
- apply `maxFreeGames` from Firestore in game limit context

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68679ac5f1f8832d8aa11cf481296a91