### PR TITLE
chore: consolidate env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-## Shared environment variables. Function-only secrets live in functions/.env.example.
+## Environment variables for both the Expo app and Cloud Functions.
 EXPO_PUBLIC_FIREBASE_API_KEY=your_new_api_key
 EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=your_new_project.firebaseapp.com
 EXPO_PUBLIC_FIREBASE_PROJECT_ID=your_new_project_id
@@ -13,6 +13,11 @@ EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key
 EXPO_PUBLIC_CHECKOUT_FUNCTION=your_checkout_function_url
 EXPO_PUBLIC_SUCCESS_URL=your_success_url
 EXPO_PUBLIC_CANCEL_URL=your_cancel_url
+
+# Stripe secrets for Cloud Functions
+STRIPE_SECRET_KEY=your_stripe_secret_key
+STRIPE_PRICE_ID=your_stripe_price_id
+STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret
 
 # External links
 EXPO_PUBLIC_PAYMENTS_URL=https://example.com/payments

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Pinged/
 
 Common settings live at the repository root:
 
-- `.env.example` – shared environment variables. `functions/.env.example` lists only Cloud Function secrets.
+- `.env.example` – environment variables for both the Expo app and Cloud Functions.
 - `.gitignore` – global ignore rules. Add function-specific ignores here instead of `functions/.gitignore`.
 - `package.json` – project-wide scripts and shared dependencies. `functions/package.json` keeps only backend-specific packages.
 

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,5 +1,0 @@
-## Function-specific secrets.
-## Shared variables live in the root .env.example file.
-STRIPE_SECRET_KEY=
-STRIPE_PRICE_ID=
-STRIPE_WEBHOOK_SECRET=

--- a/loadEnv.js
+++ b/loadEnv.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+// Load variables for both the Expo app and Cloud Functions from the root `.env` file.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const envPath = path.resolve(__dirname, '.env');


### PR DESCRIPTION
## Summary
- consolidate environment examples into single `.env.example`
- document unified config in README
- clarify env loading script

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f20e3b864832d803116cf71aba55d