### PR TITLE
Remove unused imports

### DIFF
--- a/components/ActiveGamesPreview.js
+++ b/components/ActiveGamesPreview.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useGameSessions } from '../contexts/GameSessionContext';

--- a/components/ArcadeGameWrapper.js
+++ b/components/ArcadeGameWrapper.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { View, StyleSheet, Text, Image, Animated, Easing } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TextInput } from 'react-native';
 import SafeKeyboardView from './SafeKeyboardView';
 import GradientButton from './GradientButton';

--- a/components/AvatarRing.js
+++ b/components/AvatarRing.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { View, Image, Animated, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import PropTypes from 'prop-types';

--- a/components/BoostModal.js
+++ b/components/BoostModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/Card.js
+++ b/components/Card.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   View,
   StyleSheet,

--- a/components/CategoryChips.js
+++ b/components/CategoryChips.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, TouchableOpacity, Text } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';

--- a/components/ChatContainer.js
+++ b/components/ChatContainer.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 

--- a/components/CountdownRing.js
+++ b/components/CountdownRing.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Svg, { Circle } from 'react-native-svg';
 

--- a/components/DevBanner.js
+++ b/components/DevBanner.js
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useState } from 'react';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import * as Haptics from 'expo-haptics';
-import PropTypes from 'prop-types';
 import { useDev } from '../contexts/DevContext';
 import DevPanel from './DevPanel';
 
@@ -25,7 +24,6 @@ export default function DevBanner() {
   );
 }
 
-DevBanner.propTypes = {};
 
 const styles = StyleSheet.create({
   banner: {

--- a/components/DevPanel.js
+++ b/components/DevPanel.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, Modal, ScrollView, StyleSheet, Button, Platform } from 'react-native';
 import PropTypes from 'prop-types';
 import AsyncStorage from '@react-native-async-storage/async-storage';

--- a/components/EmptyState.js
+++ b/components/EmptyState.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, Image, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import LottieView from 'lottie-react-native';

--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import Toast from 'react-native-toast-message';

--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -1,6 +1,4 @@
-import React from 'react';
 import { View, Text, Image, StyleSheet } from 'react-native';
-import PropTypes from 'prop-types';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import { eventImageSource } from '../utils/avatar';
@@ -39,7 +37,6 @@ export default function EventBanner() {
   );
 }
 
-EventBanner.propTypes = {};
 
 const getStyles = (theme) =>
   StyleSheet.create({

--- a/components/EventFlyer.js
+++ b/components/EventFlyer.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, Image, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/FavoriteStar.js
+++ b/components/FavoriteStar.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { Ionicons } from '@expo/vector-icons';

--- a/components/FilterTabs.js
+++ b/components/FilterTabs.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, TouchableOpacity, Text, Keyboard } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';

--- a/components/FullProfileModal.js
+++ b/components/FullProfileModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
 import { BlurView } from 'expo-blur';
 import PropTypes from 'prop-types';

--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text } from 'react-native';
 import { textStyles } from '../textStyles';
 import PropTypes from 'prop-types';

--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Animated, TouchableOpacity, Dimensions } from 'react-native';
 import { SPACING } from '../layout';
 import * as Haptics from 'expo-haptics';

--- a/components/GameContainer.js
+++ b/components/GameContainer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { View, TouchableOpacity, StyleSheet, Animated } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';

--- a/components/GameFilters.js
+++ b/components/GameFilters.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import SearchInput from './SearchInput';
 import FilterTabs from './FilterTabs';

--- a/components/GameMenu.js
+++ b/components/GameMenu.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/GameOverModal.js
+++ b/components/GameOverModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Modal, View, Text, Image, Pressable, StyleSheet } from 'react-native';
 import LottieView from 'lottie-react-native';
 import { BlurView } from 'expo-blur';

--- a/components/GamePickerModal.js
+++ b/components/GamePickerModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/GamePreviewModal.js
+++ b/components/GamePreviewModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import LottieView from 'lottie-react-native';
 import PropTypes from 'prop-types';

--- a/components/GameSelectList.js
+++ b/components/GameSelectList.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView, TouchableOpacity, Text, StyleSheet, View } from 'react-native';
 import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
 import PropTypes from 'prop-types';

