### PR TITLE
Restrict user reads in Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -55,7 +55,9 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
-      allow read, delete: if isUser(userId);
+      // Restrict read access to only the authenticated user
+      allow read: if request.auth.uid == userId;
+      allow delete: if isUser(userId);
       allow create: if isUser(userId) &&
         request.resource.data.uid is string &&
         request.resource.data.uid == userId;


### PR DESCRIPTION
## Summary
- restrict read access on `/users/{userId}` to the authenticated user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d9af03f70832d9aff21d8a4eee52f