### PR TITLE
Add intro clip recording support

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -13,7 +13,7 @@ import {
 import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import firebase from '../firebase';
-import { uploadAvatarAsync, uploadIntroAsync } from '../utils/upload';
+import { uploadAvatarAsync, uploadIntroClipAsync } from '../utils/upload';
 import PropTypes from 'prop-types';
 import { sanitizeText } from '../utils/sanitize';
 import { snapshotExists } from '../utils/firestore';
@@ -27,6 +27,7 @@ import { avatarSource } from '../utils/avatar';
 import RNPickerSelect from 'react-native-picker-select';
 import Toast from 'react-native-toast-message';
 import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
+import { Video } from 'expo-av';
 import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import MultiSelectList from '../components/MultiSelectList';
@@ -40,7 +41,7 @@ import useVoicePlayback from '../hooks/useVoicePlayback';
 
 const questions = [
   { key: 'avatar', label: 'Upload your photo' },
-  { key: 'voiceIntro', label: 'Record a quick voice intro' },
+  { key: 'introClip', label: 'Record a quick intro clip' },
   { key: 'displayName', label: 'What’s your name?' },
   { key: 'age', label: 'How old are you?' },
   { key: 'genderInfo', label: 'Gender & preference' },
@@ -62,7 +63,7 @@ export default function OnboardingScreen() {
   const { startRecording, stopRecording, isRecording } = useVoiceRecorder();
   const [answers, setAnswers] = useState({
     avatar: '',
-    voiceIntro: '',
+    introClip: '',
     displayName: '',
     age: '',
     gender: '',
@@ -72,7 +73,9 @@ export default function OnboardingScreen() {
     favoriteGames: [],
   });
 
-  const { playing, playPause } = useVoicePlayback(answers.voiceIntro);
+  const { playing, playPause } = useVoicePlayback(
+    answers.introClip && answers.introClip.endsWith('.m4a') ? answers.introClip : null
+  );
 
   const [step, setStep] = useState(0);
   const cardOpacity = useRef(new Animated.Value(1)).current;
@@ -95,17 +98,6 @@ export default function OnboardingScreen() {
       }).start();
     });
   };
