### PR TITLE
Fix firestore import usage in matchmaking context

### DIFF
--- a/contexts/MatchmakingContext.js
+++ b/contexts/MatchmakingContext.js
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import firebase from '../firebase';
+import firebase, { firestore } from '../firebase';
 import { useUser } from './UserContext';
 import { useListeners } from './ListenerContext';
 import { snapshotExists } from '../utils/firestore';


### PR DESCRIPTION
## Summary
- import `firestore` alongside the firebase default in `MatchmakingContext`
- use the imported alias for subcollection creation in `sendGameInvite`

## Testing
- `npm test --silent` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686f0091732c832d9a4e6f0dd1e71cdf