### PR TITLE
Fix onboarding image selection

### DIFF
--- a/screens/EditProfileScreen.js
+++ b/screens/EditProfileScreen.js
@@ -67,7 +67,8 @@ const EditProfileScreen = ({ navigation, route }) => {
     });
 
     if (!result.canceled) {
-      setAvatar(result.assets[0].uri);
+      const uri = result.assets?.[0]?.uri || result.uri;
+      if (uri) setAvatar(uri);
     }
   };
 

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -337,7 +337,10 @@ const validateField = () => {
     });
 
     if (!result.canceled) {
-      setAnswers((prev) => ({ ...prev, avatar: result.assets[0].uri }));
+      const uri = result.assets?.[0]?.uri || result.uri;
+      if (uri) {
+        setAnswers((prev) => ({ ...prev, avatar: uri }));
+      }
     }
   };
 

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -72,7 +72,8 @@ const ProfileScreen = ({ navigation, route }) => {
     });
 
     if (!result.canceled) {
-      setAvatar(result.assets[0].uri);
+      const uri = result.assets?.[0]?.uri || result.uri;
+      if (uri) setAvatar(uri);
     }
   };
 


### PR DESCRIPTION
## Summary
- handle both `assets` or `uri` fields from ImagePicker
- do the same update in Profile and EditProfile screens

## Testing
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_6870a44c2cec832d88a67e5bd59f9dd5