### PR TITLE
Add profile boost modal

### DIFF
--- a/components/BoostModal.js
+++ b/components/BoostModal.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+import GradientButton from './GradientButton';
+
+export default function BoostModal({
+  visible,
+  trialUsed = false,
+  onActivate,
+  onUpgrade,
+  onClose,
+}) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  if (!visible) return null;
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Boost Your Profile</Text>
+          <Text style={styles.desc}>
+            Boosting puts you at the top of the deck for 30 minutes.
+          </Text>
+          {!trialUsed && (
+            <Text style={styles.desc}>Enjoy one free boost to try it out!</Text>
+          )}
+          <GradientButton
+            text={trialUsed ? 'Upgrade to Premium' : 'Activate Free Boost'}
+            onPress={trialUsed ? onUpgrade : onActivate}
+            style={{ marginTop: 12 }}
+          />
+          <TouchableOpacity onPress={onClose} style={{ marginTop: 12 }}>
+            <Text style={styles.cancel}>Maybe Later</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+BoostModal.propTypes = {
+  visible: PropTypes.bool,
+  trialUsed: PropTypes.bool,
+  onActivate: PropTypes.func.isRequired,
+  onUpgrade: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    card: {
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      padding: 20,
+      width: '80%',
+      alignItems: 'center',
+    },
+    title: { fontSize: 18, fontWeight: 'bold', color: theme.text },
+    desc: {
+      fontSize: 14,
+      color: theme.textSecondary,
+      textAlign: 'center',
+      marginTop: 8,
+    },
+    cancel: { color: theme.accent },
+  });

--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -28,6 +28,7 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `premiumUpdatedAt` (timestamp)
 - `priorityScore` (number) – higher values surface the user more often
 - `boostUntil` (timestamp|null) – temporary boost end time
+- `boostTrialUsed` (boolean) – whether the free boost has been used
 - `xp` (number)
 - `streak` (number)
 - `lastActiveAt` (timestamp) – last login or game completion

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -24,6 +24,7 @@ import { useDev } from '../contexts/DevContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
 import { useMatchmaking } from '../contexts/MatchmakingContext';
 import GamePickerModal from '../components/GamePickerModal';
+import BoostModal from '../components/BoostModal';
 import { allGames } from '../data/games';
 import { icebreakers } from '../data/prompts';
 import { devUsers } from '../data/devUsers';
@@ -89,7 +90,7 @@ const SwipeScreen = () => {
   const styles = getStyles(theme);
   const navigation = useNavigation();
   const { showNotification } = useNotification();
-  const { user: currentUser } = useUser();
+  const { user: currentUser, updateUser } = useUser();
   const { play } = useSound();
   const { devMode } = useDev();
   const { addMatch } = useChats();
@@ -119,11 +120,12 @@ const SwipeScreen = () => {
   const [showGamePicker, setShowGamePicker] = useState(false);
   const [pendingInviteId, setPendingInviteId] = useState(null);
   const [showUndoPrompt, setShowUndoPrompt] = useState(false);
+  const [showBoostModal, setShowBoostModal] = useState(false);
 
   const pan = useRef(new Animated.ValueXY()).current;
-  // 3 main buttons shown in the toolbar
+  // 4 main buttons shown in the toolbar
   const scaleRefs = useRef(
-    Array(3)
+    Array(4)
       .fill(null)
       .map(() => new Animated.Value(1))
   ).current;
@@ -147,6 +149,10 @@ const SwipeScreen = () => {
 
   const [users, setUsers] = useState([]);
   const displayUser = users[currentIndex] ?? null;
+  const isDisplayBoosted =
+    displayUser?.boostUntil &&
+    (displayUser.boostUntil.toDate?.() || new Date(displayUser.boostUntil)) >
+      new Date();
   const { playing: playingIntro, playPause: playIntro } = useVoicePlayback(
     displayUser?.voiceIntro
   );
@@ -562,6 +568,30 @@ const handleSwipe = async (direction) => {
     }
   };
 
+  const activateBoost = async () => {
+    if (!currentUser?.uid) return;
+    const boostUntil = new Date(Date.now() + 30 * 60 * 1000);
+    const updates = { boostUntil };
+    if (!currentUser.boostTrialUsed) updates.boostTrialUsed = true;
+    updateUser(updates);
+    try {
+      await firebase.firestore().collection('users').doc(currentUser.uid).update(updates);
+      Toast.show({ type: 'success', text1: 'Boost activated!' });
+    } catch (e) {
+      console.warn('Failed to activate boost', e);
+      Toast.show({ type: 'error', text1: 'Boost failed' });
+    }
+    setShowBoostModal(false);
+  };
+
+  const handleBoostPress = () => {
+    if (currentUser?.boostTrialUsed && !isPremiumUser && !devMode) {
+      navigation.navigate('Premium', { context: 'upgrade' });
+    } else {
+      setShowBoostModal(true);
+    }
+  };
+
   const gradientColors = [theme.gradientStart, theme.gradientEnd];
 
 
@@ -623,6 +653,11 @@ const handleSwipe = async (direction) => {
                   color={theme.accent}
                   style={{ marginLeft: 6 }}
                 />
+                {isDisplayBoosted && (
+                  <View style={styles.boostBadge}>
+                    <Text style={styles.boostBadgeText}>🔥 Boosted</Text>
+                  </View>
+                )}
               </View>
               <TouchableOpacity
                 onPress={() => setShowDetails(true)}
@@ -656,9 +691,7 @@ const handleSwipe = async (direction) => {
               <GradientButton
                 text="Boost"
                 width={180}
-                onPress={() =>
-                  navigation.navigate('Premium', { context: 'upgrade' })
-                }
+                onPress={handleBoostPress}
                 style={{ marginTop: 20 }}
               />
               <TouchableOpacity
@@ -672,6 +705,11 @@ const handleSwipe = async (direction) => {
 
         <View style={styles.buttonRow}>
           {[
+            {
+              icon: 'flame',
+              color: '#fb923c',
+              action: handleBoostPress,
+            },
             {
               icon: "close",
               color: "#f87171",
@@ -790,6 +828,13 @@ const handleSwipe = async (direction) => {
           visible={showGamePicker}
           onSelect={handleGamePickSelect}
           onClose={() => setShowGamePicker(false)}
+        />
+        <BoostModal
+          visible={showBoostModal}
+          trialUsed={!!currentUser?.boostTrialUsed}
+          onActivate={activateBoost}
+          onUpgrade={() => navigation.navigate('Premium', { context: 'upgrade' })}
+          onClose={() => setShowBoostModal(false)}
         />
         {showUndoPrompt && (isPremiumUser || devMode) ? (
           <View style={styles.undoBanner}>
@@ -929,6 +974,14 @@ const getStyles = (theme) =>
   nopeText: {
     color: '#f87171',
   },
+  boostBadge: {
+    marginLeft: 8,
+    backgroundColor: theme.accent,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  boostBadgeText: { color: '#fff', fontSize: 12, fontWeight: 'bold' },
   superLikeBadge: {
     top: CARD_HEIGHT / 2 - 20,
     left: SCREEN_WIDTH / 2 - 80,


### PR DESCRIPTION
## Summary
- add BoostModal component for trial boost feature
- show Boost button on SwipeScreen and Boosted badge
- persist `boostTrialUsed` field
- document boostTrialUsed user field

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b7563fcd4832d9ebe36503273eaf0