### PR TITLE
Add daily free game hook

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -218,16 +218,18 @@ exports.resetFreeGameUsage = functions.pubsub
     const snap = await admin
       .firestore()
       .collection('users')
-      .where('freeGameUsed', '==', true)
+      .where('freeGamesToday', '>', 0)
       .get();
 
     const tasks = [];
     snap.forEach((doc) => {
-      tasks.push(doc.ref.update({ freeGameUsed: false }));
+      tasks.push(
+        doc.ref.update({ freeGamesToday: 0, freeGameUsed: false })
+      );
     });
 
     await Promise.all(tasks);
-    functions.logger.info(`Reset freeGameUsed for ${tasks.length} users`);
+    functions.logger.info(`Reset freeGamesToday for ${tasks.length} users`);
     return null;
   });
 

--- a/hooks/useFreeGame.js
+++ b/hooks/useFreeGame.js
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import firebase from '../firebase';
+import { useUser } from '../contexts/UserContext';
+
+export default function useFreeGame() {
+  const { user, updateUser } = useUser();
+  const freeGamesToday = user?.freeGamesToday || 0;
+
+  const recordFreeGame = useCallback(async () => {
+    if (!user?.uid) return;
+    const newCount = freeGamesToday + 1;
+    updateUser({ freeGamesToday: newCount });
+    try {
+      await firebase
+        .firestore()
+        .collection('users')
+        .doc(user.uid)
+        .update({ freeGamesToday: newCount });
+    } catch (e) {
+      console.warn('Failed to record free game', e);
+    }
+  }, [user?.uid, freeGamesToday, updateUser]);
+
+  return { freeGamesToday, recordFreeGame };
+}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -31,6 +31,7 @@ import PremiumBanner from '../components/PremiumBanner';
 import ActiveGamesPreview from '../components/ActiveGamesPreview';
 import MatchesPreview from '../components/MatchesPreview';
 import { FONT_FAMILY } from '../textStyles';
+import useFreeGame from '../hooks/useFreeGame';
 
 // Map app game IDs to boardgame registry keys for AI play
 const aiGameMap = allGames.reduce((acc, g) => {
@@ -47,6 +48,7 @@ const HomeScreen = ({ navigation }) => {
   const { user, loginBonus } = useUser();
   const isPremiumUser = !!user?.isPremium;
   const { gamesLeft } = useGameLimit();
+  const { freeGamesToday, recordFreeGame } = useFreeGame();
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
   const [playTarget, setPlayTarget] = useState('match');
   const [showBonus, setShowBonus] = useState(false);
@@ -200,7 +202,14 @@ const HomeScreen = ({ navigation }) => {
         <View style={local.swipeButtonContainer}>
           <GradientButton
             text="Swipe Now"
-            onPress={() => navigation.navigate('Swipe')}
+            onPress={() => {
+              if (!isPremiumUser && freeGamesToday >= 1) {
+                navigation.navigate('Premium', { context: 'paywall' });
+              } else {
+                recordFreeGame();
+                navigation.navigate('Swipe');
+              }
+            }}
           />
         </View>
 


### PR DESCRIPTION
## Summary
- add `useFreeGame` hook to track daily free game usage
- reset `freeGamesToday` with Cloud Function
- check free game quota on HomeScreen before swiping

## Testing
- `node tests/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_686c6b34ebbc832da42df8cd68465350