### PR TITLE
Add premium paywall screen

### DIFF
--- a/navigation/AppStack.js
+++ b/navigation/AppStack.js
@@ -12,6 +12,7 @@ const GameSessionScreen = lazy(() => import("../screens/GameSessionScreen"));
 const GameWithBotScreen = lazy(() => import("../screens/GameWithBotScreen"));
 const CommunityScreen = lazy(() => import("../screens/CommunityScreen"));
 const PremiumScreen = lazy(() => import("../screens/PremiumScreen"));
+const PremiumPaywallScreen = lazy(() => import("../screens/PremiumPaywallScreen"));
 const StatsScreen = lazy(() => import("../screens/StatsScreen"));
 const PlayScreen = lazy(() => import("../screens/PlayScreen"));
 const SwipeScreen = lazy(() => import("../screens/SwipeScreen"));
@@ -46,6 +47,7 @@ export default function AppStack() {
       <Stack.Screen name="Community" component={CommunityScreen} />
       <Stack.Screen name="EventChat" component={ChatScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
+      <Stack.Screen name="PremiumPaywall" component={PremiumPaywallScreen} />
       <Stack.Screen name="Stats" component={StatsScreen} />
       <Stack.Screen
         name="GameWithBot"

--- a/screens/PremiumPaywallScreen.js
+++ b/screens/PremiumPaywallScreen.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import GradientBackground from '../components/GradientBackground';
+import GradientButton from '../components/GradientButton';
+import ScreenContainer from '../components/ScreenContainer';
+import Header from '../components/Header';
+import { useTheme } from '../contexts/ThemeContext';
+import PropTypes from 'prop-types';
+
+export default function PremiumPaywallScreen({ navigation }) {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  return (
+    <GradientBackground style={{ flex: 1 }}>
+      <Header />
+      <ScreenContainer style={styles.container}>
+        <Text style={styles.title}>Premium Feature</Text>
+        <Text style={styles.subtitle}>
+          Superlikes and Boosts are available for Premium members.
+        </Text>
+        <GradientButton
+          text="Go Premium"
+          onPress={() => navigation.replace('Premium')}
+          style={{ marginTop: 20 }}
+        />
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Text style={styles.cancel}>Maybe Later</Text>
+        </TouchableOpacity>
+      </ScreenContainer>
+    </GradientBackground>
+  );
+}
+
+PremiumPaywallScreen.propTypes = {
+  navigation: PropTypes.shape({
+    goBack: PropTypes.func.isRequired,
+    replace: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingTop: 80,
+      alignItems: 'center',
+      paddingHorizontal: 20,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      color: theme.accent,
+      marginBottom: 12,
+    },
+    subtitle: {
+      fontSize: 16,
+      color: theme.text,
+      textAlign: 'center',
+      marginBottom: 40,
+    },
+    cancel: {
+      color: theme.textSecondary,
+      fontSize: 14,
+      marginTop: 16,
+    },
+  });

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -464,7 +464,7 @@ const handleSwipe = async (direction) => {
 
   const rewind = () => {
     if (!isPremiumUser && !devMode) {
-      navigation.navigate('Premium', { context: 'paywall' });
+      navigation.navigate('PremiumPaywall', { context: 'paywall' });
       return;
     }
     if (history.length === 0) return;
@@ -478,7 +478,7 @@ const handleSwipe = async (direction) => {
   const handleSwipeChallenge = () => {
     if (!displayUser) return;
     if (!isPremiumUser && !devMode) {
-      navigation.navigate('Premium', { context: 'paywall' });
+      navigation.navigate('PremiumPaywall', { context: 'paywall' });
       return;
     }
     setShowGamePicker(true);
@@ -487,7 +487,7 @@ const handleSwipe = async (direction) => {
   const handleSuperLike = async () => {
     if (!displayUser) return;
     if (!isPremiumUser && !devMode) {
-      navigation.navigate('Premium', { context: 'paywall' });
+      navigation.navigate('PremiumPaywall', { context: 'paywall' });
       return;
     }
 
@@ -646,7 +646,7 @@ const handleSwipe = async (direction) => {
 
   const handleBoostPress = () => {
     if (currentUser?.boostTrialUsed && !isPremiumUser && !devMode) {
-      navigation.navigate('Premium', { context: 'upgrade' });
+      navigation.navigate('PremiumPaywall', { context: 'upgrade' });
     } else {
       setShowBoostModal(true);
     }
@@ -816,7 +816,7 @@ const handleSwipe = async (direction) => {
                 onLongPress={() =>
                   btn.longAction && (isPremiumUser || devMode)
                     ? btn.longAction()
-                    : btn.longAction && navigation.navigate('Premium', { context: 'paywall' })
+                    : btn.longAction && navigation.navigate('PremiumPaywall', { context: 'paywall' })
                 }
                 delayLongPress={300}
                 style={[styles.circleButton, { backgroundColor: btn.color }]}
@@ -924,7 +924,7 @@ const handleSwipe = async (direction) => {
           visible={showBoostModal}
           trialUsed={!!currentUser?.boostTrialUsed}
           onActivate={activateBoost}
-          onUpgrade={() => navigation.navigate('Premium', { context: 'upgrade' })}
+          onUpgrade={() => navigation.navigate('PremiumPaywall', { context: 'upgrade' })}
           onClose={() => setShowBoostModal(false)}
         />
         {showUndoPrompt && (isPremiumUser || devMode) ? (


### PR DESCRIPTION
## Summary
- add `PremiumPaywallScreen`
- register new screen in the app stack
- route superlike and boost actions to `PremiumPaywall` when user lacks premium

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7ac3c8d8832db3924fba919b9d52