### PR TITLE
Remove Firebase Analytics

### DIFF
--- a/App.js
+++ b/App.js
@@ -16,7 +16,7 @@ import NotificationCenter from "./components/NotificationCenter";
 import DevBanner from "./components/DevBanner";
 import LoadingOverlay from "./components/LoadingOverlay";
 import Toast from "react-native-toast-message";
-import * as Analytics from "expo-firebase-analytics";
+import * as Analytics from "./utils/analytics";
 import usePushNotifications from "./hooks/usePushNotifications";
 import useRemoteConfig from "./hooks/useRemoteConfig";
 import RootNavigator from "./navigation/RootNavigator";

--- a/contexts/OnboardingContext.js
+++ b/contexts/OnboardingContext.js
@@ -5,7 +5,7 @@ import Loader from "../components/Loader";
 import { useAuth } from "./AuthContext";
 import { clearStoredOnboarding } from "../utils/onboarding";
 import Toast from "react-native-toast-message";
-import * as Analytics from "expo-firebase-analytics";
+import * as Analytics from "../utils/analytics";
 
 const OnboardingContext = createContext();
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "expo-splash-screen": "~0.30.10",
     "expo-updates": "~0.28.15",
     "expo-web-browser": "~14.2.0",
-    "expo-firebase-analytics": "~9.7.0",
     "firebase": "^9.6.11",
     "lottie-ios": "^4.5.1",
     "lottie-react-native": "7.2.2",

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -1,0 +1,7 @@
+export async function logEvent() {
+  // Analytics disabled
+}
+
+export async function setUserId() {
+  // Analytics disabled
+}

--- a/utils/matches.js
+++ b/utils/matches.js
@@ -1,5 +1,5 @@
 import firebase from "../firebase";
-import * as Analytics from "expo-firebase-analytics";
+import * as Analytics from "./analytics";
 
 export async function createMatchIfMissing(uid, otherUid) {
   if (!uid || !otherUid) return null;


### PR DESCRIPTION
## Summary
- remove use of `expo-firebase-analytics`
- add local stub module for analytics
- update imports to use the stub
- drop analytics dependency from package.json

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_686f4e1615fc832da7bb894b2c3b1141