### PR TITLE
Fix keyboard overlap on key screens

### DIFF
--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -18,6 +18,7 @@ import GradientButton from '../components/GradientButton';
 import Card, { CARD_STYLE } from '../components/Card';
 import EventFlyer from '../components/EventFlyer';
 import ScreenContainer from '../components/ScreenContainer';
+import SafeKeyboardView from '../components/SafeKeyboardView';
 import { eventImageSource } from '../utils/avatar';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
@@ -325,7 +326,7 @@ const CommunityScreen = () => {
       {/* Host Modal */}
       <Modal visible={showHostModal} transparent animationType="fade">
         <View style={local.modalBackdrop}>
-          <View style={local.modalCard}>
+          <SafeKeyboardView style={local.modalCard}>
             <Text style={local.modalTitle}>Host an Event</Text>
             <TextInput
               placeholder="Event Title"
@@ -374,14 +375,14 @@ const CommunityScreen = () => {
             <TouchableOpacity onPress={() => setShowHostModal(false)} style={{ marginTop: 10 }}>
               <Text style={{ color: theme.accent }}>Cancel</Text>
             </TouchableOpacity>
-          </View>
+          </SafeKeyboardView>
         </View>
       </Modal>
 
       {/* Post Modal */}
       <Modal visible={showPostModal} transparent animationType="fade">
         <View style={local.modalBackdrop}>
-          <View style={local.modalCard}>
+          <SafeKeyboardView style={local.modalCard}>
             <Text style={local.modalTitle}>Create Post</Text>
             <TextInput
               placeholder="Title"
@@ -421,7 +422,7 @@ const CommunityScreen = () => {
             <TouchableOpacity onPress={() => setShowPostModal(false)} style={{ marginTop: 10 }}>
               <Text style={{ color: theme.accent }}>Cancel</Text>
             </TouchableOpacity>
-          </View>
+          </SafeKeyboardView>
         </View>
       </Modal>
 

--- a/screens/PhoneVerificationScreen.js
+++ b/screens/PhoneVerificationScreen.js
@@ -4,6 +4,7 @@ import { View, TextInput, Text } from "react-native";
 import GradientBackground from "../components/GradientBackground";
 import GradientButton from "../components/GradientButton";
 import ScreenContainer from "../components/ScreenContainer";
+import SafeKeyboardView from "../components/SafeKeyboardView";
 import Header from "../components/Header";
 import RNPickerSelect from "react-native-picker-select";
 import { auth } from "../firebase";
@@ -123,6 +124,7 @@ export default function PhoneVerificationScreen({ navigation }) {
       <ScreenContainer
         style={{ paddingTop: HEADER_SPACING, alignItems: "center" }}
       >
+        <SafeKeyboardView style={{ flex: 1 }}>
         {!showOtp && (
           <View style={{ width: "100%" }}>
             <RNPickerSelect
@@ -164,6 +166,7 @@ export default function PhoneVerificationScreen({ navigation }) {
             <GradientButton text="Verify" onPress={verifyCode} />
           </View>
         )}
+        </SafeKeyboardView>
       </ScreenContainer>
     </GradientBackground>
   );

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -3,6 +3,7 @@ import { Text, View, TextInput, Switch, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as WebBrowser from 'expo-web-browser';
 import ScreenContainer from '../components/ScreenContainer';
+import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientButton from '../components/GradientButton';
 import GradientBackground from '../components/GradientBackground';
 import getStyles from '../styles';
@@ -83,7 +84,8 @@ const SettingsScreen = ({ navigation }) => {
   return (
     <GradientBackground style={{ flex: 1 }}>
       <ScreenContainer scroll contentContainerStyle={styles.container}>
-        <Header />
+        <SafeKeyboardView style={{ flex: 1 }}>
+          <Header />
 
       <Text style={[styles.logoText, { color: theme.text, marginBottom: 10 }]}>
         Settings
@@ -363,6 +365,7 @@ const SettingsScreen = ({ navigation }) => {
           <GradientButton text="Log Out" onPress={handleLogout} />
         </>
       )}
+        </SafeKeyboardView>
       </ScreenContainer>
     </GradientBackground>
   );


### PR DESCRIPTION
## Summary
- import and use `SafeKeyboardView` in `SettingsScreen` to avoid keyboard overlap
- wrap phone verification inputs with `SafeKeyboardView`
- ensure community post and event modals are keyboard-aware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ca58e9ab4832dbb1e8c0907374a12