### PR TITLE
Wrap ChatScreen fallback content with SafeKeyboardView

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';
 import EmptyState from '../components/EmptyState';
+import SafeKeyboardView from '../components/SafeKeyboardView';
+import { HEADER_SPACING } from '../layout';
 import { useChats } from '../contexts/ChatContext';
 
 import PrivateChat from './PrivateChat';
@@ -25,11 +27,13 @@ export default function ChatScreen({ route }) {
     return (
       <GradientBackground style={{ flex: 1 }}>
         <Header />
-        <EmptyState
-          text="No match found."
-          image={require('../assets/logo.png')}
-          style={{ marginTop: 40 }}
-        />
+        <SafeKeyboardView style={{ flex: 1, paddingTop: HEADER_SPACING }} offset={0}>
+          <EmptyState
+            text="No match found."
+            image={require('../assets/logo.png')}
+            style={{ marginTop: 40 }}
+          />
+        </SafeKeyboardView>
       </GradientBackground>
     );
   }


### PR DESCRIPTION
## Summary
- import SafeKeyboardView in `ChatScreen`
- wrap the empty state path in a SafeKeyboardView to avoid keyboard overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7a9939e8832d9a5d731ec2dc5c34