### PR TITLE
Improve Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,17 +45,20 @@ service cloud.firestore {
          request.auth.uid == request.resource.data.from || request.auth.uid == request.resource.data.to);
     }
 
-    // Mirrored invites under each user also follow the same rule
+    // Mirrored invites under each user are private to that user
     match /users/{userId}/gameInvites/{inviteId} {
-      allow read, write: if isSignedIn() && request.auth.uid == userId &&
-        (request.auth.uid == resource.data.from || request.auth.uid == resource.data.to ||
-         request.auth.uid == request.resource.data.from || request.auth.uid == request.resource.data.to);
+      allow read, write: if request.auth.uid == userId;
     }
 
     // Game sessions are restricted to the listed players
     match /gameSessions/{sessionId} {
       allow read, write: if isSignedIn() &&
         (request.auth.uid in resource.data.players || request.auth.uid in request.resource.data.players);
+    }
+
+    // Realtime games restrict access to participating players
+    match /games/{sessionId} {
+      allow read, write: if request.auth.uid in resource.data.players;
     }
 
     // Game stats follow the same player restriction


### PR DESCRIPTION
## Summary
- simplify access control to user game invites
- add rules for realtime game sessions

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686ef1e77670832d829aa3fd627de556