### PR TITLE
Replace gradientStart/End usage with theme.gradient

### DIFF
--- a/components/ArcadeGameWrapper.js
+++ b/components/ArcadeGameWrapper.js
@@ -65,7 +65,7 @@ export default function ArcadeGameWrapper({
 
   return (
     <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
+      colors={theme.gradient}
       style={styles.container}
     >
       <View style={styles.header}>

--- a/components/AvatarRing.js
+++ b/components/AvatarRing.js
@@ -90,7 +90,7 @@ export default function AvatarRing({
           <Image source={avatarSource(source)} style={imageStyle} />
         </View>
       ) : isMatch ? (
-        <LinearGradient colors={[theme.gradientStart, theme.gradientEnd]} style={ringStyle}>
+        <LinearGradient colors={theme.gradient} style={ringStyle}>
           <Image source={avatarSource(source)} style={imageStyle} />
         </LinearGradient>
       ) : (

--- a/components/Card.js
+++ b/components/Card.js
@@ -24,7 +24,7 @@ const Card = ({
 }) => {
   const { theme } = useTheme();
   const { scale, handlePressIn, handlePressOut } = useCardPressAnimation();
-  const colors = gradientColors || [theme.gradientStart, theme.gradientEnd];
+  const colors = gradientColors || theme.gradient;
 
   return (
     <AnimatedPressable

--- a/components/LoadingOverlay.js
+++ b/components/LoadingOverlay.js
@@ -13,7 +13,7 @@ export default function LoadingOverlay() {
   return (
     <View style={styles.overlay} pointerEvents="none">
       <LinearGradient
-        colors={[theme.gradientStart, theme.gradientEnd]}
+        colors={theme.gradient}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 1 }}
         style={[StyleSheet.absoluteFill, { opacity: 0.8 }]}

--- a/components/PremiumBanner.js
+++ b/components/PremiumBanner.js
@@ -11,7 +11,7 @@ export default function PremiumBanner({ onClose, onPress }) {
   const styles = getStyles(theme);
   return (
     <LinearGradient
-      colors={[theme.gradientStart, theme.gradientEnd]}
+      colors={theme.gradient}
       start={{ x: 0, y: 0 }}
       end={{ x: 1, y: 0 }}
       style={styles.container}

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -603,7 +603,7 @@ const handleSwipe = async (direction) => {
     }
   };
 
-  const gradientColors = [theme.gradientStart, theme.gradientEnd];
+  const gradientColors = theme.gradient;
 
 
   return (


### PR DESCRIPTION
## Summary
- use `theme.gradient` colors instead of start/end pair
- keep single color references to `gradientStart` for now
- update swipe screen gradient usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c7358818c832dad148243a1e07dc7