### PR TITLE
Add avatar overlay effects

### DIFF
--- a/components/AvatarCanvas.js
+++ b/components/AvatarCanvas.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View } from 'react-native';
+import Svg, { Image as SvgImage, Circle, Path } from 'react-native-svg';
+import PropTypes from 'prop-types';
+import { avatarSource } from '../utils/avatar';
+
+export const OVERLAYS = {
+  none: 'None',
+  circle: 'Circle Frame',
+  star: 'Star Sticker',
+};
+
+export default function AvatarCanvas({ source, overlay = 'none', size = 150 }) {
+  const imgSrc = avatarSource(source);
+  const radius = size / 2;
+
+  return (
+    <View style={{ width: size, height: size }}>
+      <Svg width={size} height={size}>
+        <SvgImage
+          href={imgSrc}
+          width={size}
+          height={size}
+          preserveAspectRatio="xMidYMid slice"
+        />
+        {overlay === 'circle' && (
+          <Circle
+            cx={radius}
+            cy={radius}
+            r={radius - 2}
+            strokeWidth={4}
+            stroke="#FFD700"
+            fill="transparent"
+          />
+        )}
+        {overlay === 'star' && (
+          <Path
+            d="M75 5 L90 55 L145 55 L100 85 L115 135 L75 105 L35 135 L50 85 L5 55 L60 55 Z"
+            fill="#FFD700"
+            stroke="#FFD700"
+          />
+        )}
+      </Svg>
+    </View>
+  );
+}
+
+AvatarCanvas.propTypes = {
+  source: PropTypes.any,
+  overlay: PropTypes.oneOf(Object.keys(OVERLAYS)),
+  size: PropTypes.number,
+};

--- a/components/AvatarRing.js
+++ b/components/AvatarRing.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { View, Image, Animated, StyleSheet } from 'react-native';
+import AvatarCanvas from './AvatarCanvas';
 import { LinearGradient } from 'expo-linear-gradient';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
@@ -11,6 +12,7 @@ export default function AvatarRing({
   isMatch = false,
   isOnline = false,
   isPremium = false,
+  overlay = 'none',
   style,
 }) {
   const { theme } = useTheme();
@@ -87,15 +89,15 @@ export default function AvatarRing({
               />
             </Animated.View>
           </View>
-          <Image source={avatarSource(source)} style={imageStyle} />
+          <AvatarCanvas source={source} overlay={overlay} size={size} />
         </View>
       ) : isMatch ? (
         <LinearGradient colors={theme.gradient} style={ringStyle}>
-          <Image source={avatarSource(source)} style={imageStyle} />
+          <AvatarCanvas source={source} overlay={overlay} size={size} />
         </LinearGradient>
       ) : (
         <View style={ringStyle}>
-          <Image source={avatarSource(source)} style={imageStyle} />
+          <AvatarCanvas source={source} overlay={overlay} size={size} />
         </View>
       )}
       {isOnline && (
@@ -122,6 +124,7 @@ AvatarRing.propTypes = {
   isMatch: PropTypes.bool,
   isOnline: PropTypes.bool,
   isPremium: PropTypes.bool,
+  overlay: PropTypes.string,
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -24,6 +24,7 @@ import { getFirestore, doc, setDoc, getDoc } from 'firebase/firestore';
 import * as ImagePicker from 'expo-image-picker';
 import * as Location from 'expo-location';
 import { avatarSource } from '../utils/avatar';
+import AvatarCanvas, { OVERLAYS } from '../components/AvatarCanvas';
 import RNPickerSelect from 'react-native-picker-select';
 import Toast from 'react-native-toast-message';
 import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
@@ -62,6 +63,7 @@ export default function OnboardingScreen() {
   const { startRecording, stopRecording, isRecording } = useVoiceRecorder();
   const [answers, setAnswers] = useState({
     avatar: '',
+    overlay: 'none',
     voiceIntro: '',
     displayName: '',
     age: '',
@@ -97,6 +99,7 @@ export default function OnboardingScreen() {
   };
   const [answers, setAnswers] = useState({
     avatar: '',
+    overlay: 'none',
     voiceIntro: '',
     displayName: '',
     age: '',
@@ -204,6 +207,7 @@ export default function OnboardingScreen() {
           (answers.displayName || user.displayName || '').trim()
         ),
         photoURL,
+        avatarOverlay: answers.overlay,
         voiceIntro: answers.voiceIntro || '',
         age: parseInt(answers.age, 10) || null,
         gender: sanitizeText(answers.gender),
@@ -337,15 +341,42 @@ export default function OnboardingScreen() {
 
     if (currentField === 'avatar') {
       return (
-        <TouchableOpacity onPress={pickImage} style={styles.imagePicker}>
-          {answers.avatar ? (
-            <Image source={avatarSource(answers.avatar)} style={styles.avatar} />
-          ) : (
-            <View style={styles.placeholder}>
-              <Text style={{ color: '#999' }}>Tap to select image</Text>
-            </View>
-          )}
-        </TouchableOpacity>
+        <View style={{ alignItems: 'center' }}>
+          <TouchableOpacity onPress={pickImage} style={styles.imagePicker}>
+            {answers.avatar ? (
+              <AvatarCanvas
+                source={answers.avatar}
+                overlay={answers.overlay}
+                size={150}
+              />
+            ) : (
+              <View style={styles.placeholder}>
+                <Text style={{ color: '#999' }}>Tap to select image</Text>
+              </View>
+            )}
+          </TouchableOpacity>
+          <View style={styles.overlayRow}>
+            {Object.keys(OVERLAYS).map((o) => (
+              <TouchableOpacity
+                key={o}
+                style={[
+                  styles.overlayOption,
+                  answers.overlay === o && styles.overlaySelected,
+                ]}
+                onPress={() =>
+                  setAnswers((prev) => ({ ...prev, overlay: o }))
+                }
+              >
+                <AvatarCanvas
+                  source={answers.avatar}
+                  overlay={o}
+                  size={50}
+                />
+                <Text style={styles.overlayLabel}>{OVERLAYS[o]}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
       );
     }
 
@@ -661,6 +692,23 @@ const getStyles = (theme) => {
       justifyContent: 'center',
       alignItems: 'center',
     },
+    overlayRow: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      flexWrap: 'wrap',
+    },
+    overlayOption: {
+      alignItems: 'center',
+      marginHorizontal: 5,
+      marginTop: 10,
+    },
+    overlaySelected: {
+      borderWidth: 2,
+      borderColor: accent,
+      borderRadius: 8,
+      padding: 2,
+    },
+    overlayLabel: { fontSize: FONT_SIZES.SM, color: textColor },
     locationContainer: {
       flexDirection: 'row',
       alignItems: 'center',


### PR DESCRIPTION
## Summary
- create `AvatarCanvas` for drawing avatar overlays
- show overlay picker in onboarding
- store overlay choice in profile
- support overlays in `AvatarRing`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c7788523c832d8ff2bf6599e9d694