--- a/components/GradientBackground.js
+++ b/components/GradientBackground.js
@@ -1,5 +1,5 @@
 // components/GradientBackground.js
-import React from 'react';
+
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -1,5 +1,5 @@
 // components/GradientButton.tsx
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { View, Text, Pressable, Animated, StyleSheet } from 'react-native';
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';

--- a/components/InviteUserCard.js
+++ b/components/InviteUserCard.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, Animated } from 'react-native';
 import PropTypes from 'prop-types';
 import Card from './Card';

--- a/components/Loader.js
+++ b/components/Loader.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import LottieView from 'lottie-react-native';
 import PropTypes from 'prop-types';
 

--- a/components/LoadingOverlay.js
+++ b/components/LoadingOverlay.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLoading } from '../contexts/LoadingContext';

--- a/components/LocationInfoModal.js
+++ b/components/LocationInfoModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/MatchesPreview.js
+++ b/components/MatchesPreview.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/MultiSelectList.js
+++ b/components/MultiSelectList.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { MaterialCommunityIcons } from '@expo/vector-icons';

--- a/components/NotificationCenter.js
+++ b/components/NotificationCenter.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import {
   Animated,
   Text,

--- a/components/PlayerInfoBar.js
+++ b/components/PlayerInfoBar.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, TouchableOpacity, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import ProgressBar from './ProgressBar';

--- a/components/PremiumBadge.js
+++ b/components/PremiumBadge.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/PremiumBanner.js
+++ b/components/PremiumBanner.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';

--- a/components/ProgressBar.js
+++ b/components/ProgressBar.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { View, Text, Animated, Easing } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import PropTypes from 'prop-types';

--- a/components/SafeKeyboardView.js
+++ b/components/SafeKeyboardView.js
@@ -1,5 +1,5 @@
 import { KeyboardAvoidingView, Platform } from 'react-native';
-import React from 'react';
+
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import PropTypes from 'prop-types';
 

--- a/components/ScreenContainer.js
+++ b/components/ScreenContainer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, Animated } from 'react-native';
 import PropTypes from 'prop-types';
 

--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, TextInput } from 'react-native';
 import { textStyles } from '../textStyles';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/SkeletonPlaceholder.js
+++ b/components/SkeletonPlaceholder.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { View, Animated, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import PropTypes from 'prop-types';

--- a/components/SkeletonUserCard.js
+++ b/components/SkeletonUserCard.js
@@ -1,6 +1,4 @@
-import React from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
-import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -22,7 +20,6 @@ function SkeletonUserCard() {
   );
 }
 
-SkeletonUserCard.propTypes = {};
 
 export default SkeletonUserCard;
 

--- a/components/StreakRewardModal.js
+++ b/components/StreakRewardModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
 import { BlurView } from 'expo-blur';
 import LottieView from 'lottie-react-native';

--- a/components/SyncedGame.js
+++ b/components/SyncedGame.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View } from 'react-native';
 import Loader from './Loader';
 import useGameSession from '../hooks/useGameSession';

--- a/components/TrendingBadge.js
+++ b/components/TrendingBadge.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 

--- a/components/VoiceMessageBubble.js
+++ b/components/VoiceMessageBubble.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import useVoicePlayback from '../hooks/useVoicePlayback';

--- a/components/XpInfoModal.js
+++ b/components/XpInfoModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import LottieView from 'lottie-react-native';

--- a/components/stats/ProfileCard.js
+++ b/components/stats/ProfileCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { View, Text } from 'react-native';
 import AvatarRing from '../AvatarRing';
 import { Ionicons } from '@expo/vector-icons';

--- a/components/stats/StatBox.js
+++ b/components/stats/StatBox.js
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
 

--- a/screens/ActiveGamesScreen.js
+++ b/screens/ActiveGamesScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';

--- a/screens/AdminReviewScreen.js
+++ b/screens/AdminReviewScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { View, Text, FlatList } from 'react-native';
 import PropTypes from 'prop-types';
 import firebase from '../firebase';

