### PR TITLE
Add expo analytics

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,20 +1,26 @@
-import React, { useEffect } from 'react';
-import { NavigationContainer } from '@react-navigation/native';
-import { SafeAreaView, KeyboardAvoidingView, Platform, Text } from 'react-native';
-import * as SplashScreen from 'expo-splash-screen';
-import { useFonts } from 'expo-font';
-import { useUser } from './contexts/UserContext';
-import StreakRewardModal from './components/StreakRewardModal';
-import Providers from './contexts/Providers';
-import ErrorBoundary from './components/ErrorBoundary';
-import NotificationCenter from './components/NotificationCenter';
-import DevBanner from './components/DevBanner';
-import LoadingOverlay from './components/LoadingOverlay';
-import Toast from 'react-native-toast-message';
-import usePushNotifications from './hooks/usePushNotifications';
-import useRemoteConfig from './hooks/useRemoteConfig';
-import RootNavigator from './navigation/RootNavigator';
-import { useTheme } from './contexts/ThemeContext';
+import React, { useEffect } from "react";
+import { NavigationContainer } from "@react-navigation/native";
+import {
+  SafeAreaView,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+} from "react-native";
+import * as SplashScreen from "expo-splash-screen";
+import { useFonts } from "expo-font";
+import { useUser } from "./contexts/UserContext";
+import StreakRewardModal from "./components/StreakRewardModal";
+import Providers from "./contexts/Providers";
+import ErrorBoundary from "./components/ErrorBoundary";
+import NotificationCenter from "./components/NotificationCenter";
+import DevBanner from "./components/DevBanner";
+import LoadingOverlay from "./components/LoadingOverlay";
+import Toast from "react-native-toast-message";
+import * as Analytics from "expo-firebase-analytics";
+import usePushNotifications from "./hooks/usePushNotifications";
+import useRemoteConfig from "./hooks/useRemoteConfig";
+import RootNavigator from "./navigation/RootNavigator";
+import { useTheme } from "./contexts/ThemeContext";
 
 const ThemedNotificationCenter = () => {
   const { theme } = useTheme();
@@ -26,7 +32,12 @@ const AppInner = () => {
   // No custom fonts currently loaded
   const [fontsLoaded] = useFonts({});
   const { loaded: themeLoaded } = useTheme();
-  const { loading: userLoading, streakReward, dismissStreakReward } = useUser();
+  const {
+    user,
+    loading: userLoading,
+    streakReward,
+    dismissStreakReward,
+  } = useUser();
   const {
     loading: configLoading,
     error: configError,
@@ -35,7 +46,7 @@ const AppInner = () => {
 
   useEffect(() => {
     if (alertMessage) {
-      Toast.show({ type: 'info', text1: alertMessage });
+      Toast.show({ type: "info", text1: alertMessage });
     }
   }, [alertMessage]);
 
@@ -45,13 +56,21 @@ const AppInner = () => {
     }
   }, [fontsLoaded, themeLoaded, userLoading, configLoading]);
 
+  useEffect(() => {
+    if (user?.uid) {
+      Analytics.setUserId(user.uid).catch(() => {});
+    }
+  }, [user?.uid]);
+
   if (!fontsLoaded || !themeLoaded || userLoading || configLoading) {
     return null;
   }
 
   if (configError) {
     return (
-      <SafeAreaView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <SafeAreaView
+        style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
+      >
         <Text>Failed to load configuration.</Text>
       </SafeAreaView>
     );
@@ -61,7 +80,7 @@ const AppInner = () => {
     <SafeAreaView style={{ flex: 1 }}>
       <KeyboardAvoidingView
         style={{ flex: 1 }}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={60}
       >
         <ErrorBoundary>

--- a/contexts/OnboardingContext.js
+++ b/contexts/OnboardingContext.js
@@ -5,9 +5,9 @@ import Loader from "../components/Loader";
 import { useAuth } from "./AuthContext";
 import { clearStoredOnboarding } from "../utils/onboarding";
 import Toast from "react-native-toast-message";
+import * as Analytics from "expo-firebase-analytics";
 
 const OnboardingContext = createContext();
-
 
 export const OnboardingProvider = ({ children }) => {
   const { user } = useAuth();
@@ -43,6 +43,7 @@ export const OnboardingProvider = ({ children }) => {
     try {
       await AsyncStorage.setItem(`hasOnboarded_${user.uid}`, "true");
       setHasOnboarded(true);
+      await Analytics.logEvent("onboarding_complete");
     } catch (e) {
       console.warn("Failed to persist onboarding flag", e);
     }
@@ -58,7 +59,7 @@ export const OnboardingProvider = ({ children }) => {
       setHasOnboarded(false);
     } catch (e) {
       console.warn("Failed to clear onboarding", e);
-      Toast.show({ type: 'error', text1: 'Failed to clear onboarding' });
+      Toast.show({ type: "error", text1: "Failed to clear onboarding" });
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-splash-screen": "~0.30.10",
     "expo-updates": "~0.28.15",
     "expo-web-browser": "~14.2.0",
+    "expo-firebase-analytics": "~9.7.0",
     "firebase": "^9.6.11",
     "lottie-ios": "^4.5.1",
     "lottie-react-native": "7.2.2",

--- a/utils/matches.js
+++ b/utils/matches.js
@@ -1,23 +1,30 @@
-import firebase from '../firebase';
+import firebase from "../firebase";
+import * as Analytics from "expo-firebase-analytics";
 
 export async function createMatchIfMissing(uid, otherUid) {
   if (!uid || !otherUid) return null;
   try {
     const q = await firebase
       .firestore()
-      .collection('matches')
-      .where('users', 'array-contains', uid)
+      .collection("matches")
+      .where("users", "array-contains", uid)
       .get();
-    const exists = q.docs.some((d) => (d.data().users || []).includes(otherUid));
+    const exists = q.docs.some((d) =>
+      (d.data().users || []).includes(otherUid),
+    );
     if (!exists) {
-      const ref = await firebase.firestore().collection('matches').add({
-        users: [uid, otherUid],
-        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-      });
+      const ref = await firebase
+        .firestore()
+        .collection("matches")
+        .add({
+          users: [uid, otherUid],
+          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        });
+      await Analytics.logEvent("match_created");
       return ref.id;
     }
   } catch (e) {
-    console.warn('Failed to ensure match document', e);
+    console.warn("Failed to ensure match document", e);
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- add expo-firebase-analytics dependency
- hook up Analytics in `App.js`
- track onboarding completion and match creation events

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686dfaf6e6c4832d9ee9ebe9d1ef51b8