### PR TITLE
Update skip logic for onboarding

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -50,6 +50,12 @@ const questions = [
 ];
 
 const requiredFields = ['avatar', 'displayName', 'age'];
+// Determine the index of the last required question in the flow
+const lastRequiredIndex = Math.max(
+  ...requiredFields.map((field) =>
+    questions.findIndex((q) => q.key === field)
+  )
+);
 
 export default function OnboardingScreen() {
   const { darkMode, theme } = useTheme();
@@ -575,7 +581,7 @@ export default function OnboardingScreen() {
             </Text>
           </TouchableOpacity>
         </View>
-        {step >= requiredFields.length - 1 && (
+        {step >= lastRequiredIndex && (
           <TouchableOpacity style={styles.skipButton} onPress={handleSkip}>
             <Text style={styles.skipButtonText}>Complete Profile Later</Text>
           </TouchableOpacity>


### PR DESCRIPTION
## Summary
- compute the index of the last required question
- delay showing the skip button until the user reaches it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c7762fd04832d86f33c47d0a9c621