### PR TITLE
Add deep linking config

### DIFF
--- a/App.js
+++ b/App.js
@@ -16,6 +16,16 @@ import useRemoteConfig from './hooks/useRemoteConfig';
 import RootNavigator from './navigation/RootNavigator';
 import { useTheme } from './contexts/ThemeContext';
 
+const linking = {
+  prefixes: ['https://pinged.app', 'pinged://'],
+  config: {
+    screens: {
+      HomeScreen: 'home',
+      MatchScreen: 'match/:id',
+    },
+  },
+};
+
 const ThemedNotificationCenter = () => {
   const { theme } = useTheme();
   return <NotificationCenter color={theme.accent} />;
@@ -65,7 +75,7 @@ const AppInner = () => {
         keyboardVerticalOffset={60}
       >
         <ErrorBoundary>
-          <NavigationContainer>
+          <NavigationContainer linking={linking}>
             <RootNavigator />
             <DevBanner />
           </NavigationContainer>


### PR DESCRIPTION
## Summary
- add `linking` configuration
- pass the config to `NavigationContainer`

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686dfafc6d70832d89d3ba4701396c6a