### PR TITLE
Fix __dirname error when loading env

### DIFF
--- a/loadEnv.js
+++ b/loadEnv.js
@@ -1,5 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const envPath = path.resolve(__dirname, '.env');
 if (fs.existsSync(envPath)) {


### PR DESCRIPTION
## Summary
- handle __dirname when loading environment variables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870832727ac832da64a20877a718ed3