--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import GradientBackground from '../components/GradientBackground';
 import Header from '../components/Header';

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -23,7 +23,6 @@ import { eventImageSource } from '../utils/avatar';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNavigation } from '@react-navigation/native';
-import PropTypes from 'prop-types';
 import { useUser } from '../contexts/UserContext';
 import firebase from '../firebase';
 import { SAMPLE_EVENTS, SAMPLE_POSTS } from '../data/community';
@@ -636,6 +635,5 @@ const getStyles = (theme, skeletonColor) =>
   },
 });
 
-CommunityScreen.propTypes = {};
 
 export default CommunityScreen;

--- a/screens/EditProfileScreen.js
+++ b/screens/EditProfileScreen.js
@@ -1,6 +1,6 @@
 // /screens/EditProfileScreen.js
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, TextInput, TouchableOpacity, View, Image, Switch } from 'react-native';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientBackground from '../components/GradientBackground';
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import RNPickerSelect from 'react-native-picker-select';
 import GameSelectList from '../components/GameSelectList';
 import { useTheme } from '../contexts/ThemeContext';
-import { allGames } from '../data/games';
 
 const EditProfileScreen = ({ navigation, route }) => {
   const { user, updateUser } = useUser();

--- a/screens/EmailAuthScreen.js
+++ b/screens/EmailAuthScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Text, TouchableOpacity, Alert } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import AuthForm from '../components/AuthForm';

--- a/screens/GameInviteScreen.js
+++ b/screens/GameInviteScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -11,7 +11,6 @@ import * as Haptics from 'expo-haptics';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientBackground from '../components/GradientBackground';
 import ScreenContainer from '../components/ScreenContainer';
-import GradientButton from '../components/GradientButton';
 import Header from '../components/Header';
 import SkeletonPlaceholder from '../components/SkeletonPlaceholder';
 import { useTheme } from '../contexts/ThemeContext';

--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,

--- a/screens/GameWithBotScreen.js
+++ b/screens/GameWithBotScreen.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import GameSessionScreen from './GameSessionScreen';
 import PropTypes from 'prop-types';
 

--- a/screens/GroupChat.js
+++ b/screens/GroupChat.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,

--- a/screens/LikedYouScreen.js
+++ b/screens/LikedYouScreen.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { View, FlatList, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, FlatList, Text, StyleSheet } from 'react-native';
 import getStyles from '../styles';
 import GradientBackground from '../components/GradientBackground';
 import ScreenContainer from '../components/ScreenContainer';

--- a/screens/MatchesScreen.js
+++ b/screens/MatchesScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -1,5 +1,5 @@
 // /screens/NotificationsScreen.js
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -1,5 +1,5 @@
 // screens/OnboardingScreen.js
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -15,7 +15,6 @@ import GradientBackground from '../components/GradientBackground';
 import { useTheme } from '../contexts/ThemeContext';
 import firebase from '../firebase';
 import { uploadAvatarAsync, uploadIntroClipAsync } from '../utils/upload';
-import PropTypes from 'prop-types';
 import { sanitizeText } from '../utils/sanitize';
 import { snapshotExists } from '../utils/firestore';
 import { useUser } from '../contexts/UserContext';
@@ -34,7 +33,6 @@ import MultiSelectList from '../components/MultiSelectList';
 import GameSelectList from '../components/GameSelectList';
 import { FONT_SIZES, BUTTON_STYLE, HEADER_SPACING } from '../layout';
 import Header from '../components/Header';
-import { allGames } from '../data/games';
 import { BADGE_LIST } from '../data/badges';
 import { logDev } from '../utils/logger';
 import LocationInfoModal from '../components/LocationInfoModal';
@@ -1043,4 +1041,3 @@ const getStyles = (theme) => {
   });
 };
 
-OnboardingScreen.propTypes = {};

--- a/screens/PhoneVerificationScreen.js
+++ b/screens/PhoneVerificationScreen.js
@@ -1,5 +1,5 @@
 // screens/PhoneVerificationScreen.js
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { View, TextInput, Text } from "react-native";
 import GradientBackground from "../components/GradientBackground";
 import GradientButton from "../components/GradientButton";

--- a/screens/PlayScreen.js
+++ b/screens/PlayScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   Text,
   FlatList,

--- a/screens/PremiumPaywallScreen.js
+++ b/screens/PremiumPaywallScreen.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import GradientButton from '../components/GradientButton';
 import ScreenContainer from '../components/ScreenContainer';

