### PR TITLE
Remove unused StatusBar import

### DIFF
--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -1,6 +1,6 @@
 // navigation/RootNavigator.js
 import React, { useEffect, useState, lazy, Suspense } from 'react';
-import { StatusBar, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import * as Linking from 'expo-linking';
 import { useUser } from '../contexts/UserContext';
 import { useOnboarding } from '../contexts/OnboardingContext';


### PR DESCRIPTION
## Summary
- remove the unused `StatusBar` import from `RootNavigator`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c72fb0050832d84b82a851dc1e2b5