### PR TITLE
Add onboarding presets

### DIFF
--- a/contexts/ThemeContext.js
+++ b/contexts/ThemeContext.js
@@ -3,6 +3,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { View } from 'react-native';
 import Loader from '../components/Loader';
 import { lightTheme, darkTheme } from '../theme';
+import { PRESETS } from '../data/presets';
+import { useUser } from './UserContext';
 
 const ThemeContext = createContext();
 const STORAGE_KEY = 'darkMode';
@@ -10,6 +12,7 @@ const STORAGE_KEY = 'darkMode';
 export const ThemeProvider = ({ children }) => {
   const [loaded, setLoaded] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
+  const { user } = useUser();
 
   useEffect(() => {
     let isMounted = true;
@@ -35,7 +38,15 @@ export const ThemeProvider = ({ children }) => {
     setDarkMode(next);
   };
 
-  const theme = darkMode ? darkTheme : lightTheme;
+  const baseTheme = darkMode ? darkTheme : lightTheme;
+  const preset = PRESETS.find((p) => p.id === user?.themePreset) || PRESETS[0];
+  const theme = {
+    ...baseTheme,
+    accent: preset.accent,
+    gradientStart: preset.gradientStart,
+    gradientEnd: preset.gradientEnd,
+    gradient: [preset.gradientStart, preset.gradientEnd],
+  };
 
   return (
     <ThemeContext.Provider value={{ darkMode, toggleTheme, theme, loaded }}>

--- a/data/presets.js
+++ b/data/presets.js
@@ -1,0 +1,26 @@
+export const PRESETS = [
+  {
+    id: 'default',
+    label: 'Default',
+    mood: 'Ready to play!',
+    accent: '#FF75B5',
+    gradientStart: '#8B5CF6',
+    gradientEnd: '#EC4899',
+  },
+  {
+    id: 'cool',
+    label: 'Cool',
+    mood: 'Chillin\' and ready',
+    accent: '#4FD1C5',
+    gradientStart: '#5EEAD4',
+    gradientEnd: '#2DD4BF',
+  },
+  {
+    id: 'sunny',
+    label: 'Sunny',
+    mood: 'Feeling bright',
+    accent: '#FBBF24',
+    gradientStart: '#FDE68A',
+    gradientEnd: '#F59E0B',
+  },
+];

--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -14,6 +14,7 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `favoriteGames` (array of string)
 - `bio` (string)
 - `mood` (string)
+- `themePreset` (string)
 - `promptResponses` (array of string)
 - `personalityTags` (string)
 - `badgePrefs` (array of string)

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -40,6 +40,7 @@ import { logDev } from '../utils/logger';
 import LocationInfoModal from '../components/LocationInfoModal';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import useVoicePlayback from '../hooks/useVoicePlayback';
+import { PRESETS } from '../data/presets';
 
 const overlayOptions = [
   { id: 'heart', src: overlayAssets.heart },
@@ -54,6 +55,7 @@ const questions = [
   { key: 'ageGender', label: 'Age & gender' },
   { key: 'bio', label: 'Write a short bio' },
   { key: 'location', label: 'Where are you located?' },
+  { key: 'preset', label: 'Choose a preset' },
   { key: 'mood', label: 'How are you feeling today?' },
   { key: 'favoriteGames', label: 'Select your favorite games' },
   { key: 'promptResponses', label: 'Answer some prompts' },
@@ -88,7 +90,8 @@ export default function OnboardingScreen() {
     genderPref: '',
     bio: '',
     location: '',
-    mood: '',
+    preset: 'default',
+    mood: PRESETS[0].mood,
     favoriteGames: [],
     promptResponses: ['', '', ''],
     personalityTags: '',
@@ -227,6 +230,7 @@ export default function OnboardingScreen() {
         personalityTags: sanitizeText(answers.personalityTags.trim()),
         badgePrefs: answers.badgePrefs.map((b) => sanitizeText(b)),
         bio: sanitizeText(answers.bio.trim()),
+        themePreset: answers.preset,
         onboardingComplete: true,
         createdAt: firebase.firestore.FieldValue.serverTimestamp(),
       };
@@ -486,6 +490,32 @@ export default function OnboardingScreen() {
             <Ionicons name="arrow-forward" size={16} color={theme.accent} />
           </TouchableOpacity>
         </View>
+      );
+    }
+
+    if (currentField === 'preset') {
+      const options = PRESETS.map((p) => ({ label: p.label, value: p.id }));
+      return (
+        <RNPickerSelect
+          onValueChange={(val) => {
+            Haptics.selectionAsync().catch(() => {});
+            const preset = PRESETS.find((p) => p.id === val) || PRESETS[0];
+            setAnswers((prev) => ({
+              ...prev,
+              preset: val,
+              mood: preset.mood,
+            }));
+          }}
+          value={answers.preset}
+          placeholder={{ label: 'Select a preset', value: null }}
+          useNativeAndroidPickerStyle={false}
+          style={{
+            inputIOS: styles.input,
+            inputAndroid: styles.input,
+            placeholder: { color: darkMode ? '#999' : '#aaa' },
+          }}
+          items={options}
+        />
       );
     }
 


### PR DESCRIPTION
## Summary
- add preset data
- let `ThemeProvider` read the user's preset
- extend onboarding flow with preset picker
- store selected preset in Firestore
- document new `themePreset` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c883f5a6c832d9b3e907b9096bdb4