### PR TITLE
Handle foreground push notifications

### DIFF
--- a/hooks/usePushNotifications.js
+++ b/hooks/usePushNotifications.js
@@ -1,8 +1,48 @@
 import { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
 import { registerForPushNotificationsAsync } from '../utils/notifications';
 import firebase from '../firebase';
+import { useNotification } from '../contexts/NotificationContext';
 
 export default function usePushNotifications() {
+  const { showNotification } = useNotification();
+
+  useEffect(() => {
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({ shouldShowAlert: false }),
+    });
+
+    const sub = Notifications.addNotificationReceivedListener((notification) => {
+      try {
+        const data = notification.request?.content?.data || {};
+        let message = notification.request?.content?.body;
+        if (data && data.type) {
+          switch (data.type) {
+            case 'match':
+              message = "It's a match!";
+              break;
+            case 'chat':
+              message = 'New message';
+              break;
+            case 'invite':
+              message = 'Game invite received';
+              break;
+            default:
+              break;
+          }
+        }
+        if (message) {
+          showNotification(message);
+        }
+      } catch (e) {
+        console.warn('Failed to process incoming notification', e);
+      }
+    });
+
+    return () => {
+      sub.remove();
+    };
+  }, [showNotification]);
   useEffect(() => {
     const unsub = firebase.auth().onAuthStateChanged((fbUser) => {
       if (!fbUser) return;


### PR DESCRIPTION
## Summary
- register notification listener in `usePushNotifications`
- parse notification data types and display messages using `NotificationContext`
- use Expo `setNotificationHandler` to prevent system alerts while showing our custom notifications

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686ef91a5244832d87c0e0dcda4bda78