### PR TITLE
Refactor gradient theme

### DIFF
--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -8,7 +8,8 @@ import getStyles from '../styles';
 export default function GradientBackground({ children, colors, style }) {
   const { theme } = useTheme();
   const styles = getStyles(theme);
-  const gradientColors = colors || [theme.gradientStart, theme.gradientEnd];
+  const gradientColors =
+    colors || theme.gradient || [theme.gradientStart, theme.gradientEnd];
 
   return (
     <LinearGradient colors={gradientColors} style={[{ flex: 1 }, style]}>

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -77,7 +77,7 @@ export default function GradientButton({
         disabled={disabled}
       >
         <AnimatedLinearGradient
-          colors={[theme.gradientStart, theme.gradientEnd]}
+          colors={theme.gradient}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 0 }}
           style={[
@@ -96,7 +96,7 @@ export default function GradientButton({
         >
           <AnimatedLinearGradient
             pointerEvents="none"
-            colors={[theme.gradientStart, theme.gradientEnd]}
+            colors={theme.gradient}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 0 }}
             style={{

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -453,7 +453,7 @@ export default function OnboardingScreen() {
     );
   };
   return (
-    <GradientBackground colors={[styles.gradientStart, styles.gradientEnd]} style={styles.container}>
+    <GradientBackground style={styles.container}>
       <Header showLogoOnly />
       <SafeKeyboardView style={styles.inner}>
         <Text style={styles.progressText}>{`Step ${step + 1} of ${questions.length}`}</Text>
@@ -645,8 +645,6 @@ const getStyles = (theme) => {
       fontSize: FONT_SIZES.MD,
       textDecorationLine: 'underline',
     },
-    gradientStart: theme.gradientStart,
-    gradientEnd: theme.gradientEnd,
   });
 };
 

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -28,7 +28,7 @@ export default function SplashScreen({ onFinish }) {
   const showEgg = useRef(Math.random() < 0.02).current;
   const { darkMode, theme } = useTheme();
   const styles = getStyles(theme);
-  const colors = [theme.gradientStart, theme.gradientEnd];
+  const colors = theme.gradient;
 
   useEffect(() => {
     const timeout = setTimeout(onFinish, splashDuration);

--- a/theme.js
+++ b/theme.js
@@ -4,8 +4,9 @@ export const lightTheme = {
   text: '#222222',
   textSecondary: '#666666',
   accent: '#FF75B5',
-  gradientStart: '#FF75B5',
-  gradientEnd: '#FF9A75',
+  gradientStart: '#8B5CF6',
+  gradientEnd: '#EC4899',
+  gradient: ['#8B5CF6', '#EC4899'],
   headerBackground: '#ffffff',
 };
 
@@ -15,8 +16,9 @@ export const darkTheme = {
   text: '#EDEDED',
   textSecondary: '#A0A0A0',
   accent: '#FF75B5',
-  gradientStart: '#FF75B5',
-  gradientEnd: '#FF9A75',
+  gradientStart: '#8B5CF6',
+  gradientEnd: '#EC4899',
+  gradient: ['#8B5CF6', '#EC4899'],
   headerBackground: 'rgba(255,255,255,0.05)',
 };
 


### PR DESCRIPTION
## Summary
- modernize theme gradients
- update `GradientBackground` and `GradientButton` to read the new gradient array
- rely on theme gradient in `SplashScreen` and `OnboardingScreen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b33b5a694832d8498bbf52fcfd322