### PR TITLE
Add onNewInvite export

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -211,6 +211,9 @@ exports.onGameInviteCreated = functions.firestore
   return null;
 });
 
+// Alias for backward compatibility
+exports.onNewInvite = exports.onGameInviteCreated;
+
 exports.resetFreeGameUsage = functions.pubsub
   .schedule('0 0 * * *')
   .timeZone('UTC')


### PR DESCRIPTION
## Summary
- add `onNewInvite` in Cloud Functions as alias for `onGameInviteCreated`

## Testing
- `npm test --silent` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686efb0effe4832d875c3c9bb2e8d357