### PR TITLE
Expand streak reward UX

### DIFF
--- a/components/StreakRewardModal.js
+++ b/components/StreakRewardModal.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function StreakRewardModal({ visible, streak, onClose }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Streak Reward!</Text>
+          <Text style={styles.text}>{`You reached a ${streak}-day streak!`}</Text>
+          <TouchableOpacity onPress={onClose} style={styles.button}>
+            <Text style={styles.buttonText}>Awesome!</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+StreakRewardModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  streak: PropTypes.number,
+  onClose: PropTypes.func.isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: '#0009',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    card: {
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      padding: 20,
+      alignItems: 'center',
+      width: '80%',
+    },
+    title: {
+      color: theme.text,
+      fontSize: 18,
+      fontWeight: 'bold',
+      marginBottom: 8,
+    },
+    text: {
+      color: theme.text,
+      fontSize: 16,
+      marginBottom: 16,
+      textAlign: 'center',
+    },
+    button: {
+      backgroundColor: theme.accent,
+      paddingHorizontal: 20,
+      paddingVertical: 8,
+      borderRadius: 20,
+    },
+    buttonText: { color: '#fff', fontWeight: 'bold' },
+  });
+

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -31,6 +31,7 @@ import PremiumBanner from '../components/PremiumBanner';
 import ActiveGamesPreview from '../components/ActiveGamesPreview';
 import MatchesPreview from '../components/MatchesPreview';
 import { FONT_FAMILY } from '../textStyles';
+import StreakRewardModal from '../components/StreakRewardModal';
 
 // Map app game IDs to boardgame registry keys for AI play
 const aiGameMap = allGames.reduce((acc, g) => {
@@ -44,13 +45,14 @@ const aiGameMap = allGames.reduce((acc, g) => {
 const CARD_SIZE = 140;
 const HomeScreen = ({ navigation }) => {
   const { theme } = useTheme();
-  const { user, loginBonus } = useUser();
+  const { user, loginBonus, streakReward, acknowledgeStreakReward } = useUser();
   const isPremiumUser = !!user?.isPremium;
   const { gamesLeft } = useGameLimit();
   const [gamePickerVisible, setGamePickerVisible] = useState(false);
   const [playTarget, setPlayTarget] = useState('match');
   const [showBonus, setShowBonus] = useState(false);
   const [showPremiumBanner, setShowPremiumBanner] = useState(!isPremiumUser);
+  const [showStreakReward, setShowStreakReward] = useState(false);
   const local = getStyles(theme);
 
 
@@ -67,6 +69,12 @@ const HomeScreen = ({ navigation }) => {
       return () => clearTimeout(t);
     }
   }, [loginBonus]);
+
+  useEffect(() => {
+    if (streakReward) {
+      setShowStreakReward(true);
+    }
+  }, [streakReward]);
 
   useEffect(() => {
     setShowPremiumBanner(!isPremiumUser);
@@ -223,6 +231,14 @@ const HomeScreen = ({ navigation }) => {
             </View>
           </View>
         </Modal>
+        <StreakRewardModal
+          visible={showStreakReward}
+          streak={streakReward}
+          onClose={() => {
+            setShowStreakReward(false);
+            acknowledgeStreakReward();
+          }}
+        />
       </ScreenContainer>
     </GradientBackground>
   );


### PR DESCRIPTION
## Summary
- show streak reward modal on 7-day multiples
- store `streakRewardedAt` timestamp when rewarding
- expose reward state via `UserContext`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c6fe40780832dbe4f4bd9fdb82593