### PR TITLE
Fix dotenv dependency

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+// Minimal environment loader to avoid external dependencies
+import './loadEnv.js';
 
 export default {
   expo: {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
-require('dotenv').config();
+// Load environment variables from root .env file without external packages
+require('../loadEnv.js');
 
 admin.initializeApp();
 

--- a/functions/notifications.js
+++ b/functions/notifications.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const fetch = global.fetch;
-require('dotenv').config();
+// Load environment variables from root .env file without external packages
+require('../loadEnv.js');
 
 async function pushToUser(uid, title, body, extra = {}) {
   const snap = await admin.firestore().collection('users').doc(uid).get();

--- a/functions/payments.js
+++ b/functions/payments.js
@@ -1,7 +1,8 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const Stripe = require('stripe');
-require('dotenv').config();
+// Load environment variables from root .env file without external packages
+require('../loadEnv.js');
 
 const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
 

--- a/loadEnv.js
+++ b/loadEnv.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+const envPath = path.resolve(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+  const content = fs.readFileSync(envPath, 'utf8');
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(/^\s*([^#][^=]*)=(.*)$/);
+    if (m) {
+      const key = m[1].trim();
+      let value = m[2].trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (process.env[key] === undefined) {
+        process.env[key] = value;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- avoid requiring external `dotenv/config` module
- provide local env loader to read `.env`
- use the local loader in functions and Expo config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68707c625128832db923d692ee7a286b