### PR TITLE
Fix user doc read rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -51,7 +51,7 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
-      allow read: if signedIn();
+      allow read: if request.auth.uid == userId;
       allow create: if isUser(userId);
       // Only allow users to update their own document
       allow update: if isUser(userId) &&


### PR DESCRIPTION
## Summary
- update `firestore.rules` so `/users/{userId}` docs are readable only by their owner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d7a3c4854832d86146618e398df43