### PR TITLE
Update Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -24,6 +24,57 @@ service cloud.firestore {
       }
     }
 
+    // Event chats are only accessible to participants
+    match /events/{eventId}/messages/{messageId} {
+      allow read, write: if isSignedIn() &&
+        request.auth.uid in get(/databases/$(database)/documents/events/$(eventId)).data.participants;
+    }
+
+    // Community posts are public read but only the creator may write
+    match /communityPosts/{postId} {
+      allow read: if true;
+      allow write: if isSignedIn() &&
+        request.auth.uid ==
+          (resource.data.userId != null ? resource.data.userId : request.resource.data.userId);
+    }
+
+    // Game invites can be read or written only by the involved users
+    match /gameInvites/{inviteId} {
+      allow read, write: if isSignedIn() &&
+        (request.auth.uid == resource.data.from || request.auth.uid == resource.data.to ||
+         request.auth.uid == request.resource.data.from || request.auth.uid == request.resource.data.to);
+    }
+
+    // Mirrored invites under each user also follow the same rule
+    match /users/{userId}/gameInvites/{inviteId} {
+      allow read, write: if isSignedIn() && request.auth.uid == userId &&
+        (request.auth.uid == resource.data.from || request.auth.uid == resource.data.to ||
+         request.auth.uid == request.resource.data.from || request.auth.uid == request.resource.data.to);
+    }
+
+    // Game sessions are restricted to the listed players
+    match /gameSessions/{sessionId} {
+      allow read, write: if isSignedIn() &&
+        (request.auth.uid in resource.data.players || request.auth.uid in request.resource.data.players);
+    }
+
+    // Game stats follow the same player restriction
+    match /gameStats/{statId} {
+      allow read, write: if isSignedIn() &&
+        (request.auth.uid in resource.data.players || request.auth.uid in request.resource.data.players);
+    }
+
+    // Match history documents can only be accessed by the pair of users involved
+    match /matchHistory/{pairId} {
+      allow read, write: if isSignedIn() &&
+        (request.auth.uid in resource.data.users || request.auth.uid in request.resource.data.users);
+    }
+
+    // Per-user notifications are private to that user
+    match /users/{userId}/notifications/{notificationId} {
+      allow read, write: if isSignedIn() && request.auth.uid == userId;
+    }
+
     // Deny all other reads and writes
     match /{document=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary
- expand Firestore security rules for new collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686de3a0a654832db086dfa087ee9379