### PR TITLE
Add Google fonts and use in screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,12 @@ import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaView, KeyboardAvoidingView, Platform, Text } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
+import {
+  Inter_400Regular,
+  Inter_500Medium,
+  Inter_700Bold,
+} from '@expo-google-fonts/inter';
+import { Roboto_700Bold } from '@expo-google-fonts/roboto';
 import { useUser } from './contexts/UserContext';
 import Providers from './contexts/Providers';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -22,7 +28,12 @@ const ThemedNotificationCenter = () => {
 
 const AppInner = () => {
   usePushNotifications();
-  const [fontsLoaded] = useFonts({});
+  const [fontsLoaded] = useFonts({
+    Inter_400Regular,
+    Inter_500Medium,
+    Inter_700Bold,
+    Roboto_700Bold,
+  });
   const { loaded: themeLoaded } = useTheme();
   const { loading: userLoading } = useUser();
   const {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "expo-updates": "~0.28.15",
     "expo-blur": "~14.1.5",
     "prop-types": "^15.8.1",
-    "react-native-svg": "^15.2.0"
+    "react-native-svg": "^15.2.0",
+    "@expo-google-fonts/inter": "^0.2.2",
+    "@expo-google-fonts/roboto": "^0.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -29,6 +29,7 @@ import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
 import { HEADER_SPACING, FONT_SIZES, BUTTON_STYLE } from '../layout';
 import * as Haptics from 'expo-haptics';
 import EmptyState from '../components/EmptyState';
+import { FONT_FAMILY } from '../textStyles';
 
 
 const FILTERS = ['All', 'Tonight', 'Flirty', 'Tournaments'];
@@ -439,7 +440,7 @@ const getStyles = (theme, skeletonColor) =>
   StyleSheet.create({
   header: {
     fontSize: FONT_SIZES.XL,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.heading,
     textAlign: 'center',
     marginVertical: 16,
   },
@@ -458,12 +459,13 @@ const getStyles = (theme, skeletonColor) =>
   },
   bannerTitle: {
     color: theme.accent,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.bold,
     fontSize: FONT_SIZES.MD
   },
   bannerText: {
     fontSize: FONT_SIZES.SM,
-    color: '#555'
+    color: '#555',
+    fontFamily: FONT_FAMILY.regular,
   },
   flyerList: {
     paddingHorizontal: 16,
@@ -485,7 +487,8 @@ const getStyles = (theme, skeletonColor) =>
   badge: {
     fontSize: FONT_SIZES.SM - 2,
     color: '#28c76f',
-    marginTop: 4
+    marginTop: 4,
+    fontFamily: FONT_FAMILY.medium,
   },
   badgePopup: {
     backgroundColor: '#fff',
@@ -500,12 +503,13 @@ const getStyles = (theme, skeletonColor) =>
     marginBottom: 6
   },
   badgeTitle: {
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.bold,
     fontSize: FONT_SIZES.MD
   },
   badgeText: {
     fontSize: FONT_SIZES.SM - 1,
-    color: '#666'
+    color: '#666',
+    fontFamily: FONT_FAMILY.regular,
   },
   postCard: {
     borderRadius: 12,
@@ -516,7 +520,7 @@ const getStyles = (theme, skeletonColor) =>
   },
   postTitle: {
     fontSize: FONT_SIZES.MD - 1,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.bold,
     marginBottom: 2
   },
   postTime: {
@@ -526,7 +530,8 @@ const getStyles = (theme, skeletonColor) =>
   },
   postDesc: {
     fontSize: FONT_SIZES.SM - 1,
-    color: '#666'
+    color: '#666',
+    fontFamily: FONT_FAMILY.regular,
   },
   skelLine: {
     height: 12,
@@ -558,7 +563,7 @@ const getStyles = (theme, skeletonColor) =>
     elevation: 10
   },
   modalTitle: {
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.bold,
     fontSize: 16,
     marginBottom: 12
   },
@@ -568,7 +573,8 @@ const getStyles = (theme, skeletonColor) =>
     borderRadius: 10,
     padding: 10,
     fontSize: 13,
-    marginBottom: 10
+    marginBottom: 10,
+    fontFamily: FONT_FAMILY.regular,
   },
   fab: {
     position: 'absolute',

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -29,6 +29,7 @@ import { eventImageSource } from '../utils/avatar';
 import PremiumBanner from '../components/PremiumBanner';
 import ActiveGamesPreview from '../components/ActiveGamesPreview';
 import MatchesPreview from '../components/MatchesPreview';
+import { FONT_FAMILY } from '../textStyles';
 
 // Map app game IDs to boardgame registry keys for AI play
 const aiGameMap = allGames.reduce((acc, g) => {
@@ -235,7 +236,7 @@ const getStyles = (theme) =>
     },
     welcome: {
       fontSize: 18,
-      fontWeight: 'bold',
+      fontFamily: FONT_FAMILY.heading,
       alignSelf: 'center',
       marginTop: 20,
       marginBottom: 8,
@@ -248,7 +249,7 @@ const getStyles = (theme) =>
     },
     sectionTitle: {
       fontSize: 16,
-      fontWeight: '700',
+      fontFamily: FONT_FAMILY.bold,
       alignSelf: 'center',
       marginBottom: 8,
       color: theme.accent,
@@ -264,11 +265,12 @@ const getStyles = (theme) =>
     },
     levelText: {
       fontSize: 16,
-      fontWeight: '600',
+      fontFamily: FONT_FAMILY.bold,
       marginBottom: 4,
     },
     streakLabel: {
       fontSize: 12,
+      fontFamily: FONT_FAMILY.regular,
       marginTop: 8,
       marginBottom: 2,
     },
@@ -298,12 +300,12 @@ const getStyles = (theme) =>
     },
     fullTileText: {
       fontSize: 16,
-      fontWeight: '600',
+      fontFamily: FONT_FAMILY.bold,
       marginLeft: 12,
     },
     tileText: {
       fontSize: 14,
-      fontWeight: '500',
+      fontFamily: FONT_FAMILY.medium,
     },
     modalBackdrop: {
       flex: 1,
@@ -340,7 +342,7 @@ const getStyles = (theme) =>
     },
     eventTitle: {
       fontSize: 14,
-      fontWeight: 'bold',
+      fontFamily: FONT_FAMILY.bold,
     },
     eventTime: {
       fontSize: 12,
@@ -349,6 +351,7 @@ const getStyles = (theme) =>
     },
     eventDesc: {
       fontSize: 12,
+      fontFamily: FONT_FAMILY.regular,
     },
     featuredEventCard: {
       flexDirection: 'row',
@@ -381,7 +384,7 @@ const getStyles = (theme) =>
     },
     postTitle: {
       fontSize: 14,
-      fontWeight: 'bold',
+      fontFamily: FONT_FAMILY.bold,
     },
     postTime: {
       fontSize: 12,
@@ -390,6 +393,7 @@ const getStyles = (theme) =>
     },
     postDesc: {
       fontSize: 12,
+      fontFamily: FONT_FAMILY.regular,
     },
     communityBoard: {
       width: '100%',

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -41,6 +41,7 @@ import EmptyState from '../components/EmptyState';
 import { useSound } from '../contexts/SoundContext';
 import { useFilters } from '../contexts/FilterContext';
 import PropTypes from 'prop-types';
+import { FONT_FAMILY } from '../textStyles';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -765,6 +766,7 @@ const getStyles = (theme) =>
     borderRadius: 4,
     marginBottom: 4,
     fontSize: 12,
+    fontFamily: FONT_FAMILY.medium,
   },
   nameRow: {
     flexDirection: 'row',
@@ -772,7 +774,7 @@ const getStyles = (theme) =>
   },
   nameText: {
     fontSize: 24,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.heading,
     color: '#fff',
   },
   expandIcon: {
@@ -787,6 +789,7 @@ const getStyles = (theme) =>
   },
   noMoreText: {
     fontSize: 20,
+    fontFamily: FONT_FAMILY.bold,
     color: '#999',
     textAlign: 'center',
   },
@@ -794,6 +797,7 @@ const getStyles = (theme) =>
     color: theme.accent,
     textDecorationLine: 'underline',
     fontSize: 16,
+    fontFamily: FONT_FAMILY.medium,
   },
   buttonRow: {
     position: 'absolute',
@@ -833,7 +837,7 @@ const getStyles = (theme) =>
   },
   badgeText: {
     fontSize: 32,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.bold,
     color: '#fff',
   },
   likeText: {
@@ -885,12 +889,13 @@ const getStyles = (theme) =>
   },
   matchText: {
     fontSize: 22,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.bold,
     color: '#fff',
     marginTop: 20,
   },
   suggestText: {
     fontSize: 14,
+    fontFamily: FONT_FAMILY.regular,
     color: '#fff',
     marginTop: 6,
     textAlign: 'center',

--- a/textStyles.js
+++ b/textStyles.js
@@ -1,19 +1,28 @@
 import { StyleSheet } from 'react-native';
 import { FONT_SIZES } from './layout';
 
+export const FONT_FAMILY = {
+  regular: 'Inter_400Regular',
+  medium: 'Inter_500Medium',
+  bold: 'Inter_700Bold',
+  heading: 'Roboto_700Bold',
+};
+
 export const textStyles = StyleSheet.create({
   title: {
     fontSize: FONT_SIZES.XL,
-    fontWeight: 'bold',
+    fontFamily: FONT_FAMILY.heading,
   },
   subtitle: {
     fontSize: FONT_SIZES.LG,
-    fontWeight: '600',
+    fontFamily: FONT_FAMILY.bold,
   },
   label: {
     fontSize: FONT_SIZES.SM,
+    fontFamily: FONT_FAMILY.medium,
   },
   body: {
     fontSize: FONT_SIZES.MD,
+    fontFamily: FONT_FAMILY.regular,
   },
 });


### PR DESCRIPTION
## Summary
- load Inter and Roboto fonts with `useFonts`
- define reusable `FONT_FAMILY` constants
- apply fonts on Home, Swipe and Community screens
- add google font packages to `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b33b4d530832db82682badee38b8f