### PR TITLE
Add cancelInvite helper for invites

### DIFF
--- a/screens/GameSessionScreen.js
+++ b/screens/GameSessionScreen.js
@@ -71,7 +71,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
   const { user, addGameXP } = useUser();
   const isPremiumUser = !!user?.isPremium;
   const requireCredits = useRequireGameCredits();
-  const { sendGameInvite, cancelGameInvite } = useMatchmaking();
+  const { sendGameInvite, cancelInvite } = useMatchmaking();
 
   const { game, opponent, status = 'waiting', inviteId } = route.params || {};
 
@@ -238,7 +238,7 @@ const LiveSessionScreen = ({ route, navigation }) => {
 
   const handleCancel = async () => {
     try {
-      if (inviteId) await cancelGameInvite(inviteId);
+      if (inviteId) await cancelInvite(inviteId);
     } catch (e) {
       console.warn('Failed to cancel invite', e);
     }

--- a/screens/SwipeScreen.js
+++ b/screens/SwipeScreen.js
@@ -100,7 +100,7 @@ const SwipeScreen = () => {
   const { devMode } = useDev();
   const { addMatch } = useChats();
   const { gamesLeft, recordGamePlayed } = useGameLimit();
-  const { sendGameInvite, cancelGameInvite } = useMatchmaking();
+  const { sendGameInvite, cancelInvite } = useMatchmaking();
   const isPremiumUser = !!currentUser?.isPremium;
   const requireCredits = useRequireGameCredits();
   const {
@@ -462,7 +462,7 @@ const SwipeScreen = () => {
   const undoInvite = async () => {
     if (!pendingInviteId) return;
     try {
-      await cancelGameInvite(pendingInviteId);
+      await cancelInvite(pendingInviteId);
       Toast.show({ type: 'success', text1: 'Invite cancelled' });
     } catch (e) {
       console.warn('Failed to cancel invite', e);


### PR DESCRIPTION
## Summary
- add a `cancelInvite` function that removes invite docs from root and user subcollections
- use the new helper when canceling or undoing invites

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686f009a0874832d9e523b77b3731a90