### PR TITLE
Handle presence deletions and add tests

### DIFF
--- a/tests/syncPresence.test.js
+++ b/tests/syncPresence.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+
+const { firestore, mockFirestore } = require('firebase-admin');
+const { syncPresence } = require('../functions/invites');
+
+(async () => {
+  const ctx = { params: { uid: 'user1' } };
+
+  // Presence update
+  await syncPresence(
+    {
+      before: { val: () => null },
+      after: { val: () => ({ state: 'online', last_changed: 1000 }) },
+    },
+    ctx,
+  );
+  assert.deepStrictEqual(mockFirestore._data['user1'], {
+    online: true,
+    lastOnline: { _ts: 1000 },
+  });
+
+  // Presence deletion
+  await syncPresence(
+    {
+      before: { val: () => ({ state: 'offline', last_changed: 2000 }) },
+      after: { val: () => null },
+    },
+    ctx,
+  );
+  assert.strictEqual(mockFirestore._data['user1'].online, false);
+  assert.deepStrictEqual(mockFirestore._data['user1'].lastOnline, { _ts: 2000 });
+
+  console.log('syncPresence tests completed');
+})();


### PR DESCRIPTION
## Summary
- update presence sync to set user offline when status node is deleted
- add unit tests for presence updates and deletions

## Testing
- `node tests/syncPresence.test.js`
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_6875c0d6772c832da6a63d387d6f7e02