### PR TITLE
Refactor spacing and lighten card shadows

### DIFF
--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Animated, TouchableOpacity, Dimensions } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
+import { SPACING } from '../layout';
 
 const CARD_WIDTH = Dimensions.get('window').width * 0.42;
 
@@ -10,18 +11,18 @@ const GameCardBase = ({ children, scale, onPress, onPressIn, onPressOut }) => (
     <TouchableOpacity
       style={{
         width: CARD_WIDTH,
-        marginHorizontal: 8,
-        marginBottom: 20,
+        marginHorizontal: SPACING.SM,
+        marginBottom: SPACING.XL,
         backgroundColor: '#fff',
         borderRadius: 16,
-        paddingVertical: 20,
+        paddingVertical: SPACING.XL,
         alignItems: 'center',
         justifyContent: 'center',
         shadowColor: '#000',
-        shadowOpacity: 0.08,
+        shadowOpacity: 0.05,
         shadowOffset: { width: 0, height: 4 },
         shadowRadius: 6,
-        elevation: 4,
+        elevation: 2,
         position: 'relative',
       }}
       onPressIn={onPressIn}

--- a/layout.js
+++ b/layout.js
@@ -13,6 +13,15 @@ export const BUTTON_STYLE = {
   borderRadius: 8,
 };
 
+export const SPACING = {
+  XS: 4,
+  SM: 8,
+  MD: 12,
+  LG: 16,
+  XL: 20,
+  XXL: 24,
+};
+
 export const HEADER_HEIGHT = 60;
 export const HEADER_SPACING = Platform.OS === 'ios'
   ? HEADER_HEIGHT + 40

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -14,7 +14,7 @@ import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
-import { HEADER_SPACING } from '../layout';
+import { HEADER_SPACING, SPACING } from '../layout';
 
 import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
@@ -230,67 +230,67 @@ const getStyles = (theme) =>
   StyleSheet.create({
     container: {
       alignItems: 'stretch',
-      paddingHorizontal: 16,
-      paddingVertical: 20,
+      paddingHorizontal: SPACING.LG,
+      paddingVertical: SPACING.XL,
     },
     welcome: {
       fontSize: 18,
       fontWeight: 'bold',
       alignSelf: 'center',
-      marginTop: 20,
-      marginBottom: 8,
+      marginTop: SPACING.XL,
+      marginBottom: SPACING.SM,
     },
     bonus: {
       fontSize: 14,
       color: '#2ecc71',
-      marginBottom: 8,
+      marginBottom: SPACING.SM,
       alignSelf: 'center',
     },
     sectionTitle: {
       fontSize: 16,
       fontWeight: '700',
       alignSelf: 'center',
-      marginBottom: 8,
+      marginBottom: SPACING.SM,
       color: theme.accent,
     },
     progressCard: {
-      marginBottom: 16,
+      marginBottom: SPACING.LG,
       alignSelf: 'stretch',
     },
     group: {
-      marginBottom: 24,
+      marginBottom: SPACING.XXL,
       alignItems: 'stretch',
       width: '100%',
     },
     levelText: {
       fontSize: 16,
       fontWeight: '600',
-      marginBottom: 4,
+      marginBottom: SPACING.XS,
     },
     streakLabel: {
       fontSize: 12,
-      marginTop: 8,
+      marginTop: SPACING.SM,
       marginBottom: 2,
     },
     carousel: {
-      paddingHorizontal: 16,
-      marginBottom: 12,
+      paddingHorizontal: SPACING.LG,
+      marginBottom: SPACING.MD,
     },
     tile: {
       width: CARD_SIZE,
       height: 100,
       justifyContent: 'center',
       alignItems: 'center',
-      marginRight: 12,
+      marginRight: SPACING.MD,
     },
     fullTile: {
       alignSelf: 'stretch',
       flexDirection: 'row',
       alignItems: 'center',
       paddingVertical: 18,
-      paddingHorizontal: 16,
+      paddingHorizontal: SPACING.LG,
       borderRadius: 12,
-      marginBottom: 12,
+      marginBottom: SPACING.MD,
     },
     tileEmoji: {
       fontSize: 28,
@@ -299,7 +299,7 @@ const getStyles = (theme) =>
     fullTileText: {
       fontSize: 16,
       fontWeight: '600',
-      marginLeft: 12,
+      marginLeft: SPACING.MD,
     },
     tileText: {
       fontSize: 14,
@@ -314,7 +314,7 @@ const getStyles = (theme) =>
     modalCard: {
       backgroundColor: '#fff',
       borderRadius: 12,
-      padding: 20,
+      padding: SPACING.XL,
       width: '80%',
       alignItems: 'center',
     },
@@ -328,9 +328,9 @@ const getStyles = (theme) =>
     eventCard: {
       flexDirection: 'row',
       borderRadius: 12,
-      padding: 12,
+      padding: SPACING.MD,
       width: '100%',
-      marginRight: 12,
+      marginRight: SPACING.MD,
       alignItems: 'center',
     },
     eventImage: {
@@ -354,14 +354,14 @@ const getStyles = (theme) =>
       flexDirection: 'row',
       alignItems: 'center',
       borderRadius: 12,
-      padding: 12,
-      marginBottom: 12,
+      padding: SPACING.MD,
+      marginBottom: SPACING.MD,
       alignSelf: 'stretch',
       shadowColor: '#000',
-      shadowOpacity: 0.1,
+      shadowOpacity: 0.06,
       shadowOffset: { width: 0, height: 2 },
       shadowRadius: 4,
-      elevation: 3,
+      elevation: 2,
     },
     featuredEventContent: {
       flex: 1,
@@ -369,15 +369,15 @@ const getStyles = (theme) =>
     },
     swipeButtonContainer: {
       position: 'absolute',
-      left: 20,
-      right: 20,
-      bottom: 20,
+      left: SPACING.XL,
+      right: SPACING.XL,
+      bottom: SPACING.XL,
     },
     postCardPreview: {
       borderRadius: 12,
-      padding: 12,
+      padding: SPACING.MD,
       alignSelf: 'stretch',
-      marginBottom: 12,
+      marginBottom: SPACING.MD,
     },
     postTitle: {
       fontSize: 14,
@@ -393,17 +393,17 @@ const getStyles = (theme) =>
     },
     communityBoard: {
       width: '100%',
-      marginBottom: 24,
+      marginBottom: SPACING.XXL,
     },
     boardBackground: {
       backgroundColor: '#deb887',
-      padding: 12,
+      padding: SPACING.MD,
       borderRadius: 12,
       borderWidth: 2,
       borderColor: '#caa76b',
     },
     noteWrapper: {
-      marginBottom: 24,
+      marginBottom: SPACING.XXL,
       alignItems: 'center',
       width: '100%',
     },
@@ -412,10 +412,10 @@ const getStyles = (theme) =>
       borderWidth: 1,
       borderColor: '#e0d4b9',
       shadowColor: '#000',
-      shadowOpacity: 0.25,
+      shadowOpacity: 0.15,
       shadowOffset: { width: 0, height: 2 },
       shadowRadius: 4,
-      elevation: 3,
+      elevation: 2,
     },
     rotateLeft: {
       transform: [{ rotate: '-2deg' }],

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -17,7 +17,7 @@ import GradientButton from '../components/GradientButton';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
-import { HEADER_SPACING } from '../layout';
+import { HEADER_SPACING, SPACING } from '../layout';
 import { useNotification } from '../contexts/NotificationContext';
 import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
@@ -732,9 +732,9 @@ const getStyles = (theme) =>
     borderRadius: 20,
     overflow: 'hidden',
     backgroundColor: '#fff',
-    elevation: 8,
+    elevation: 4,
     shadowColor: '#000',
-    shadowOpacity: 0.2,
+    shadowOpacity: 0.1,
     shadowRadius: 8,
     shadowOffset: { width: 0, height: 4 },
   },
@@ -753,7 +753,7 @@ const getStyles = (theme) =>
     bottom: BUTTON_ROW_BOTTOM + 80,
     left: 0,
     right: 0,
-    paddingHorizontal: 20,
+    paddingHorizontal: SPACING.XL,
     paddingVertical: 10,
   },
   distanceBadge: {
@@ -802,7 +802,7 @@ const getStyles = (theme) =>
     right: 0,
     flexDirection: 'row',
     justifyContent: 'space-evenly',
-    paddingHorizontal: 20,
+    paddingHorizontal: SPACING.XL,
   },
   circleButton: {
     width: 60,
@@ -810,7 +810,7 @@ const getStyles = (theme) =>
     borderRadius: 30,
     alignItems: 'center',
     justifyContent: 'center',
-    elevation: 4,
+    elevation: 2,
   },
   badge: {
     position: 'absolute',
@@ -820,13 +820,13 @@ const getStyles = (theme) =>
     borderRadius: 8,
   },
   likeBadge: {
-    left: 20,
+    left: SPACING.XL,
     borderColor: '#4ade80',
     transform: [{ rotate: '-30deg' }],
     backgroundColor: 'rgba(74, 222, 128, 0.2)',
   },
   nopeBadge: {
-    right: 20,
+    right: SPACING.XL,
     borderColor: '#f87171',
     transform: [{ rotate: '30deg' }],
     backgroundColor: 'rgba(248, 113, 113, 0.2)',
@@ -868,7 +868,7 @@ const getStyles = (theme) =>
   },
   detailsContainer: {
     backgroundColor: theme.card,
-    padding: 20,
+    padding: SPACING.XL,
     borderRadius: 12,
     width: '80%',
   },
@@ -887,14 +887,14 @@ const getStyles = (theme) =>
     fontSize: 22,
     fontWeight: 'bold',
     color: '#fff',
-    marginTop: 20,
+    marginTop: SPACING.XL,
   },
   suggestText: {
     fontSize: 14,
     color: '#fff',
     marginTop: 6,
     textAlign: 'center',
-    paddingHorizontal: 20,
+    paddingHorizontal: SPACING.XL,
   },
 });
 


### PR DESCRIPTION
## Summary
- define `SPACING` constants
- use spacing constants in `HomeScreen` and `SwipeScreen`
- tone down shadow and elevation styles
- update `GameCardBase` to use new spacing constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b33b70ed0832db86da22275cb3756