### PR TITLE
Reset to Main after onboarding

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -214,6 +214,7 @@ export default function OnboardingScreen() {
       updateUser(profile);
       markOnboarded();
       Toast.show({ type: 'success', text1: 'Profile saved!' });
+      navigation.reset({ index: 0, routes: [{ name: 'Main' }] });
     } catch (e) {
       console.error('Save error:', e);
       Toast.show({ type: 'error', text1: 'Failed to save profile' });


### PR DESCRIPTION
## Summary
- reset navigation to enter Main after successfully saving onboarding profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686daa2e843c832d89a267c089549447