### PR TITLE
refactor: centralize shadow styles

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -10,6 +10,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../contexts/ThemeContext';
 import useCardPressAnimation from '../hooks/useCardPressAnimation';
 import PropTypes from 'prop-types';
+import { shadowStyle } from '../styles/common';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -36,7 +37,7 @@ const Card = ({
       {...rest}
     >
       <LinearGradient colors={colors} style={styles.gradient}>
-        <View style={[styles.card, { backgroundColor: theme.card }, style]}>
+        <View style={[styles.card, shadowStyle, { backgroundColor: theme.card }, style]}>
           {(icon || text) && (
             <View style={styles.headerRow}>
               {icon && <View style={styles.icon}>{icon}</View>}
@@ -66,11 +67,6 @@ Card.propTypes = {
 export const CARD_STYLE = {
   borderRadius: 16,
   padding: 16,
-  shadowColor: '#000',
-  shadowOpacity: 0.05,
-  shadowOffset: { width: 0, height: 2 },
-  shadowRadius: 4,
-  elevation: 2,
 };
 
 const styles = StyleSheet.create({

--- a/components/EventBanner.js
+++ b/components/EventBanner.js
@@ -6,6 +6,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { eventImageSource } from '../utils/avatar';
 import GradientButton from './GradientButton';
 import { textStyles } from '../textStyles';
+import { shadowStyle } from '../styles/common';
 
 const NEXT_EVENT = {
   title: 'Checkers Blitz Tournament',
@@ -22,6 +23,7 @@ export default function EventBanner() {
     <View
       style={[
         local.container,
+        shadowStyle,
         { backgroundColor: darkMode ? '#333' : '#fff' },
       ]}
     >
@@ -46,16 +48,11 @@ const getStyles = (theme) =>
     container: {
       flexDirection: 'row',
       alignItems: 'center',
-    borderRadius: 16,
-    marginHorizontal: 16,
-    padding: 12,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3,
-  },
+      borderRadius: 16,
+      marginHorizontal: 16,
+      padding: 12,
+      marginBottom: 16,
+    },
   image: {
     width: 60,
     height: 60,

--- a/components/EventFlyer.js
+++ b/components/EventFlyer.js
@@ -5,6 +5,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { eventImageSource } from '../utils/avatar';
 import GradientButton from './GradientButton';
 import { CARD_STYLE } from './Card';
+import { shadowStyle } from '../styles/common';
 
 const EventFlyer = ({ event, onJoin, joined, style, disabled }) => {
   const { darkMode, theme } = useTheme();
@@ -17,6 +18,7 @@ const EventFlyer = ({ event, onJoin, joined, style, disabled }) => {
     <View
       style={[
         styles.container,
+        shadowStyle,
         { backgroundColor: theme.card },
         style,
       ]}
@@ -68,11 +70,6 @@ const getStyles = (theme, darkMode) =>
       borderRadius: CARD_STYLE.borderRadius,
       borderWidth: 1,
       borderColor: darkMode ? 'rgba(255,255,255,0.1)' : '#e0d4b9',
-      shadowColor: '#000',
-      shadowOpacity: 0.25,
-      shadowOffset: { width: 0, height: 3 },
-      shadowRadius: 5,
-      elevation: 4,
       transform: [{ rotate: '-1deg' }],
     },
     image: {

--- a/components/GameCardBase.js
+++ b/components/GameCardBase.js
@@ -3,28 +3,27 @@ import { Animated, TouchableOpacity, Dimensions } from 'react-native';
 import { SPACING } from '../layout';
 import * as Haptics from 'expo-haptics';
 import PropTypes from 'prop-types';
+import { shadowStyle } from '../styles/common';
 
 const CARD_WIDTH = Dimensions.get('window').width * 0.42;
 
 const GameCardBase = ({ children, scale, onPress, onPressIn, onPressOut, onHoverIn }) => (
   <Animated.View style={{ transform: [{ scale }] }}>
     <TouchableOpacity
-      style={{
-        width: CARD_WIDTH,
-        marginHorizontal: SPACING.SM,
-        marginBottom: SPACING.XL,
-        backgroundColor: '#fff',
-        borderRadius: 16,
-        paddingVertical: SPACING.XL,
-        alignItems: 'center',
-        justifyContent: 'center',
-        shadowColor: '#000',
-        shadowOpacity: 0.05,
-        shadowOffset: { width: 0, height: 4 },
-        shadowRadius: 6,
-        elevation: 2,
-        position: 'relative',
-      }}
+      style={[
+        {
+          width: CARD_WIDTH,
+          marginHorizontal: SPACING.SM,
+          marginBottom: SPACING.XL,
+          backgroundColor: '#fff',
+          borderRadius: 16,
+          paddingVertical: SPACING.XL,
+          alignItems: 'center',
+          justifyContent: 'center',
+          position: 'relative',
+        },
+        shadowStyle,
+      ]}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       onMouseEnter={onHoverIn}

--- a/components/GamePreviewModal.js
+++ b/components/GamePreviewModal.js
@@ -4,6 +4,7 @@ import LottieView from 'lottie-react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 import GradientButton from './GradientButton';
+import { shadowStyle } from '../styles/common';
 
 export default function GamePreviewModal({
   visible,
@@ -30,7 +31,7 @@ export default function GamePreviewModal({
       onRequestClose={onClose}
     >
       <View style={styles.backdrop}>
-        <View style={styles.card}>
+        <View style={[styles.card, shadowStyle]}>
           <LottieView
             source={require('../assets/hearts.json')}
             autoPlay
@@ -104,11 +105,6 @@ const getStyles = (theme) =>
       borderRadius: 20,
       padding: 20,
       paddingBottom: 30,
-      shadowColor: '#000',
-      shadowOpacity: 0.12,
-      shadowOffset: { width: 0, height: 4 },
-      shadowRadius: 8,
-      elevation: 5,
       alignItems: 'center',
     },
     banner: { width: '100%', height: 80, marginBottom: 10 },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Image, TouchableOpacity, StyleSheet, Platform, Text } from 'react-native';
+import { View, Image, TouchableOpacity, StyleSheet, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -7,6 +7,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
 import useUnreadNotifications from '../hooks/useUnreadNotifications';
 import { HEADER_HEIGHT } from '../layout';
+import { shadowStyle } from '../styles/common';
 
 export interface HeaderProps {
   /** Only show the center logo */
@@ -31,7 +32,7 @@ const Header: React.FC<HeaderProps> = ({ showLogoOnly = false }) => {
       edges={['top']}
       style={[styles.safeArea, { backgroundColor: theme.headerBackground }]}
     >
-      <View style={styles.container}>
+      <View style={[styles.container, shadowStyle]}>
         {showLogoOnly ? (
           <Image source={require('../assets/logo.png')} style={styles.logo} />
         ) : (
@@ -76,7 +77,7 @@ const Header: React.FC<HeaderProps> = ({ showLogoOnly = false }) => {
         )}
       </View>
       {menuOpen && !showLogoOnly && (
-        <View style={[styles.dropdown, { backgroundColor: theme.card }]}>
+        <View style={[styles.dropdown, shadowStyle, { backgroundColor: theme.card }]}>
           {menuItems.map((item) => (
             <TouchableOpacity
               key={item.label}
@@ -110,17 +111,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    ...Platform.select({
-      ios: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-      },
-      android: {
-        elevation: 6,
-      },
-    }),
   },
   rightIcons: {
     flexDirection: 'row',
@@ -196,10 +186,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingVertical: 8,
     width: 160,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 6,
   },
   menuItem: {
     paddingVertical: 8,

--- a/components/NotificationCenter.js
+++ b/components/NotificationCenter.js
@@ -12,6 +12,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNotification } from '../contexts/NotificationContext';
 import PropTypes from 'prop-types';
+import { shadowStyle } from '../styles/common';
 
 const screenWidth = Dimensions.get('window').width;
 const TOAST_HEIGHT = 60;
@@ -67,6 +68,7 @@ const ToastItem = ({ item, index, color, onDismiss }) => {
       {...panResponder.panHandlers}
       style={[
         styles.toast,
+        shadowStyle,
         {
           backgroundColor: color,
           top: index * (TOAST_HEIGHT + 8) + 20,
@@ -142,10 +144,6 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 18,
     borderRadius: 20,
-    shadowColor: '#000',
-    shadowOpacity: 0.3,
-    shadowRadius: 6,
-    elevation: 6,
   },
   text: {
     color: '#fff',

--- a/components/SkeletonUserCard.js
+++ b/components/SkeletonUserCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
+import { shadowStyle } from '../styles/common';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -11,7 +12,7 @@ function SkeletonUserCard() {
   const { theme } = useTheme();
   const styles = getStyles(theme);
   return (
-    <View style={styles.card}>
+    <View style={[styles.card, shadowStyle]}>
       <View style={styles.image} />
       <View style={styles.info}>
         <View style={styles.name} />
@@ -34,11 +35,6 @@ const getStyles = (theme) =>
       borderRadius: 20,
       overflow: 'hidden',
       backgroundColor: theme.card,
-      elevation: 8,
-      shadowColor: '#000',
-      shadowOpacity: 0.2,
-      shadowRadius: 8,
-      shadowOffset: { width: 0, height: 4 },
     },
     image: {
       width: '100%',

--- a/components/UserCard.js
+++ b/components/UserCard.js
@@ -14,6 +14,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { SPACING } from '../layout';
 import PropTypes from 'prop-types';
 import { FONT_FAMILY } from '../textStyles';
+import { shadowStyle } from '../styles/common';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -41,6 +42,7 @@ export default function UserCard({
       {...panHandlers}
       style={[
         styles.card,
+        shadowStyle,
         {
           transform: [
             { translateX: pan.x },
@@ -115,11 +117,6 @@ const getStyles = (theme) =>
       borderRadius: 20,
       overflow: 'hidden',
       backgroundColor: '#fff',
-      elevation: 4,
-      shadowColor: '#000',
-      shadowOpacity: 0.1,
-      shadowRadius: 8,
-      shadowOffset: { width: 0, height: 4 },
     },
     image: {
       width: '100%',

--- a/screens/ActiveGamesScreen.js
+++ b/screens/ActiveGamesScreen.js
@@ -13,6 +13,7 @@ import Loader from '../components/Loader';
 import EmptyState from '../components/EmptyState';
 import { HEADER_SPACING, SPACING } from '../layout';
 import { CARD_STYLE } from '../components/Card';
+import { shadowStyle } from '../styles/common';
 import PropTypes from 'prop-types';
 
 const ActiveGamesScreen = ({ navigation }) => {
@@ -52,7 +53,7 @@ const ActiveGamesScreen = ({ navigation }) => {
     const title = games[item.gameId]?.meta?.name || 'Game';
     return (
       <TouchableOpacity
-        style={[styles.card, { backgroundColor: theme.card }]}
+        style={[styles.card, shadowStyle, { backgroundColor: theme.card }]}
         onPress={() =>
           navigation.navigate('GameSession', {
             sessionId: item.id,
@@ -102,10 +103,9 @@ const ActiveGamesScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
   card: {
     padding: SPACING.LG,
-    borderRadius: 16,
+    borderRadius: CARD_STYLE.borderRadius,
     marginHorizontal: SPACING.LG,
     marginBottom: SPACING.MD,
-    ...CARD_STYLE,
   },
   gameText: {
     fontSize: 16,

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -599,7 +599,6 @@ const getStyles = (theme, skeletonColor) =>
     borderRadius: 16,
     padding: 16,
     marginBottom: 28,
-    ...CARD_STYLE,
   },
   bannerImage: {
     width: '100%',
@@ -626,7 +625,6 @@ const getStyles = (theme, skeletonColor) =>
     borderRadius: 16,
     padding: 16,
     marginBottom: 20,
-    ...CARD_STYLE,
   },
   flyerImage: {
     width: 70,
@@ -666,7 +664,6 @@ const getStyles = (theme, skeletonColor) =>
     padding: 14,
     marginHorizontal: 16,
     marginBottom: 16,
-    ...CARD_STYLE,
   },
   postTitle: {
     fontSize: FONT_SIZES.MD - 1,

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -546,11 +546,6 @@ const getStyles = (theme) =>
       padding: SPACING.MD,
       marginBottom: SPACING.MD,
       alignSelf: 'stretch',
-      shadowColor: '#000',
-      shadowOpacity: 0.05,
-      shadowOffset: { width: 0, height: 2 },
-      shadowRadius: 4,
-      elevation: 2,
     },
     featuredEventContent: {
       flex: 1,

--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
 import { useSound } from '../contexts/SoundContext';
 import useCardPressAnimation from '../hooks/useCardPressAnimation';
 import EmptyState from '../components/EmptyState';
+import { shadowStyle } from '../styles/common';
 
 const AnimatedButton = ({ onPress, text, loading, disabled, style }) => {
   const {
@@ -155,7 +156,7 @@ const NotificationsScreen = ({ navigation }) => {
             [0, 1].map((i) => (
               <View
                 key={`skel-${i}`}
-                style={[local.card, { backgroundColor: theme.card }]}
+                style={[local.card, shadowStyle, { backgroundColor: theme.card }]}
               >
                 <View
                   style={[local.skelText, { backgroundColor: theme.textSecondary }]}
@@ -177,6 +178,7 @@ const NotificationsScreen = ({ navigation }) => {
               key={inv.id}
               style={[
                 local.card,
+                shadowStyle,
                 { backgroundColor: theme.card },
               ]}
             >
@@ -216,7 +218,7 @@ const NotificationsScreen = ({ navigation }) => {
           [0, 1].map((i) => (
             <View
               key={`note-skel-${i}`}
-              style={[local.card, { backgroundColor: theme.card }]}
+              style={[local.card, shadowStyle, { backgroundColor: theme.card }]}
             >
               <View
                 style={[local.skelText, { backgroundColor: theme.textSecondary }]}
@@ -232,7 +234,7 @@ const NotificationsScreen = ({ navigation }) => {
           notifications.map((note) => (
             <View
               key={note.id}
-              style={[local.card, { backgroundColor: theme.card }]}
+              style={[local.card, shadowStyle, { backgroundColor: theme.card }]}
             >
               <Text style={[local.text, { color: theme.text }]}>{note.message}</Text>
               <View style={local.actions}>
@@ -259,11 +261,6 @@ const local = StyleSheet.create({
     borderRadius: 14,
     padding: 16,
     marginBottom: 14,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 3
   },
   text: {
     fontSize: 14,

--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -38,6 +38,7 @@ import { BADGE_LIST } from '../utils/badges';
 import LocationInfoModal from '../components/LocationInfoModal';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import useVoicePlayback from '../hooks/useVoicePlayback';
+import { shadowStyle } from '../styles/common';
 import { PRESETS } from '../data/presets';
 import Loader from '../components/Loader';
 
@@ -784,7 +785,7 @@ const validateField = () => {
 
         {renderDots()}
 
-        <View style={styles.card}>
+        <View style={[styles.card, shadowStyle]}>
           <Text style={styles.questionText}>{questions[step].label}</Text>
           {renderInput()}
         </View>
@@ -879,11 +880,6 @@ const getStyles = (theme) => {
       backgroundColor: cardBg,
       borderRadius: 12,
       padding: 20,
-      shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.2,
-      shadowRadius: 4,
-      elevation: 3,
     },
     questionText: {
       color: textColor,

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -25,6 +25,7 @@ import { useFilters } from '../contexts/FilterContext';
 import Toast from 'react-native-toast-message';
 import { HEADER_SPACING, SPACING } from '../layout';
 import { CARD_STYLE } from '../components/Card';
+import { shadowStyle } from '../styles/common';
 import { textStyles } from '../textStyles';
 import logger from '../utils/logger';
 
@@ -171,7 +172,7 @@ const SettingsScreen = ({ navigation }) => {
             Settings
           </Text>
 
-        <View style={local.sectionCard}>
+        <View style={[local.sectionCard, shadowStyle]}>
           <Text style={local.sectionTitle}>Account</Text>
           <Text style={[styles.settingText, { color: theme.textSecondary }]}>
             Account: {user?.email || 'Unknown'}
@@ -203,7 +204,7 @@ const SettingsScreen = ({ navigation }) => {
           />
         </View>
 
-        <View style={local.sectionCard}>
+        <View style={[local.sectionCard, shadowStyle]}>
           <Text style={local.sectionTitle}>Appearance</Text>
           <Text style={styles.settingText}>Pick a color theme</Text>
           <View style={{ flexDirection: 'row', marginBottom: SPACING.MD }}>
@@ -230,7 +231,7 @@ const SettingsScreen = ({ navigation }) => {
           </View>
         </View>
 
-        <View style={local.sectionCard}>
+        <View style={[local.sectionCard, shadowStyle]}>
           <Text style={local.sectionTitle}>Discovery & Privacy</Text>
           {isPremium && (
             <>
@@ -456,7 +457,7 @@ const SettingsScreen = ({ navigation }) => {
           />
         </View>
 
-        <View style={local.sectionCard}>
+        <View style={[local.sectionCard, shadowStyle]}>
           <Text style={local.sectionTitle}>Payment</Text>
           <GradientButton
             text="Manage Payment Method"
@@ -480,7 +481,7 @@ const SettingsScreen = ({ navigation }) => {
           />
         </View>
 
-        <View style={local.sectionCard}>
+        <View style={[local.sectionCard, shadowStyle]}>
           <Text style={local.sectionTitle}>Support</Text>
           <GradientButton
             text="Contact Us"
@@ -524,7 +525,7 @@ const SettingsScreen = ({ navigation }) => {
         />
 
         {showAdvanced && (
-          <View style={local.sectionCard}>
+          <View style={[local.sectionCard, shadowStyle]}>
             <GradientButton
               text={`Toggle ${darkMode ? 'Light' : 'Dark'} Mode`}
               onPress={toggleTheme}
@@ -565,7 +566,6 @@ const getLocalStyles = (theme) =>
       marginBottom: SPACING.LG,
       padding: SPACING.LG,
       borderRadius: CARD_STYLE.borderRadius,
-      ...CARD_STYLE,
     },
     sectionTitle: {
       ...textStyles.subtitle,

--- a/styles.js
+++ b/styles.js
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native';
 import { BUTTON_STYLE, FONT_SIZES } from './layout';
+import { shadowStyle } from './styles/common';
 
 const getStyles = (theme) =>
   StyleSheet.create({
@@ -41,11 +42,7 @@ const getStyles = (theme) =>
     marginBottom: 20,
     width: '100%',
     alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.2,
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 6,
-    elevation: 4
+    ...shadowStyle,
   },
     emailBtn: {
       backgroundColor: theme.accent,
@@ -55,11 +52,7 @@ const getStyles = (theme) =>
       width: '100%',
       alignItems: 'center',
     marginBottom: 10,
-    shadowColor: '#000',
-    shadowOpacity: 0.2,
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 6,
-    elevation: 4
+    ...shadowStyle
   },
     btnText: {
       color: '#fff',
@@ -116,11 +109,7 @@ const getStyles = (theme) =>
     width: '100%',
     alignItems: 'center',
     marginBottom: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.2,
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 6,
-    elevation: 4
+    ...shadowStyle
   },
   navBtnText: {
     color: '#fff',
@@ -131,13 +120,13 @@ const getStyles = (theme) =>
       backgroundColor: theme.card,
     borderRadius: 20,
     padding: 20,
-    shadowColor: '#000',
+    alignItems: 'center',
+    width: 320,
+    ...shadowStyle,
     shadowOpacity: 0.3,
     shadowOffset: { width: 0, height: 5 },
     shadowRadius: 10,
     elevation: 6,
-    alignItems: 'center',
-    width: 320
   },
   cardImage: {
     width: 280,
@@ -223,11 +212,8 @@ const getStyles = (theme) =>
     borderRadius: 30,
     alignItems: 'center',
     justifyContent: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.2,
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 6,
-    elevation: 5
+    ...shadowStyle,
+    elevation: 5,
   },
   buttonIcon: {
     fontSize: 28,

--- a/styles/common.js
+++ b/styles/common.js
@@ -1,0 +1,7 @@
+export const shadowStyle = {
+  shadowColor: '#000',
+  shadowOpacity: 0.2,
+  shadowOffset: { width: 0, height: 4 },
+  shadowRadius: 6,
+  elevation: 4,
+};


### PR DESCRIPTION
## Summary
- centralize common shadow properties in `styles/common.js`
- reuse shared `shadowStyle` across cards, banners, flyers, and other components
- apply `shadowStyle` to various screens and refactor `CARD_STYLE` usage

## Testing
- `npm test` *(fails: jest not found)*
- `npm install jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f20f02160832d9c13c4b913c9d3f2