### PR TITLE
Fix theme context usage in App

### DIFF
--- a/App.js
+++ b/App.js
@@ -20,7 +20,7 @@ const ThemedNotificationCenter = () => {
   return <NotificationCenter color={theme.accent} />;
 };
 
-export default function App() {
+const AppInner = () => {
   usePushNotifications();
   const [fontsLoaded] = useFonts({});
   const { loaded: themeLoaded } = useTheme();
@@ -63,17 +63,23 @@ export default function App() {
         keyboardVerticalOffset={60}
       >
         <ErrorBoundary>
-          <Providers>
-            <NavigationContainer>
-              <RootNavigator />
-              <DevBanner />
-            </NavigationContainer>
-            <ThemedNotificationCenter />
-            <LoadingOverlay />
-            <Toast />
-          </Providers>
+          <NavigationContainer>
+            <RootNavigator />
+            <DevBanner />
+          </NavigationContainer>
+          <ThemedNotificationCenter />
+          <LoadingOverlay />
+          <Toast />
         </ErrorBoundary>
       </KeyboardAvoidingView>
     </SafeAreaView>
+  );
+};
+
+export default function App() {
+  return (
+    <Providers>
+      <AppInner />
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary
- delay loading App providers until ThemeContext is available
- wrap inner App component with `Providers`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ce264ed4832dad647d1d63a33735