### PR TITLE
Add premium XP multiplier and badge display

### DIFF
--- a/components/GameContainer.js
+++ b/components/GameContainer.js
@@ -42,6 +42,7 @@ export default function GameContainer({
             name={player.name || 'You'}
             xp={player.xp}
             badges={player.badges}
+            isPremium={player.isPremium}
           />
           {onToggleChat && (
             <TouchableOpacity style={styles.chatToggle} onPress={onToggleChat}>
@@ -56,6 +57,7 @@ export default function GameContainer({
             name={opponent.name || 'Opponent'}
             xp={opponent.xp}
             badges={opponent.badges}
+            isPremium={opponent.isPremium}
           />
         </View>
       )}

--- a/components/PlayerInfoBar.js
+++ b/components/PlayerInfoBar.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { BADGE_LIST, getBadgeMeta } from '../utils/badges';
 
 
-export default function PlayerInfoBar({ name, xp = 0, badges = [] }) {
+export default function PlayerInfoBar({ name, xp = 0, badges = [], isPremium }) {
   const { theme } = useTheme();
   const level = Math.floor(xp / 100);
   const progress = xp % 100;
@@ -21,6 +21,21 @@ export default function PlayerInfoBar({ name, xp = 0, badges = [] }) {
       <Text style={{ fontWeight: '600', color: theme.text }}>{name}</Text>
       <Text style={{ fontSize: 12, color: theme.textSecondary }}>Level {level}</Text>
       <ProgressBar value={progress} max={100} color={theme.accent} />
+      {isPremium && (
+        <Text
+          style={{
+            fontSize: 10,
+            color: '#fff',
+            backgroundColor: theme.accent,
+            paddingHorizontal: 6,
+            paddingVertical: 2,
+            borderRadius: 8,
+            marginTop: 4,
+          }}
+        >
+          Premium XP
+        </Text>
+      )}
       <View style={{ flexDirection: 'row', marginTop: 4 }}>
         {BADGE_LIST.map((badge) => {
           const earned = badges.includes(badge.id);
@@ -48,4 +63,5 @@ PlayerInfoBar.propTypes = {
   name: PropTypes.string.isRequired,
   xp: PropTypes.number,
   badges: PropTypes.array,
+  isPremium: PropTypes.bool,
 };

--- a/contexts/UserContext.js
+++ b/contexts/UserContext.js
@@ -118,7 +118,9 @@ export const UserProvider = ({ children }) => {
       newStreak = 1;
     }
 
-    const newXP = (user.xp || 0) + amount;
+    const multiplier = user.isPremium ? 1.5 : 1;
+    const gained = Math.round(amount * multiplier);
+    const newXP = (user.xp || 0) + gained;
     const newBadges = computeBadges({
       xp: newXP,
       streak: newStreak,

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -238,11 +238,17 @@ const LiveSessionScreen = ({ route, navigation }) => {
       <Header showLogoOnly />
 
       <View style={{ flexDirection: 'row', paddingHorizontal: 16, marginTop: 10 }}>
-        <PlayerInfoBar name="You" xp={user?.xp || 0} badges={userBadges} />
+        <PlayerInfoBar
+          name="You"
+          xp={user?.xp || 0}
+          badges={userBadges}
+          isPremium={user?.isPremium}
+        />
         <PlayerInfoBar
           name={opponent.displayName}
           xp={opponentProfile?.xp || 0}
           badges={oppBadges}
+          isPremium={opponentProfile?.isPremium}
         />
       </View>
 
@@ -507,6 +513,7 @@ function BotSessionScreen({ route }) {
               badges: user?.badges || [],
               isPremium: user?.isPremium,
             })}
+            isPremium={user?.isPremium}
           />
           <PlayerInfoBar name={bot.name} xp={0} badges={[]} />
         </View>

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -134,6 +134,9 @@ const HomeScreen = ({ navigation }) => {
             <Card style={[local.progressCard, { backgroundColor: theme.card }]}>
               <Text style={[local.levelText, { color: theme.text }]}>{`Level ${level}`}</Text>
               <ProgressBar value={xpProgress} max={100} color={theme.accent} />
+              {isPremiumUser && (
+                <Text style={local.premiumXp}>Premium XP</Text>
+              )}
               <Text style={[local.streakLabel, { color: theme.textSecondary }]}>{`${user?.streak || 0} day streak`}</Text>
               <ProgressBar value={streakProgress} max={7} color="#2ecc71" />
               {nextUnlock && (
@@ -273,6 +276,16 @@ const getStyles = (theme) =>
       fontSize: 16,
       fontWeight: '600',
       marginBottom: 4,
+    },
+    premiumXp: {
+      fontSize: 10,
+      color: '#fff',
+      backgroundColor: theme.accent,
+      alignSelf: 'flex-start',
+      paddingHorizontal: 6,
+      paddingVertical: 2,
+      borderRadius: 8,
+      marginTop: 4,
     },
     streakLabel: {
       fontSize: 12,

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -140,6 +140,9 @@ const StatsScreen = ({ navigation }) => {
         <StatBox loading={loading} styles={styles}>
           <Text style={styles.statLabel}>{`XP Level ${level}`}</Text>
           <ProgressBar value={xpProgress} max={100} color={theme.accent} />
+          {isPremium && (
+            <Text style={styles.premiumXp}>Premium XP</Text>
+          )}
           <Text style={styles.statSub}>{stats.xp} XP</Text>
         </StatBox>
 
@@ -228,6 +231,16 @@ const getStyles = (theme) => StyleSheet.create({
     paddingVertical: 4,
     borderRadius: 12,
     fontSize: FONT_SIZES.SM - 2
+  },
+  premiumXp: {
+    fontSize: FONT_SIZES.SM - 2,
+    color: '#fff',
+    backgroundColor: theme.accent,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 8,
+    marginTop: 4,
   },
   sectionTitle: {
     fontSize: FONT_SIZES.MD,


### PR DESCRIPTION
## Summary
- reward Premium members with 1.5x XP gains
- show **Premium XP** badge near level bars
- pass premium status through PlayerInfoBar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b77796488832db9ea728c1cd6d8de