-  const [answers, setAnswers] = useState({
-    avatar: '',
-    voiceIntro: '',
-    displayName: '',
-    age: '',
-    gender: '',
-    genderPref: '',
-    bio: '',
-    location: '',
-    favoriteGames: [],
-  });
   const defaultGameOptions = allGames.map((g) => ({
     label: g.title,
     value: g.title,
@@ -204,7 +196,7 @@ export default function OnboardingScreen() {
           (answers.displayName || user.displayName || '').trim()
         ),
         photoURL,
-        voiceIntro: answers.voiceIntro || '',
+        introClipUrl: answers.introClip || '',
         age: parseInt(answers.age, 10) || null,
         gender: sanitizeText(answers.gender),
         genderPref: sanitizeText(answers.genderPref),
@@ -278,24 +270,48 @@ export default function OnboardingScreen() {
     }
   };
 
-  const handleVoicePress = async () => {
+  const handleAudioPress = async () => {
     if (isRecording) {
       const result = await stopRecording();
       if (result) {
         try {
-          const url = await uploadIntroAsync(
+          const url = await uploadIntroClipAsync(
             result.uri,
             firebase.auth().currentUser.uid
           );
-          if (url)
-            setAnswers((prev) => ({ ...prev, voiceIntro: url }));
+          if (url) setAnswers((prev) => ({ ...prev, introClip: url }));
         } catch (e) {
-          console.error('Voice upload failed:', e);
+          console.error('Intro clip upload failed:', e);
           Toast.show({ type: 'error', text1: 'Failed to upload intro' });
         }
       }
     } else {
       await startRecording();
+    }
+  };
+
+  const handleVideoPress = async () => {
+    Haptics.selectionAsync().catch(() => {});
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== 'granted') {
+      Toast.show({ type: 'error', text1: 'Permission denied' });
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+      videoMaxDuration: 15,
+    });
+    if (!result.canceled) {
+      try {
+        const url = await uploadIntroClipAsync(
+          result.assets[0].uri,
+          firebase.auth().currentUser.uid
+        );
+        if (url) setAnswers((prev) => ({ ...prev, introClip: url }));
+      } catch (e) {
+        console.error('Intro clip upload failed:', e);
+        Toast.show({ type: 'error', text1: 'Failed to upload intro' });
+      }
     }
   };
 
@@ -349,27 +365,41 @@ export default function OnboardingScreen() {
       );
     }
 
-    if (currentField === 'voiceIntro') {
+    if (currentField === 'introClip') {
       return (
         <View style={{ alignItems: 'center' }}>
-          <TouchableOpacity
-            onPress={handleVoicePress}
-            style={styles.voiceButton}
-          >
-            <Ionicons
-              name={isRecording ? 'stop' : 'mic'}
-              size={28}
-              color="#fff"
-            />
-          </TouchableOpacity>
-          {answers.voiceIntro ? (
-            <TouchableOpacity onPress={playPause} style={styles.playButton}>
+          <View style={{ flexDirection: 'row' }}>
+            <TouchableOpacity onPress={handleAudioPress} style={styles.voiceButton}>
               <Ionicons
-                name={playing ? 'pause' : 'play'}
+                name={isRecording ? 'stop' : 'mic'}
                 size={28}
                 color="#fff"
               />
             </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleVideoPress}
+              style={[styles.voiceButton, { marginLeft: 20 }]}
+            >
+              <Ionicons name="videocam" size={28} color="#fff" />
+            </TouchableOpacity>
+          </View>
+          {answers.introClip ? (
+            answers.introClip.endsWith('.m4a') ? (
+              <TouchableOpacity onPress={playPause} style={styles.playButton}>
+                <Ionicons
+                  name={playing ? 'pause' : 'play'}
+                  size={28}
+                  color="#fff"
+                />
+              </TouchableOpacity>
+            ) : (
+              <Video
+                source={{ uri: answers.introClip }}
+                style={{ width: 200, height: 200, marginTop: 10 }}
+                useNativeControls
+                resizeMode="contain"
+              />
+            )
           ) : null}
         </View>
       );

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -156,12 +156,18 @@ const SwipeScreen = () => {
     (displayUser.boostUntil.toDate?.() || new Date(displayUser.boostUntil)) >
       new Date();
   const { playing: playingIntro, playPause: playIntro } = useVoicePlayback(
-    displayUser?.voiceIntro
+    displayUser?.introClipUrl && displayUser.introClipUrl.endsWith('.m4a')
+      ? displayUser.introClipUrl
+      : null
   );
   const {
     playing: playingMatchIntro,
     playPause: playMatchIntro,
-  } = useVoicePlayback(matchedUser?.voiceIntro);
+  } = useVoicePlayback(
+    matchedUser?.introClipUrl && matchedUser.introClipUrl.endsWith('.m4a')
+      ? matchedUser.introClipUrl
+      : null
+  );
 
   useEffect(() => {
     setCurrentIndex(0);
@@ -226,7 +232,7 @@ const SwipeScreen = () => {
             displayName: u.displayName || 'User',
             age: u.age || '',
             bio: u.bio || '',
-            voiceIntro: u?.voiceIntro || '',
+            introClipUrl: u?.introClipUrl || '',
             favoriteGames: Array.isArray(u.favoriteGames) ? u.favoriteGames : [],
             gender: u.gender || '',
             genderPref: u.genderPref || '',
@@ -790,18 +796,29 @@ const handleSwipe = async (direction) => {
                   {displayUser?.displayName}, {displayUser?.age}
                 </Text>
                 <Text style={styles.bioText}>{displayUser?.bio}</Text>
-                {displayUser?.voiceIntro ? (
-                  <TouchableOpacity
-                    onPress={playIntro}
-                    style={styles.playIntro}
-                  >
-                    <Ionicons
-                      name={playingIntro ? 'pause' : 'play'}
-                      size={32}
-                      color={theme.accent}
-                    />
-                  </TouchableOpacity>
-                ) : null}
+                {displayUser?.introClipUrl
+                  ? displayUser.introClipUrl.endsWith('.m4a')
+                    ? (
+                        <TouchableOpacity
+                          onPress={playIntro}
+                          style={styles.playIntro}
+                        >
+                          <Ionicons
+                            name={playingIntro ? 'pause' : 'play'}
+                            size={32}
+                            color={theme.accent}
+                          />
+                        </TouchableOpacity>
+                      )
+                    : (
+                        <Video
+                          source={{ uri: displayUser.introClipUrl }}
+                          style={{ width: 200, height: 200, alignSelf: 'center', marginTop: 10 }}
+                          useNativeControls
+                          resizeMode="contain"
+                        />
+                      )
+                  : null}
                 <GradientButton
                   text="Close"
                   width={120}
@@ -823,15 +840,29 @@ const handleSwipe = async (direction) => {
                 style={{ width: 300, height: 300 }}
               />
               <Text style={styles.matchText}>It's a Match with {matchedUser.displayName}!</Text>
-              {matchedUser?.voiceIntro ? (
-                <TouchableOpacity onPress={playMatchIntro} style={styles.playIntro}>
-                  <Ionicons
-                    name={playingMatchIntro ? 'pause' : 'play'}
-                    size={32}
-                    color="#fff"
-                  />
-                </TouchableOpacity>
-              ) : null}
+              {matchedUser?.introClipUrl
+                ? matchedUser.introClipUrl.endsWith('.m4a')
+                  ? (
+                      <TouchableOpacity
+                        onPress={playMatchIntro}
+                        style={styles.playIntro}
+                      >
+                        <Ionicons
+                          name={playingMatchIntro ? 'pause' : 'play'}
+                          size={32}
+                          color="#fff"
+                        />
+                      </TouchableOpacity>
+                    )
+                  : (
+                      <Video
+                        source={{ uri: matchedUser.introClipUrl }}
+                        style={{ width: 200, height: 200, marginTop: 10 }}
+                        useNativeControls
+                        resizeMode="contain"
+                      />
+                    )
+                : null}
               {matchLine ? (
                 <Text style={styles.suggestText}>{`Try: "${matchLine}"`}</Text>
               ) : null}

--- a/storage.rules
+++ b/storage.rules
@@ -10,5 +10,8 @@ service firebase.storage {
     match /voiceIntros/{userId}/{allPaths=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+    match /introClips/{userId}/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }

--- a/utils/upload.js
+++ b/utils/upload.js
@@ -82,3 +82,23 @@ export async function uploadIntroAsync(uri, uid) {
     return null;
   }
 }
+
+export async function uploadIntroClipAsync(uri, uid) {
+  if (!uri || !uid) throw new Error('uri and uid required');
+  try {
+    const response = await fetch(uri);
+    const blob = await response.blob();
+    const extMatch = uri.match(/\.([a-zA-Z0-9]+)$/);
+    const ext = extMatch ? extMatch[1] : 'mp4';
+    const filename = `${Date.now()}.${ext}`;
+    const ref = firebase.storage().ref().child(`introClips/${uid}/${filename}`);
+    const uploadTask = ref.put(blob);
+    await new Promise((resolve, reject) => {
+      uploadTask.on('state_changed', null, reject, resolve);
+    });
+    return ref.getDownloadURL();
+  } catch (e) {
+    console.warn('Failed to upload intro clip', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- enable recording of intro clips during onboarding
- allow storing intro clips in `/introClips/{uid}` via a new upload helper
- show intro clips on swipe cards and match modals
- update storage rules to allow saving intro clips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c77786b4c832d99e639b45ede1264