### PR TITLE
remove node-fetch in functions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const Stripe = require('stripe');
-const fetch = require('node-fetch');
+const fetch = global.fetch;
 require('dotenv').config();
 
 admin.initializeApp();

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,7 +9,6 @@
         "dotenv": "^16.5.0",
         "firebase-admin": "^11.10.1",
         "firebase-functions": "^4.4.1",
-        "node-fetch": "^2.6.7",
         "stripe": "^12.18.0"
       },
       "engines": {
@@ -2437,26 +2436,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-forge": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,7 +6,6 @@
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^4.4.1",
     "stripe": "^12.18.0",
-    "dotenv": "^16.5.0",
-    "node-fetch": "^2.6.7"
+    "dotenv": "^16.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- drop `node-fetch` dependency from the Functions package
- rely on the global `fetch` provided by Node.js

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686efb109a70832d901c33a5c31fbb2b