### PR TITLE
Wrap header in SafeAreaView

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { SafeAreaView, View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
+import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -24,7 +25,10 @@ const Header: React.FC<HeaderProps> = ({ showLogoOnly = false }) => {
   ];
 
   return (
-    <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.headerBackground }]}>
+    <SafeAreaView
+      edges={['top']}
+      style={[styles.safeArea, { backgroundColor: theme.headerBackground }]}
+    >
       <View style={styles.container}>
         {showLogoOnly ? (
           <Image source={require('../assets/logo.png')} style={styles.logo} />

--- a/styles.js
+++ b/styles.js
@@ -208,7 +208,7 @@ const getStyles = (theme) =>
     flex: 1,
     justifyContent: 'flex-start',
     alignItems: 'stretch',
-    paddingTop: 40
+    // Padding handled by header SafeAreaView
   },
   swipeButtons: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- use SafeAreaView from react-native-safe-area-context in `Header`
- let the SafeAreaView handle the top inset by passing `edges={['top']}`
- remove hardcoded padding for swiping screen style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c6b2a85e8832db531c1dac06d0a5c