### PR TITLE
Restrict writes on events and community posts

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -106,7 +106,9 @@ service cloud.firestore {
     }
 
     match /events/{eventId} {
-      allow read, write: if signedIn();
+      allow read: if signedIn();
+      allow create, update: if request.auth.uid == request.resource.data.hostId;
+      allow delete: if request.auth.uid == resource.data.hostId;
     }
 
     match /matchHistory/{historyId} {
@@ -127,7 +129,8 @@ service cloud.firestore {
     // Community Board posts accessible to all signed-in users
     match /communityPosts/{postId} {
       allow read: if true;
-      allow write: if signedIn();
+      allow create, update: if request.auth.uid == request.resource.data.hostId;
+      allow delete: if request.auth.uid == resource.data.hostId;
     }
   }
 }


### PR DESCRIPTION
## Summary
- tighten firestore rules for `events` and `communityPosts` so that only the host can write

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7a47394c832da1f0ca705a192b57