### PR TITLE
Add spacing constants and refine card shadows

### DIFF
--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Animated, TouchableOpacity, Dimensions } from 'react-native';
+import { SPACING } from '../layout';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
 
@@ -10,18 +11,18 @@ const GameCardBase = ({ children, scale, onPress, onPressIn, onPressOut }) => (
     <TouchableOpacity
       style={{
         width: CARD_WIDTH,
-        marginHorizontal: 8,
-        marginBottom: 20,
+        marginHorizontal: SPACING.SM,
+        marginBottom: SPACING.XL,
         backgroundColor: '#fff',
         borderRadius: 16,
-        paddingVertical: 20,
+        paddingVertical: SPACING.XL,
         alignItems: 'center',
         justifyContent: 'center',
         shadowColor: '#000',
-        shadowOpacity: 0.08,
+        shadowOpacity: 0.05,
         shadowOffset: { width: 0, height: 4 },
         shadowRadius: 6,
-        elevation: 4,
+        elevation: 3,
         position: 'relative',
       }}
       onPressIn={onPressIn}

--- a/layout.js
+++ b/layout.js
@@ -13,6 +13,15 @@ export const BUTTON_STYLE = {
   borderRadius: 8,
 };
 
+export const SPACING = {
+  XS: 4,
+  SM: 8,
+  MD: 12,
+  LG: 16,
+  XL: 20,
+  XXL: 24,
+};
+
 export const HEADER_HEIGHT = 60;
 export const HEADER_SPACING = Platform.OS === 'ios'
   ? HEADER_HEIGHT + 40

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -14,7 +14,7 @@ import ScreenContainer from '../components/ScreenContainer';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import { useGameLimit } from '../contexts/GameLimitContext';
-import { HEADER_SPACING } from '../layout';
+import { HEADER_SPACING, SPACING } from '../layout';
 
 import { allGames } from '../data/games';
 import { games as gameRegistry } from '../games';
@@ -368,14 +368,14 @@ const getStyles = (theme) =>
       flexDirection: 'row',
       alignItems: 'center',
       borderRadius: 12,
-      padding: 12,
-      marginBottom: 12,
+      padding: SPACING.MD,
+      marginBottom: SPACING.MD,
       alignSelf: 'stretch',
       shadowColor: '#000',
-      shadowOpacity: 0.1,
+      shadowOpacity: 0.05,
       shadowOffset: { width: 0, height: 2 },
       shadowRadius: 4,
-      elevation: 3,
+      elevation: 2,
     },
     featuredEventContent: {
       flex: 1,
@@ -383,15 +383,15 @@ const getStyles = (theme) =>
     },
     swipeButtonContainer: {
       position: 'absolute',
-      left: 20,
-      right: 20,
-      bottom: 20,
+      left: SPACING.XL,
+      right: SPACING.XL,
+      bottom: SPACING.XL,
     },
     postCardPreview: {
       borderRadius: 12,
-      padding: 12,
+      padding: SPACING.MD,
       alignSelf: 'stretch',
-      marginBottom: 12,
+      marginBottom: SPACING.MD,
     },
     postTitle: {
       fontSize: 14,
@@ -408,17 +408,17 @@ const getStyles = (theme) =>
     },
     communityBoard: {
       width: '100%',
-      marginBottom: 24,
+      marginBottom: SPACING.XXL,
     },
     boardBackground: {
       backgroundColor: '#deb887',
-      padding: 12,
+      padding: SPACING.MD,
       borderRadius: 12,
       borderWidth: 2,
       borderColor: '#caa76b',
     },
     noteWrapper: {
-      marginBottom: 24,
+      marginBottom: SPACING.XXL,
       alignItems: 'center',
       width: '100%',
     },
@@ -427,10 +427,10 @@ const getStyles = (theme) =>
       borderWidth: 1,
       borderColor: '#e0d4b9',
       shadowColor: '#000',
-      shadowOpacity: 0.25,
+      shadowOpacity: 0.15,
       shadowOffset: { width: 0, height: 2 },
       shadowRadius: 4,
