### PR TITLE
Implement event ticket feature

### DIFF
--- a/components/EventFlyer.js
+++ b/components/EventFlyer.js
@@ -27,6 +27,9 @@ const EventFlyer = ({ event, onJoin, joined, style }) => {
           </View>
         </View>
         <Text style={styles.desc}>{event.description}</Text>
+        {event.ticketed && (
+          <Text style={styles.ticketed}>🎟 Ticketed Event</Text>
+        )}
         <GradientButton
           text={joined ? 'RSVP\'d' : 'RSVP'}
           onPress={onJoin}
@@ -97,6 +100,11 @@ const getStyles = (theme, darkMode) =>
       marginTop: 4,
       color: theme.textSecondary,
       fontSize: 13,
+    },
+    ticketed: {
+      marginTop: 2,
+      color: theme.accent,
+      fontSize: 12,
     },
   });
 

--- a/data/community.js
+++ b/data/community.js
@@ -5,6 +5,7 @@ export const SAMPLE_EVENTS = [
     time: 'Friday @ 9PM',
     category: 'Flirty',
     description: 'Wild dares, real connections.',
+    ticketed: true,
     image: require('../assets/user2.jpg'),
   },
   {
@@ -21,6 +22,7 @@ export const SAMPLE_EVENTS = [
     time: 'Sunday Night',
     category: 'Flirty',
     description: 'Spicy, bold, fun.',
+    ticketed: true,
     image: require('../assets/user4.jpg'),
   },
   {

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -38,7 +38,7 @@ const CommunityScreen = () => {
   const skeletonColor = darkMode ? '#555' : '#ddd';
   const local = getStyles(theme, skeletonColor);
   const navigation = useNavigation();
-  const { user } = useUser();
+  const { user, redeemEventTicket } = useUser();
   const [events, setEvents] = useState([]);
   const [loadingEvents, setLoadingEvents] = useState(true);
   const [joinedEvents, setJoinedEvents] = useState([]);
@@ -125,6 +125,28 @@ const CommunityScreen = () => {
     );
   };
 
+  const handleJoin = (event) => {
+    const isJoined = joinedEvents.includes(event.id);
+    if (!isJoined && event.ticketed && !user?.isPremium && !(user.eventTickets || []).includes(event.id)) {
+      Alert.alert('Ticket Required', 'Redeem a ticket or upgrade to Premium.', [
+        {
+          text: 'Use Ticket',
+          onPress: () => {
+            redeemEventTicket(event.id);
+            toggleJoin(event.id);
+          },
+        },
+        {
+          text: 'Upgrade',
+          onPress: () => navigation.navigate('Premium', { context: 'paywall' }),
+        },
+        { text: 'Cancel', style: 'cancel' },
+      ]);
+      return;
+    }
+    toggleJoin(event.id);
+  };
+
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
@@ -149,7 +171,7 @@ const CommunityScreen = () => {
         key={event.id}
         event={event}
         joined={isJoined}
-        onJoin={() => toggleJoin(event.id)}
+        onJoin={() => handleJoin(event)}
       />
     );
   };
@@ -419,7 +441,7 @@ const CommunityScreen = () => {
               text={optionsEvent?.isJoined ? 'Cancel RSVP' : 'Join Event'}
               onPress={() => {
                 if (optionsEvent) {
-                  toggleJoin(optionsEvent.event.id);
+                  handleJoin(optionsEvent.event);
                 }
                 setShowOptionsModal(false);
               }}


### PR DESCRIPTION
## Summary
- mark select sample events as ticketed
- show badge for ticketed events on community board
- track event ticket usage in `UserContext`
- restrict ticketed events for non-premium users unless they redeem a ticket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b78085cb8832db8a20334efddabde