### PR TITLE
Add Jest tests for Firebase functions

### DIFF
--- a/functions/__tests__/checkout.test.js
+++ b/functions/__tests__/checkout.test.js
@@ -1,0 +1,36 @@
+let stripeMock;
+
+jest.mock('stripe', () => jest.fn(() => stripeMock));
+
+const functions = require('firebase-functions');
+
+describe('createCheckoutSession', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.STRIPE_SECRET_KEY = 'sk_test';
+    process.env.STRIPE_PRICE_ID = 'price_123';
+    stripeMock = { checkout: { sessions: { create: jest.fn() } } };
+  });
+
+  it('creates a Stripe checkout session with correct parameters', async () => {
+    stripeMock.checkout.sessions.create.mockResolvedValue({ url: 'https://stripe.session/url' });
+    const { createCheckoutSession } = require('../index');
+    const context = { auth: { uid: 'user1' } };
+    const data = { successUrl: 'http://success', cancelUrl: 'http://cancel' };
+    const res = await createCheckoutSession(data, context);
+    expect(res).toEqual({ url: 'https://stripe.session/url' });
+    expect(stripeMock.checkout.sessions.create).toHaveBeenCalledWith({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      line_items: [{ price: process.env.STRIPE_PRICE_ID, quantity: 1 }],
+      metadata: { uid: 'user1' },
+      success_url: 'http://success',
+      cancel_url: 'http://cancel'
+    });
+  });
+
+  it('throws on unauthenticated call', async () => {
+    const { createCheckoutSession } = require('../index');
+    await expect(createCheckoutSession({}, { auth: null })).rejects.toBeInstanceOf(functions.https.HttpsError || Error);
+  });
+});

--- a/functions/__tests__/invite.test.js
+++ b/functions/__tests__/invite.test.js
@@ -1,0 +1,32 @@
+let fetchMock;
+
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+const userGetMock = jest.fn();
+admin.firestore = jest.fn(() => ({
+  collection: () => ({
+    doc: () => ({ get: userGetMock })
+  })
+}));
+admin.initializeApp = jest.fn();
+
+process.env.STRIPE_SECRET_KEY = 'x';
+
+let onGameInviteCreated;
+
+describe('onGameInviteCreated', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fetchMock = jest.fn(() => Promise.resolve({ json: () => ({ ok: true }) }));
+    global.fetch = fetchMock;
+    userGetMock.mockResolvedValue({ data: () => ({ pushToken: 'token' }) });
+    onGameInviteCreated = require('../index').onGameInviteCreated;
+  });
+
+  it('sends a push notification', async () => {
+    const snap = { data: () => ({ to: 'uid2', fromName: 'Bob', gameId: 'g1' }), id: 'invite1' };
+    await onGameInviteCreated(snap, {});
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,5 +7,11 @@
     "firebase-functions": "^4.4.1",
     "stripe": "^12.18.0",
     "dotenv": "^16.5.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "deploy": "firebase deploy --only functions,firestore,storage && expo export && firebase hosting:channel:deploy live",
-    "test": "node tests/runTests.js && node tests/firestoreRules.test.js"
+    "test": "node tests/runTests.js && node tests/firestoreRules.test.js && npm --prefix functions test"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- add Jest setup under `functions/`
- create tests for `createCheckoutSession`
- test invite notification flow
- run functions tests from root `npm test`

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686f1a7c40c8832d9efb56eed59eef36