### PR TITLE
Add daily streak reward modal

### DIFF
--- a/components/StreakRewardModal.js
+++ b/components/StreakRewardModal.js
@@ -1,0 +1,97 @@
+import React, { useEffect } from 'react';
+import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
+import { BlurView } from 'expo-blur';
+import LottieView from 'lottie-react-native';
+import * as Haptics from 'expo-haptics';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function StreakRewardModal({ visible, streak, onClose }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  useEffect(() => {
+    if (visible) {
+      Haptics.notificationAsync(
+        Haptics.NotificationFeedbackType.Success
+      ).catch(() => {});
+    }
+  }, [visible]);
+  return (
+    <Modal animationType="fade" transparent visible={visible} onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={styles.animationContainer} pointerEvents="none">
+          <LottieView
+            source={require('../assets/confetti.json')}
+            autoPlay
+            loop={false}
+            style={styles.animation}
+          />
+        </View>
+        <BlurView intensity={80} tint="dark" style={styles.card}>
+          <Text style={styles.title}>Streak Reward!</Text>
+          <Text style={styles.text}>{`You reached a ${streak}-day streak!`}</Text>
+          <Pressable onPress={onClose} android_ripple={{ color: theme.text }} style={styles.closeBtn}>
+            <Text style={styles.btnText}>Awesome!</Text>
+          </Pressable>
+        </BlurView>
+      </View>
+    </Modal>
+  );
+}
+
+StreakRewardModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  streak: PropTypes.number.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: '#0009',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    animationContainer: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    animation: { width: '100%', height: '100%' },
+    card: {
+      padding: 24,
+      borderRadius: 20,
+      width: 260,
+      alignItems: 'center',
+      overflow: 'hidden',
+      backgroundColor: theme.card,
+    },
+    title: {
+      fontSize: 22,
+      fontWeight: 'bold',
+      color: theme.text,
+      marginBottom: 6,
+      textAlign: 'center',
+    },
+    text: {
+      fontSize: 16,
+      color: theme.text,
+      marginBottom: 20,
+      textAlign: 'center',
+    },
+    closeBtn: {
+      backgroundColor: theme.accent,
+      paddingVertical: 10,
+      paddingHorizontal: 32,
+      borderRadius: 16,
+      width: '100%',
+      overflow: 'hidden',
+    },
+    btnText: {
+      color: '#fff',
+      fontWeight: 'bold',
+      fontSize: 16,
+      textAlign: 'center',
+    },
+  });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -13,6 +13,7 @@ import Header from '../components/Header';
 import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
+import StreakRewardModal from '../components/StreakRewardModal';
 import { useGameLimit } from '../contexts/GameLimitContext';
 import { HEADER_SPACING } from '../layout';
 
@@ -42,7 +43,7 @@ const aiGameMap = allGames.reduce((acc, g) => {
 const CARD_SIZE = 140;
 const HomeScreen = ({ navigation }) => {
   const { theme } = useTheme();
-  const { user, loginBonus } = useUser();
+  const { user, loginBonus, streakReward, dismissStreakReward } = useUser();
   const isPremiumUser = !!user?.isPremium;
   const { gamesLeft } = useGameLimit();
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
@@ -215,6 +216,11 @@ const HomeScreen = ({ navigation }) => {
             </View>
           </View>
         </Modal>
+        <StreakRewardModal
+          visible={streakReward}
+          streak={user?.streak || 0}
+          onClose={dismissStreakReward}
+        />
       </ScreenContainer>
     </GradientBackground>
   );


### PR DESCRIPTION
## Summary
- reward 7-day streak completions
- show modal when the streak reward triggers
- persist `streakRewardedAt` to avoid duplicate rewards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b327885ec832da4f3cfd3c2feadee