### PR TITLE
Handle presence deletions

### DIFF
--- a/tests/presenceSync.test.js
+++ b/tests/presenceSync.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const admin = require('firebase-admin');
+const { syncPresence } = require('../functions/invites');
+
+let lastSet = null;
+
+admin.firestore = () => ({
+  collection: () => ({
+    doc: () => ({
+      set: async (data, opts) => {
+        lastSet = { data, opts };
+      },
+    }),
+  }),
+  Timestamp: {
+    fromMillis: (ms) => ({ ms }),
+  },
+  FieldValue: {
+    serverTimestamp: () => 'serverTimestamp',
+  },
+});
+
+function snap(val) {
+  return { val: () => val };
+}
+
+(async () => {
+  await syncPresence({ before: snap(null), after: snap({ state: 'online', last_changed: 1 }) }, { params: { uid: 'u1' } });
+  assert.deepStrictEqual(lastSet, {
+    data: { online: true, lastOnline: { ms: 1 } },
+    opts: { merge: true },
+  });
+
+  await syncPresence({ before: snap({ state: 'online', last_changed: 2 }), after: snap(null) }, { params: { uid: 'u1' } });
+  assert.deepStrictEqual(lastSet, {
+    data: { online: false, lastOnline: { ms: 2 } },
+    opts: { merge: true },
+  });
+
+  console.log('presence sync tests completed');
+})();


### PR DESCRIPTION
## Summary
- mark users offline when their presence entry is removed
- cover presence updates and deletions with tests

## Testing
- `node tests/presenceSync.test.js` *(fails: Cannot find module 'firebase-admin')*
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_68771131b028832d8991a942aae5582c