### PR TITLE
Add game select component with badge preview

### DIFF
--- a/components/GameSelectList.js
+++ b/components/GameSelectList.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { ScrollView, TouchableOpacity, Text, StyleSheet, View } from 'react-native';
+import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { allGames } from '../data/games';
+import { BADGE_LIST } from '../data/badges';
+
+export default function GameSelectList({ selected = [], onChange, theme, showPreviewBadges = false }) {
+  const toggle = (title) => {
+    if (!onChange) return;
+    if (selected.includes(title)) {
+      onChange(selected.filter((v) => v !== title));
+    } else {
+      onChange([...selected, title]);
+    }
+  };
+
+  const styles = getStyles(theme);
+
+  return (
+    <>
+      <ScrollView style={styles.container}>
+        {allGames.map((g) => (
+          <TouchableOpacity
+            key={g.id}
+            style={styles.option}
+            onPress={() => toggle(g.title)}
+          >
+            {g.icon}
+            <View style={styles.info}>
+              <Text style={styles.label}>{g.title}</Text>
+              <Text style={styles.category}>{g.category}</Text>
+            </View>
+            <MaterialCommunityIcons
+              name={selected.includes(g.title) ? 'checkbox-marked' : 'checkbox-blank-outline'}
+              size={24}
+              color={theme?.accent}
+              style={styles.checkbox}
+            />
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+      {showPreviewBadges && (
+        <View style={styles.badgeRow}>
+          {BADGE_LIST.map((b) => (
+            <Ionicons
+              key={b.id}
+              name={b.icon}
+              size={20}
+              color={theme?.accent}
+              style={styles.badgeIcon}
+            />
+          ))}
+        </View>
+      )}
+    </>
+  );
+}
+
+GameSelectList.propTypes = {
+  selected: PropTypes.array,
+  onChange: PropTypes.func,
+  theme: PropTypes.object,
+  showPreviewBadges: PropTypes.bool,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { maxHeight: 250 },
+    option: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 6,
+    },
+    info: { flex: 1, marginLeft: 8 },
+    label: { color: theme?.text || '#000', fontSize: 16 },
+    category: { color: theme?.textSecondary || '#666', fontSize: 12 },
+    checkbox: { marginLeft: 8 },
+    badgeRow: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      marginTop: 12,
+    },
+    badgeIcon: { marginHorizontal: 4 },
+  });

--- a/screens/EditProfileScreen.js
+++ b/screens/EditProfileScreen.js
@@ -17,7 +17,7 @@ import { avatarSource } from '../utils/avatar';
 import { sanitizeText } from '../utils/sanitize';
 import PropTypes from 'prop-types';
 import RNPickerSelect from 'react-native-picker-select';
-import MultiSelectList from '../components/MultiSelectList';
+import GameSelectList from '../components/GameSelectList';
 import { useTheme } from '../contexts/ThemeContext';
 import { allGames } from '../data/games';
 
@@ -35,8 +35,6 @@ const EditProfileScreen = ({ navigation, route }) => {
   const [favoriteGames, setFavoriteGames] = useState(
     Array.isArray(user?.favoriteGames) ? user.favoriteGames : []
   );
-  const defaultGameOptions = allGames.map((g) => ({ label: g.title, value: g.title }));
-  const [gameOptions, setGameOptions] = useState(defaultGameOptions);
   const [avatar, setAvatar] = useState(user?.photoURL || '');
   const [jobTitle, setJobTitle] = useState(user?.jobTitle || '');
   const [company, setCompany] = useState(user?.company || '');
@@ -98,23 +96,6 @@ const EditProfileScreen = ({ navigation, route }) => {
     setEditMode(route?.params?.editMode || false);
   }, [route?.params?.editMode]);
 
-  useEffect(() => {
-    const unsub = firebase
-      .firestore()
-      .collection('games')
-      .orderBy('title')
-      .onSnapshot(
-        (snap) => {
-          if (!snap.empty) {
-            setGameOptions(
-              snap.docs.map((d) => ({ label: d.data().title, value: d.data().title }))
-            );
-          }
-        },
-        (e) => console.warn('Failed to load games', e)
-      );
-    return unsub;
-  }, []);
 
   const handleSave = async () => {
     if (!user) return;
@@ -309,8 +290,7 @@ const EditProfileScreen = ({ navigation, route }) => {
         onChangeText={setLocation}
       />
 
-      <MultiSelectList
-        options={gameOptions}
+      <GameSelectList
         selected={favoriteGames}
         onChange={setFavoriteGames}
         theme={theme}

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -32,6 +32,7 @@ import { Video } from 'expo-av';
 import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import MultiSelectList from '../components/MultiSelectList';
+import GameSelectList from '../components/GameSelectList';
 import { FONT_SIZES, BUTTON_STYLE, HEADER_SPACING } from '../layout';
 import Header from '../components/Header';
 import { allGames } from '../data/games';
@@ -106,34 +107,9 @@ export default function OnboardingScreen() {
       setTransitioning(false);
     }, 600);
   };
-  const defaultGameOptions = allGames.map((g) => ({
-    label: g.title,
-    value: g.title,
-  }));
-  const [gameOptions, setGameOptions] = useState(defaultGameOptions);
+  // favorite games selection uses static list from data/games.js
   const badgeOptions = BADGE_LIST.map((b) => ({ label: b.title, value: b.id }));
   const [showLocationInfo, setShowLocationInfo] = useState(false);
-
-  useEffect(() => {
-    const unsub = firebase
-      .firestore()
-      .collection('games')
-      .orderBy('title')
-      .onSnapshot(
-        (snap) => {
-          if (!snap.empty) {
-            setGameOptions(
-              snap.docs.map((d) => ({
-                label: d.data().title,
-                value: d.data().title,
-              }))
-            );
-          }
-        },
-        (e) => console.warn('Failed to load games', e)
-      );
-    return unsub;
-  }, []);
 
   const currentField = questions[step].key;
   const progress = (step + 1) / questions.length;
@@ -528,13 +504,13 @@ export default function OnboardingScreen() {
 
     if (currentField === 'favoriteGames') {
       return (
-        <MultiSelectList
-          options={gameOptions}
+        <GameSelectList
           selected={answers.favoriteGames}
           onChange={(vals) =>
             setAnswers((prev) => ({ ...prev, favoriteGames: vals }))
           }
           theme={theme}
+          showPreviewBadges
         />
       );
     }


### PR DESCRIPTION
## Summary
- create `GameSelectList` component for choosing games
- integrate new component into onboarding and profile editing
- show preview of unlockable badges when selecting favorite games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c874884f4832d8c4191a6b0c9a6d8