### PR TITLE
Add onboarding preset step

### DIFF
--- a/contexts/ThemeContext.js
+++ b/contexts/ThemeContext.js
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { View } from 'react-native';
 import Loader from '../components/Loader';
 import { lightTheme, darkTheme } from '../theme';
+import { useUser } from './UserContext';
 
 const ThemeContext = createContext();
 const STORAGE_KEY = 'darkMode';
@@ -10,6 +11,7 @@ const STORAGE_KEY = 'darkMode';
 export const ThemeProvider = ({ children }) => {
   const [loaded, setLoaded] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
+  const { user } = useUser();
 
   useEffect(() => {
     let isMounted = true;
@@ -35,7 +37,16 @@ export const ThemeProvider = ({ children }) => {
     setDarkMode(next);
   };
 
-  const theme = darkMode ? darkTheme : lightTheme;
+  const base = darkMode ? darkTheme : lightTheme;
+  const overrides = user?.themeColors || {};
+  const theme = {
+    ...base,
+    ...overrides,
+    gradient: [
+      overrides.gradientStart || base.gradientStart,
+      overrides.gradientEnd || base.gradientEnd,
+    ],
+  };
 
   return (
     <ThemeContext.Provider value={{ darkMode, toggleTheme, theme, loaded }}>

--- a/data/presets.js
+++ b/data/presets.js
@@ -1,0 +1,35 @@
+export const PRESETS = [
+  {
+    id: 'chill',
+    label: 'Chill',
+    mood: 'Chill',
+    status: 'Just hanging out',
+    theme: {
+      accent: '#66bb6a',
+      gradientStart: '#43a047',
+      gradientEnd: '#66bb6a',
+    },
+  },
+  {
+    id: 'competitive',
+    label: 'Competitive',
+    mood: 'Hyped',
+    status: 'Ready to win',
+    theme: {
+      accent: '#ff7043',
+      gradientStart: '#ff5722',
+      gradientEnd: '#ff7043',
+    },
+  },
+  {
+    id: 'social',
+    label: 'Social',
+    mood: 'Friendly',
+    status: "Let's chat",
+    theme: {
+      accent: '#42a5f5',
+      gradientStart: '#1e88e5',
+      gradientEnd: '#42a5f5',
+    },
+  },
+];

--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -13,6 +13,10 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `location` (string)
 - `favoriteGames` (array of string)
 - `bio` (string)
+- `preset` (string) – selected style preset
+- `mood` (string)
+- `statusMessage` (string)
+- `themeColors` (map) – `{ accent, gradientStart, gradientEnd }`
 - `jobTitle` (string)
 - `company` (string)
 - `school` (string)


### PR DESCRIPTION
## Summary
- allow selecting a preset during onboarding
- save preset choice, mood and theme colors to Firestore
- support theme overrides based on user's preset
- document new Firestore fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c86beff68832da3a3b76ec34312c0