### PR TITLE
Update schema docs and storage rules

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -40,6 +40,11 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `online` (boolean)
 - `lastOnline` (timestamp) – last presence update time
 - `badges` (array of string) – earned badge IDs
+- `mood` (string) – optional status message
+- `introClipUrl` (string) – voice or video intro clip
+- `profilePrompts` (map) – prompt answers keyed by id
+- `personalityTags` (array of string) – descriptive tags
+- `badgePreferences` (map) – user-selected badge display
 - `visibility` (string) – `standard` or `incognito`
 - `discoveryEnabled` (boolean) – hide from swipe if false
 - `messagePermission` (string) – `everyone`, `verified`, or `profile100`

--- a/storage.rules
+++ b/storage.rules
@@ -10,5 +10,8 @@ service firebase.storage {
     match /voiceIntros/{userId}/{allPaths=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+    match /introClips/{userId}/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- document new user fields: mood, intro clip, profile prompts, personality tags and badge preferences
- allow uploading intro clips in Firebase Storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c778f952c832db86b68c4ff44c340