### PR TITLE
Rename push token field

### DIFF
--- a/docs/FIRESTORE_SCHEMA.md
+++ b/docs/FIRESTORE_SCHEMA.md
@@ -42,7 +42,7 @@ This document outlines the final Firestore structure used by the Pinged applicat
 - `streakRewardedAt` (timestamp) – last time a streak reward notification was sent
 - `dailyPlayCount` (number) – count of games started today for free users
 - `lastGamePlayedAt` (timestamp) – when the last game session began
-- `expoPushToken` (string)
+- `pushToken` (string)
 - `online` (boolean)
 - `lastOnline` (timestamp) – last presence update time
 - `badges` (array of string) – earned badge IDs

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,7 +11,7 @@ const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
 async function pushToUser(uid, title, body, extra = {}) {
   const snap = await admin.firestore().collection('users').doc(uid).get();
   const userData = snap.data();
-  const token = userData && userData.expoPushToken;
+  const token = userData && userData.pushToken;
   if (!token) {
     functions.logger.info(`No Expo push token for user ${uid}`);
     return null;
@@ -113,7 +113,7 @@ exports.sendPushNotification = functions.https.onCall(async (data, context) => {
   try {
     const snap = await admin.firestore().collection('users').doc(uid).get();
     const userData = snap.data();
-    const token = userData && userData.expoPushToken;
+    const token = userData && userData.pushToken;
     if (!token) {
       throw new Error('No Expo push token for user');
     }

--- a/hooks/usePushNotifications.js
+++ b/hooks/usePushNotifications.js
@@ -13,7 +13,7 @@ export default function usePushNotifications() {
               .firestore()
               .collection('users')
               .doc(fbUser.uid)
-              .update({ expoPushToken: token })
+              .update({ pushToken: token })
               .catch((e) => console.warn('Failed to save push token', e));
           }
         })


### PR DESCRIPTION
## Summary
- update Firestore documentation for `pushToken`
- store `pushToken` in `usePushNotifications`
- reference `pushToken` in Cloud Functions

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686ef9188b80832dbe6211e35b090248