-      elevation: 3,
+      elevation: 2,
     },
     rotateLeft: {
       transform: [{ rotate: '-2deg' }],

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -19,7 +19,7 @@ import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import useRematchHistory from '../hooks/useRematchHistory';
 import Toast from 'react-native-toast-message';
 import PropTypes from 'prop-types';
-import { HEADER_SPACING } from '../layout';
+import { HEADER_SPACING, SPACING } from '../layout';
 import EmptyState from '../components/EmptyState';
 
 const SKELETON_NEW_COUNT = 5;
@@ -300,23 +300,23 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     alignSelf: 'center',
     textAlign: 'center',
-    marginBottom: 8,
+    marginBottom: SPACING.SM,
     color: '#ff4081',
   },
   newList: {
-    marginBottom: 12,
-    paddingHorizontal: 8,
+    marginBottom: SPACING.MD,
+    paddingHorizontal: SPACING.SM,
     justifyContent: 'center',
   },
   newMatch: {
     alignItems: 'center',
-    marginRight: 12,
+    marginRight: SPACING.MD,
   },
   newAvatar: {
     width: 64,
     height: 64,
     borderRadius: 32,
-    marginBottom: 6,
+    marginBottom: SPACING.SM,
   },
   newName: {
     fontSize: 13,
@@ -327,8 +327,8 @@ const styles = StyleSheet.create({
   chatItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 12,
-    padding: 12,
+    marginBottom: SPACING.MD,
+    padding: SPACING.MD,
     alignSelf: 'center',
     width: '90%',
     maxWidth: 400,
@@ -338,15 +338,15 @@ const styles = StyleSheet.create({
     width: 56,
     height: 56,
     borderRadius: 28,
-    marginRight: 12,
+    marginRight: SPACING.MD,
   },
   avatarColumn: {
     alignItems: 'center',
-    marginRight: 12,
+    marginRight: SPACING.MD,
   },
   avatarName: {
     fontSize: 12,
-    marginTop: 4,
+    marginTop: SPACING.XS,
     maxWidth: 64,
     textAlign: 'center',
   },
@@ -360,8 +360,8 @@ const styles = StyleSheet.create({
   },
   playBtn: {
     backgroundColor: '#ff4081',
-    paddingVertical: 6,
-    paddingHorizontal: 12,
+    paddingVertical: SPACING.SM,
+    paddingHorizontal: SPACING.MD,
     borderRadius: 12,
   },
   playText: {

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -17,7 +17,7 @@ import GradientButton from '../components/GradientButton';
 import { LinearGradient } from 'expo-linear-gradient';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
-import { HEADER_SPACING } from '../layout';
+import { HEADER_SPACING, SPACING } from '../layout';
 import { useNotification } from '../contexts/NotificationContext';
 import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
@@ -824,9 +824,9 @@ const getStyles = (theme) =>
     borderRadius: 20,
     overflow: 'hidden',
     backgroundColor: '#fff',
-    elevation: 8,
+    elevation: 6,
     shadowColor: '#000',
-    shadowOpacity: 0.2,
+    shadowOpacity: 0.1,
     shadowRadius: 8,
     shadowOffset: { width: 0, height: 4 },
   },
@@ -845,8 +845,8 @@ const getStyles = (theme) =>
     bottom: BUTTON_ROW_BOTTOM + 80,
     left: 0,
     right: 0,
-    paddingHorizontal: 20,
-    paddingVertical: 10,
+    paddingHorizontal: SPACING.XL,
+    paddingVertical: SPACING.SM,
   },
   distanceBadge: {
     alignSelf: 'flex-start',
@@ -905,7 +905,7 @@ const getStyles = (theme) =>
     borderRadius: 30,
     alignItems: 'center',
     justifyContent: 'center',
-    elevation: 4,
+    elevation: 3,
   },
   badge: {
     position: 'absolute',
@@ -963,7 +963,7 @@ const getStyles = (theme) =>
   },
   detailsContainer: {
     backgroundColor: theme.card,
-    padding: 20,
+    padding: SPACING.XL,
     borderRadius: 12,
     width: '80%',
   },


### PR DESCRIPTION
## Summary
- define `SPACING` constants in `layout.js`
- use spacing constants in `GameCardBase`, `HomeScreen`, `SwipeScreen`, and `MatchesScreen`
- reduce shadow opacity and elevation for card styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c6f1a0dcc832d96234e3fb7f95801