### PR TITLE
Add region pack support

### DIFF
--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -64,14 +64,18 @@ const PlayScreen = ({ navigation }) => {
   };
 
   const filteredGames = allGames.filter((game) => {
+    const inRegion =
+      !user?.regionPack || user.regionPack.includes(game.id);
     const matchCategory =
       filter === 'All' ||
       (filter === 'Free' && !game.premium) ||
       (filter === 'Premium' && game.premium) ||
       (filter === 'Favorites' && favorites.includes(game.id));
-    const matchSearch = game.title.toLowerCase().includes(search.toLowerCase());
+    const matchSearch = game.title
+      .toLowerCase()
+      .includes(search.toLowerCase());
     const matchTag = category === 'All' || game.category === category;
-    return matchCategory && matchSearch && matchTag;
+    return inRegion && matchCategory && matchSearch && matchTag;
   });
 
 

--- a/utils/region.js
+++ b/utils/region.js
@@ -1,0 +1,22 @@
+import * as Location from 'expo-location';
+import { logDev } from './logger';
+
+const REGION_PACKS = {
+  IN: ['32'], // Snakes & Ladders
+  JP: ['9'],  // Gomoku
+};
+
+export async function getRegionPack() {
+  try {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') return [];
+    const loc = await Location.getCurrentPositionAsync({});
+    const [geo] = await Location.reverseGeocodeAsync(loc.coords);
+    const code = geo.isoCountryCode?.toUpperCase();
+    if (!code) return [];
+    return REGION_PACKS[code] || [];
+  } catch (e) {
+    logDev('Failed to fetch region pack', e);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `getRegionPack` helper to read location and map to game IDs
- filter playable games in `PlayScreen` by `user.regionPack`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c6b6360d4832da8938c9c3b445eb9