--- a/screens/PremiumScreen.js
+++ b/screens/PremiumScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import GradientButton from '../components/GradientButton';

--- a/screens/PrivateChat.js
+++ b/screens/PrivateChat.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -1,6 +1,6 @@
 // /screens/ProfileScreen.js
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, TextInput, TouchableOpacity, View, Image, ScrollView, Share } from 'react-native';
 import SafeKeyboardView from '../components/SafeKeyboardView';
 import GradientBackground from '../components/GradientBackground';

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   Text,
   View,

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -1,5 +1,5 @@
 // screens/SplashScreen.js
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Animated, Image, StatusBar, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import LottieView from 'lottie-react-native';

--- a/screens/StatsScreen.js
+++ b/screens/StatsScreen.js
@@ -1,6 +1,6 @@
 // /screens/StatsScreen.js
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import GradientBackground from '../components/GradientBackground';

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,
@@ -18,7 +18,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { Easing } from 'react-native';
 import Header from '../components/Header';
 import { useTheme } from '../contexts/ThemeContext';
-import { HEADER_SPACING, SPACING } from '../layout';
+import { SPACING } from '../layout';
 import { useNotification } from '../contexts/NotificationContext';
 import { useUser } from '../contexts/UserContext';
 import { useDev } from '../contexts/DevContext';
@@ -46,7 +46,6 @@ import FullProfileModal from '../components/FullProfileModal';
 import useVoicePlayback from '../hooks/useVoicePlayback';
 import { useSound } from '../contexts/SoundContext';
 import { useFilters } from '../contexts/FilterContext';
-import PropTypes from 'prop-types';
 import { FONT_FAMILY } from '../textStyles';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -1206,6 +1205,5 @@ const getStyles = (theme) =>
   debugText: { color: '#fff', fontSize: 12, fontFamily: FONT_FAMILY.regular },
 });
 
-SwipeScreen.propTypes = {};
 
 export default SwipeScreen;

--- a/screens/UpdateScreen.js
+++ b/screens/UpdateScreen.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Text, Linking, Platform } from 'react-native';
 import GradientBackground from '../components/GradientBackground';
 import GradientButton from '../components/GradientButton';

--- a/screens/VerifyHumanScreen.js
+++ b/screens/VerifyHumanScreen.js
@@ -1,5 +1,5 @@
 // screens/VerifyHumanScreen.js
-import React from "react";
+
 import { Image } from "react-native";
 import GradientBackground from "../components/GradientBackground";
 import GradientButton from "../components/GradientButton";

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -1,5 +1,5 @@
 // screens/LoginScreen.js
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import Toast from 'react-native-toast-message';
 import GradientBackground from '../../components/GradientBackground';

