### PR TITLE
Fix firebase rules testing version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3",
-    "@firebase/rules-unit-testing": "^3.0.0"
+    "@firebase/rules-unit-testing": "^2.1.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- resolve firebase peer dependency conflict by downgrading `@firebase/rules-unit-testing`

## Testing
- `npm test` *(fails: Cannot find module '@firebase/rules-unit-testing')*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6870625f7b2c832daee710e2ffae1ad2