### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p>This page explains how we collect, use and share your information. It is a placeholder for the full policy.</p>
+</body>
+</html>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <h1>Terms of Service</h1>
+  <p>These are the placeholder terms of service for the Pinged app.</p>
+</body>
+</html>

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -375,9 +375,17 @@ const SettingsScreen = ({ navigation }) => {
             }
           />
           <GradientButton
-            text="Privacy"
+            text="Privacy Policy"
             onPress={() =>
-              WebBrowser.openBrowserAsync('https://example.com/privacy')
+              WebBrowser.openBrowserAsync(
+                'https://example.com/privacy-policy.html'
+              )
+            }
+          />
+          <GradientButton
+            text="Terms of Service"
+            onPress={() =>
+              WebBrowser.openBrowserAsync('https://example.com/terms.html')
             }
           />
         </View>


### PR DESCRIPTION
## Summary
- add placeholders for privacy policy and terms of service
- link new privacy and terms pages from settings screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7af0d8bc832db4011094855a06e8