--- a/scripts/find_unused_imports.js
+++ b/scripts/find_unused_imports.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseImports(code) {
+  const importRegex = /^import\s+([^'";]+)\s+from\s+['"][^'"]+['"]/gm;
+  const imports = [];
+  let match;
+  while ((match = importRegex.exec(code))) {
+    const statement = match[1].trim();
+    // default import or named imports
+    if (statement.startsWith('{')) {
+      // named imports
+      const names = statement
+        .replace(/[{}]/g, '')
+        .split(',')
+        .map(s => {
+          const parts = s.trim().split(' as ');
+          return parts[1] ? parts[1] : parts[0];
+        });
+      imports.push(...names);
+    } else if (statement.includes(',')) {
+      const [defaultName, namedPart] = statement.split(',');
+      imports.push(defaultName.trim());
+      const names = namedPart
+        .replace(/[{}]/g, '')
+        .split(',')
+        .map(s => {
+          const parts = s.trim().split(' as ');
+          return parts[1] ? parts[1] : parts[0];
+        });
+      imports.push(...names);
+    } else {
+      const parts = statement.split(' as ');
+      const name = parts[1] ? parts[1].trim() : parts[0].trim();
+      if (name !== '*') {
+        imports.push(name);
+      }
+    }
+  }
+  return imports;
+}
+
+function findUnused(file) {
+  const code = fs.readFileSync(file, 'utf8');
+  const imports = parseImports(code);
+  const restCode = code.replace(/^import[^\n]+\n/gm, '');
+  const unused = imports.filter(name => !new RegExp('\\b' + name + '\\b', 'm').test(restCode));
+  return unused;
+}
+
+const dirs = ['screens', 'components'];
+for (const dir of dirs) {
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.js') && !file.endsWith('.tsx')) continue;
+    const filepath = path.join(dir, file);
+    const unused = findUnused(filepath);
+    if (unused.length) {
+      console.log(filepath + ': ' + unused.join(', '));
+    }
+  }
+}

--- a/scripts/remove_react_imports.sh
+++ b/scripts/remove_react_imports.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+for file in "$@"; do
+  sed -i -e "s/^import React, {/import {/" \
+         -e "s/^import React from 'react';//" \
+         -e "s/^import React from \"react\";//" \
+         -e "s/^import React,{/import {/" \
+         "$file"
+done

--- a/unused.log
+++ b/unused.log
@@ -1,0 +1,75 @@
+screens/ActiveGamesScreen.js: React
+screens/AdminReviewScreen.js: React
+screens/ChatScreen.js: React
+screens/CommunityScreen.js: React, PropTypes
+screens/EditProfileScreen.js: React, allGames
+screens/EmailAuthScreen.js: React
+screens/GameInviteScreen.js: React, GradientButton
+screens/GameSessionScreen.js: React
+screens/GameWithBotScreen.js: React
+screens/GroupChat.js: React
+screens/HomeScreen.js: React, games
+screens/LikedYouScreen.js: React, TouchableOpacity
+screens/MatchesScreen.js: React
+screens/NotificationsScreen.js: React
+screens/OnboardingScreen.js: React, PropTypes, allGames
+screens/PhoneVerificationScreen.js: React
+screens/PlayScreen.js: React
+screens/PremiumPaywallScreen.js: React, View
+screens/PremiumScreen.js: React
+screens/PrivateChat.js: React
+screens/ProfileScreen.js: React
+screens/SettingsScreen.js: React
+screens/SplashScreen.js: React
+screens/StatsScreen.js: React
+screens/SwipeScreen.js: React, HEADER_SPACING, PropTypes
+screens/UpdateScreen.js: React
+screens/VerifyHumanScreen.js: React
+components/ActiveGamesPreview.js: React, TouchableOpacity
+components/ArcadeGameWrapper.js: React
+components/AvatarRing.js: React
+components/BoostModal.js: React
+components/Card.js: React
+components/CategoryChips.js: React
+components/ChatContainer.js: React
+components/CountdownRing.js: React
+components/DevBanner.js: React, View, PropTypes
+components/DevPanel.js: React
+components/EmptyState.js: React
+components/EventBanner.js: React, PropTypes
+components/EventFlyer.js: React
+components/FavoriteStar.js: React
+components/FilterTabs.js: React
+components/FullProfileModal.js: React
+components/GameCard.js: React
+components/GameCardBase.js: React
+components/GameContainer.js: React
+components/GameFilters.js: React
+components/GameMenu.js: React
+components/GameOverModal.js: React
+components/GamePickerModal.js: React
+components/GamePreviewModal.js: React
+components/GameSelectList.js: React
+components/GradientBackground.js: React
+components/GradientButton.tsx: type { StyleProp
+components/InviteUserCard.js: React
+components/Loader.js: React
+components/LoadingOverlay.js: React
+components/LocationInfoModal.js: React
+components/MatchesPreview.js: React
+components/MultiSelectList.js: React
+components/NotificationCenter.js: React
+components/PlayerInfoBar.js: React
+components/PremiumBadge.js: React
+components/PremiumBanner.js: React
+components/ProgressBar.js: React
+components/SafeKeyboardView.js: React
+components/ScreenContainer.js: React
+components/SearchInput.js: React
+components/SkeletonPlaceholder.js: React
+components/SkeletonUserCard.js: React, PropTypes
+components/StreakRewardModal.js: React
+components/SyncedGame.js: React
+components/TrendingBadge.js: React
+components/VoiceMessageBubble.js: React
+components/XpInfoModal.js: React


### PR DESCRIPTION
## Summary
- drop unused props and imports across screens and components
- add a script for detecting unused imports
- helper for stripping React imports in bulk

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ddea732b4832d9ec4efe65ae559b0