### PR TITLE
Fix ScrollView tap persistence

### DIFF
--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -25,6 +25,7 @@ export default function ScreenContainer({
     <AnimatedSafeAreaView style={[styles.container, style, { opacity: fadeAnim }]}>
       {scroll ? (
         <ScrollView
+          keyboardShouldPersistTaps="handled"
           contentContainerStyle={[styles.content, contentContainerStyle]}
           {...rest}
         >

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -217,7 +217,12 @@ const CommunityScreen = () => {
         <Text style={local.header}>🎉 Community Board</Text>
 
         {/* Filters */}
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ paddingHorizontal: 16, marginBottom: 16 }}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          style={{ paddingHorizontal: 16, marginBottom: 16 }}
+        >
           {FILTERS.map((f, i) => (
             <TouchableOpacity
               key={i}

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -524,7 +524,11 @@ function BotSessionScreen({ route }) {
         >
         <ScreenContainer style={{ paddingTop: HEADER_SPACING, paddingBottom: 20 }}>
         <View style={botStyles.gameTabs}>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
             {Object.entries(gameMap).map(([key, val]) => (
               <TouchableOpacity
                 key={key}
@@ -658,7 +662,7 @@ function SpectatorSessionScreen({ route }) {
           ))}
         </View>
         <View style={styles.logBox}>
-          <ScrollView ref={scrollRef}>
+          <ScrollView ref={scrollRef} keyboardShouldPersistTaps="handled">
             {moveHistory.map((m, idx) => (
               <Text key={idx} style={styles.logText}>
                 Player {Number(m.player) + 1}: {m.action}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -122,6 +122,7 @@ const HomeScreen = ({ navigation }) => {
       <ScreenContainer>
         <Header showLogoOnly />
         <ScrollView
+          keyboardShouldPersistTaps="handled"
           contentContainerStyle={[
             local.container,
             { paddingTop: HEADER_SPACING, paddingBottom: 100 },

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -149,6 +149,7 @@ const NotificationsScreen = ({ navigation }) => {
     <GradientBackground style={styles.container}>
       <Header navigation={navigation} />
       <ScrollView
+        keyboardShouldPersistTaps="handled"
         contentContainerStyle={{
           paddingTop: HEADER_SPACING,
           padding: 20,


### PR DESCRIPTION
## Summary
- keep keyboard taps on ScrollView in ScreenContainer
- handle taps on Home, GameSession, Community, and Notifications screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7a9e5550832db74efb8883033474