### PR TITLE
chore: centralize shared configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+## Shared environment variables. Function-only secrets live in functions/.env.example.
 EXPO_PUBLIC_FIREBASE_API_KEY=your_new_api_key
 EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=your_new_project.firebaseapp.com
 EXPO_PUBLIC_FIREBASE_PROJECT_ID=your_new_project_id

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Pinged/
 ├── app.json               # Expo config
 ├── app.config.js          # Runtime env + plugin config
 
+## Configuration Files
+
+Common settings live at the repository root:
+
+- `.env.example` – shared environment variables. `functions/.env.example` lists only Cloud Function secrets.
+- `.gitignore` – global ignore rules. Add function-specific ignores here instead of `functions/.gitignore`.
+- `package.json` – project-wide scripts and shared dependencies. `functions/package.json` keeps only backend-specific packages.
+
+Update the root files for shared changes; only touch files under `functions/` when the setting applies exclusively to Cloud Functions.
+
 Features
 
     Push notifications with Expo

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,3 +1,5 @@
+## Function-specific secrets.
+## Shared variables live in the root .env.example file.
 STRIPE_SECRET_KEY=
 STRIPE_PRICE_ID=
 STRIPE_WEBHOOK_SECRET=

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^4.4.1",
-    "stripe": "^12.18.0",
-    "dotenv": "^16.5.0"
+    "stripe": "^12.18.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- document shared environment variables in root .env.example and trim functions/.env.example to function-only secrets
- remove duplicate ignore rules and consolidate dependencies in functions/package.json
- add README guidance on where shared vs. function-specific settings belong

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden fetching @testing-library/jest-native)*
- `npm test` *(fails: jest not found)*
- `npm test --prefix functions` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dfdce5d0c832d9eeb7cfa52211b1c