### PR TITLE
Add profile modal and card tapping

### DIFF
--- a/components/FullProfileModal.js
+++ b/components/FullProfileModal.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Modal, View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { BlurView } from 'expo-blur';
+import PropTypes from 'prop-types';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function FullProfileModal({ visible, onClose, user }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  if (!user) return null;
+  const games = Array.isArray(user.favoriteGames)
+    ? user.favoriteGames.join(', ')
+    : '';
+  const fields = [
+    { label: 'Age', value: user.age },
+    { label: 'Location', value: user.location },
+    { label: 'Gender', value: user.gender },
+    { label: 'Looking for', value: user.genderPref },
+    { label: 'Favorite Games', value: games },
+    { label: 'Bio', value: user.bio },
+  ];
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <BlurView intensity={60} tint="dark" style={styles.backdrop}>
+        <View style={styles.card}>
+          <ScrollView contentContainerStyle={styles.content}>
+            <Text style={styles.name}>{user.displayName}</Text>
+            {fields.map(
+              (f) =>
+                f.value ? (
+                  <Text key={f.label} style={styles.field}>{`${f.label}: ${f.value}`}</Text>
+                ) : null
+            )}
+            <TouchableOpacity onPress={onClose} style={styles.button}>
+              <Text style={styles.buttonText}>Close</Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </View>
+      </BlurView>
+    </Modal>
+  );
+}
+
+FullProfileModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  user: PropTypes.object,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    backdrop: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    card: {
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      width: '85%',
+      maxHeight: '80%',
+      overflow: 'hidden',
+    },
+    content: { padding: 20 },
+    name: {
+      fontSize: 22,
+      fontWeight: 'bold',
+      color: theme.text,
+      textAlign: 'center',
+      marginBottom: 12,
+    },
+    field: { color: theme.text, fontSize: 16, marginBottom: 6 },
+    button: {
+      marginTop: 20,
+      alignSelf: 'center',
+      backgroundColor: theme.accent,
+      paddingHorizontal: 20,
+      paddingVertical: 8,
+      borderRadius: 20,
+    },
+    buttonText: { color: '#fff', fontWeight: 'bold' },
+  });

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -42,6 +42,7 @@ import useRequireGameCredits from '../hooks/useRequireGameCredits';
 import * as Haptics from 'expo-haptics';
 import SkeletonUserCard from '../components/SkeletonUserCard';
 import EmptyState from '../components/EmptyState';
+import FullProfileModal from '../components/FullProfileModal';
 import useVoicePlayback from '../hooks/useVoicePlayback';
 import { useSound } from '../contexts/SoundContext';
 import { useFilters } from '../contexts/FilterContext';
@@ -117,6 +118,7 @@ const SwipeScreen = () => {
   const [history, setHistory] = useState([]);
   const [showSuperLikeAnim, setShowSuperLikeAnim] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
+  const [showProfile, setShowProfile] = useState(false);
   const [matchLine, setMatchLine] = useState('');
   const [matchGame, setMatchGame] = useState(null);
   const [loadingUsers, setLoadingUsers] = useState(true);
@@ -569,6 +571,18 @@ const handleSwipe = async (direction) => {
         useNativeDriver: false,
       }),
       onPanResponderRelease: (_, gesture) => {
+        const isTap = Math.abs(gesture.dx) < 10 && Math.abs(gesture.dy) < 10;
+        if (isTap) {
+          setImageIndex((i) =>
+            (i + 1) % (displayUser?.images?.length || 1)
+          );
+          Animated.spring(pan, {
+            toValue: { x: 0, y: 0 },
+            useNativeDriver: false,
+          }).start();
+          return;
+        }
+
         if (gesture.dy < -120 && Math.abs(gesture.dx) < 80) {
           handleSwipeChallenge();
         } else if (gesture.dx > 120) {
@@ -727,6 +741,15 @@ const handleSwipe = async (direction) => {
                 style={styles.expandIcon}
               >
                 <Ionicons name="chevron-up" size={24} color="#fff" />
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => {
+                  Haptics.selectionAsync().catch(() => {});
+                  setShowProfile(true);
+                }}
+                style={styles.infoIcon}
+              >
+                <Ionicons name="information-circle" size={24} color="#fff" />
               </TouchableOpacity>
             </View>
           </TouchableOpacity>
@@ -920,6 +943,11 @@ const handleSwipe = async (direction) => {
           onSelect={handleGamePickSelect}
           onClose={() => setShowGamePicker(false)}
         />
+        <FullProfileModal
+          visible={showProfile}
+          onClose={() => setShowProfile(false)}
+          user={displayUser}
+        />
         <BoostModal
           visible={showBoostModal}
           trialUsed={!!currentUser?.boostTrialUsed}
@@ -1008,6 +1036,11 @@ const getStyles = (theme) =>
     position: 'absolute',
     bottom: -30,
     alignSelf: 'center',
+  },
+  infoIcon: {
+    position: 'absolute',
+    top: SPACING.MD,
+    right: SPACING.MD,
   },
   noMoreWrapper: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- open FullProfileModal when tapping the info icon
- support cycling profile images by tapping the swipe card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d7ac0a0e4832daea731e2dcfbc2d3