### PR TITLE
Refine home and community layouts

### DIFF
--- a/components/EventFlyer.js
+++ b/components/EventFlyer.js
@@ -61,7 +61,7 @@ const getStyles = (theme, darkMode) =>
       shadowOffset: { width: 0, height: 3 },
       shadowRadius: 5,
       elevation: 4,
-      transform: [{ rotate: '-2deg' }],
+      transform: [{ rotate: '-1deg' }],
     },
     image: {
       width: 70,

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -270,24 +270,26 @@ const CommunityScreen = () => {
       {/* Floating actions */}
       {showFabMenu && (
         <View style={local.fabMenu}>
-          <TouchableOpacity
+          <GradientButton
+            text="Host Event"
             onPress={() => {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
               setShowHostModal(true);
               setShowFabMenu(false);
             }}
-          >
-            <Text style={local.fabItem}>🎤 Host Event</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            width={140}
+            marginVertical={6}
+          />
+          <GradientButton
+            text="New Post"
             onPress={() => {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
               setShowPostModal(true);
               setShowFabMenu(false);
             }}
-          >
-            <Text style={local.fabItem}>✏️ New Post</Text>
-          </TouchableOpacity>
+            width={140}
+            marginVertical={6}
+          />
         </View>
       )}
       <TouchableOpacity
@@ -441,13 +443,13 @@ const getStyles = (theme, skeletonColor) =>
     fontSize: FONT_SIZES.XL,
     fontWeight: 'bold',
     textAlign: 'center',
-    marginVertical: 16,
+    marginVertical: 20,
   },
   banner: {
     marginHorizontal: 16,
     borderRadius: 16,
     padding: 16,
-    marginBottom: 20,
+    marginBottom: 28,
     ...CARD_STYLE,
   },
   bannerImage: {
@@ -473,7 +475,7 @@ const getStyles = (theme, skeletonColor) =>
     alignItems: 'center',
     borderRadius: 16,
     padding: 16,
-    marginBottom: 16,
+    marginBottom: 20,
     ...CARD_STYLE,
   },
   flyerImage: {
@@ -511,7 +513,7 @@ const getStyles = (theme, skeletonColor) =>
     borderRadius: 12,
     padding: 14,
     marginHorizontal: 16,
-    marginBottom: 12,
+    marginBottom: 16,
     ...CARD_STYLE,
   },
   postTitle: {
@@ -591,14 +593,11 @@ const getStyles = (theme, skeletonColor) =>
     position: 'absolute',
     bottom: 88,
     right: 20,
-    backgroundColor: theme.accent,
-    borderRadius: 8,
+    backgroundColor: theme.card,
+    borderRadius: 12,
     padding: 8,
+    elevation: 5,
   },
-  fabItem: {
-    color: '#fff',
-    paddingVertical: 6,
-  }
 });
 
 CommunityScreen.propTypes = {};

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -254,11 +254,11 @@ const getStyles = (theme) =>
       color: theme.accent,
     },
     progressCard: {
-      marginBottom: 16,
+      marginBottom: 20,
       alignSelf: 'stretch',
     },
     group: {
-      marginBottom: 24,
+      marginBottom: 32,
       alignItems: 'stretch',
       width: '100%',
     },
@@ -393,17 +393,17 @@ const getStyles = (theme) =>
     },
     communityBoard: {
       width: '100%',
-      marginBottom: 24,
+      marginBottom: 32,
     },
     boardBackground: {
       backgroundColor: '#deb887',
-      padding: 12,
+      padding: 16,
       borderRadius: 12,
       borderWidth: 2,
       borderColor: '#caa76b',
     },
     noteWrapper: {
-      marginBottom: 24,
+      marginBottom: 32,
       alignItems: 'center',
       width: '100%',
     },
@@ -418,10 +418,10 @@ const getStyles = (theme) =>
       elevation: 3,
     },
     rotateLeft: {
-      transform: [{ rotate: '-2deg' }],
+      transform: [{ rotate: '-1deg' }],
     },
     rotateRight: {
-      transform: [{ rotate: '2deg' }],
+      transform: [{ rotate: '1deg' }],
     },
     pin: {
       position: 'absolute',


### PR DESCRIPTION
## Summary
- soften EventFlyer tilt
- give HomeScreen groups more spacing
- adjust community board note rotations
- use GradientButton for CommunityScreen fab menu
- add room between CommunityScreen sections

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b33b7a0f0832d9628f2883f6959ec