### PR TITLE
Fix onboarding voiceIntro crash

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -56,6 +56,18 @@ export default function OnboardingScreen() {
   const styles = getStyles(theme);
 
   const { startRecording, stopRecording, isRecording } = useVoiceRecorder();
+  const [answers, setAnswers] = useState({
+    avatar: '',
+    voiceIntro: '',
+    displayName: '',
+    age: '',
+    gender: '',
+    genderPref: '',
+    bio: '',
+    location: '',
+    favoriteGames: [],
+  });
+
   const { playing, playPause } = useVoicePlayback(answers.voiceIntro);
 
   const [step, setStep] = useState(0);


### PR DESCRIPTION
## Summary
- initialize `answers` state before passing `answers.voiceIntro` to `useVoicePlayback`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b9f71f7f4832d8b4b900470d3511e